### PR TITLE
全文検索、多重度複数のプロパティで値にnullが含まれると、クロールでエラーが発生する（3.1）

### DIFF
--- a/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/FulltextSearchLuceneService.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/FulltextSearchLuceneService.java
@@ -352,6 +352,10 @@ public class FulltextSearchLuceneService extends AbstractFulltextSeachService {
 	}
 
 	private String convertValue(Object val) throws IOException {
+		if (val == null) {
+			return "";
+		}
+		
 		String strVal = null;
 		if (val instanceof Timestamp) {
 			final SimpleDateFormat dateTimeFormat = DateUtil.getSimpleDateFormat(getLocaleFormat().getOutputDatetimeSecFormat(), true);


### PR DESCRIPTION
全文検索、多重度複数のプロパティで値にnullが含まれると、クロールでエラーが発生する。
オブジェクトNullの分岐を追加し、エラーを解消する。