### PR TITLE
全文検索、多重度複数のプロパティで値にnullが含まれると、クロールでエラーが発生する

### DIFF
--- a/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/AbstractFulltextSearchService.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/AbstractFulltextSearchService.java
@@ -186,6 +186,10 @@ public abstract class AbstractFulltextSearchService implements FulltextSearchSer
 	protected abstract void createIndexData(final int tenantId, String defName);
 	
 	protected String toValue(Object val) throws IOException {
+		if (val == null) {
+			return "";
+		}
+		
 		if (val instanceof Timestamp) {
 			final SimpleDateFormat dateTimeFormat = DateUtil.getSimpleDateFormat(getLocaleFormat().getOutputDatetimeSecFormat(), true);
 			dateTimeFormat.setLenient(false);


### PR DESCRIPTION
全文検索、多重度複数のプロパティで値にnullが含まれると、クロールでエラーが発生する。
オブジェクトNullの分岐を追加し、エラーを解消する。