### PR TITLE
ファイルアップロード、Tikaを利用したマジックバイトチェック機能提供

### DIFF
--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/FileUploadTikaAdapter.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/FileUploadTikaAdapter.java
@@ -31,6 +31,12 @@ import java.util.List;
  * apache tika のバージョンアップ時は本インターフェースの実装クラスだけを修正することを想定している。
  * </p>
  *
+ * <p>
+ * アップロードファイルの検査の流れとして FileTypeDetector で抽出した MediaType(MimeType) を、MagicByteChecker で利用する。
+ * Tika機能を利用する場合、TikaFileTypeDetector で抽出可能な MediaType(MimeType) と、TikaMagicByteChecker で検査可能なファイル種別を同一にするため、
+ * 同一の Tika インスタンスを利用する必要がある。そのため、本インターフェース実装クラスのインスタンスを共有（bean定義）して利用する。
+ * </p>
+ *
  * @author SEKIGUCHI Naoya
  */
 public interface FileUploadTikaAdapter {

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/FileUploadTikaAdapter.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/FileUploadTikaAdapter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.web.fileupload;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * FileUpload機能で利用する Tika 機能アダプターインターフェース
+ *
+ * <p>
+ * apache tika への依存を本クラスで解決することを目的としたインターフェース。
+ * apache tika のバージョンアップ時は本インターフェースの実装クラスだけを修正することを想定している。
+ * </p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public interface FileUploadTikaAdapter {
+	/**
+	 * ファイルから MimeType（メディアタイプ）を検出する
+	 * @param in ファイル InputStream
+	 * @param name ファイル名
+	 * @return 検出された MimeType（メディアタイプ）
+	 * @throws IOException ファイル入出力例外
+	 */
+	String detect(InputStream in, String name) throws IOException;
+
+	/**
+	 * MimeType（メディアタイプ）文字列より MimeType インスタンスを取得する
+	 * @param type MimeType（メディアタイプ）文字列
+	 * @return MimeType インスタンス
+	 */
+	TikaMimeType getMimeType(String type);
+
+	/**
+	 * Tika MimeType インターフェース
+	 */
+	public interface TikaMimeType {
+		/**
+		 * MimeType 名を取得する
+		 * @return MimeType 名
+		 */
+		String getName();
+
+		/**
+		 * MimeType に定義されている拡張子リストを取得する
+		 * @return MimeType に定義されている拡張子リスト
+		 */
+		List<String> getExtensions();
+
+		/**
+		 * MimeType に magic bytes の定義が存在するか確認する。
+		 * @return MimeType に magic bytes の定義が存在する場合 true
+		 */
+		boolean hasMagic();
+
+		/**
+		 * MimeType の magic bytes の定義に一致するか確認する
+		 * @param magic チェック対象ファイルの magic byte
+		 * @return 一致する場合 true
+		 */
+		boolean matchesMagic(byte[] magic);
+	}
+}

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/FileUploadTikaAdapter.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/FileUploadTikaAdapter.java
@@ -58,6 +58,20 @@ public interface FileUploadTikaAdapter {
 	TikaMimeType getParentMimeType(TikaMimeType type);
 
 	/**
+	 * parentType の子として childType が定義されているか確認する
+	 *
+	 * <p>
+	 * ユースケース
+	 * "application/octet-stream" の MimeType の場合に、は全ての親として返却されるパターンがあるので、定義として存在しているか確認する。
+	 * </p>
+	 *
+	 * @param parentType 親として定義されているMimeType（汎化した定義）
+	 * @param childType 子として定義されているMimeType（特化した定義）
+	 * @return superType の子として childType が定義されている場合 true を返却
+	 */
+	boolean hasChild(TikaMimeType parentType, TikaMimeType childType);
+
+	/**
 	 * Tika MimeType インターフェース
 	 */
 	public interface TikaMimeType {

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/FileUploadTikaAdapter.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/FileUploadTikaAdapter.java
@@ -51,6 +51,13 @@ public interface FileUploadTikaAdapter {
 	TikaMimeType getMimeType(String type);
 
 	/**
+	 * MimeType の親として定義されている MimeType を取得する
+	 * @param type 対象 MimeType
+	 * @return 親 MimeType
+	 */
+	TikaMimeType getParentMimeType(TikaMimeType type);
+
+	/**
 	 * Tika MimeType インターフェース
 	 */
 	public interface TikaMimeType {

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/FileUploadTikaAdapterImpl.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/FileUploadTikaAdapterImpl.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.apache.tika.Tika;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.exception.TikaException;
+import org.apache.tika.mime.MediaType;
 import org.apache.tika.mime.MimeType;
 import org.apache.tika.mime.MimeTypeException;
 import org.iplass.mtp.spi.ObjectBuilder;
@@ -86,6 +87,18 @@ public class FileUploadTikaAdapterImpl implements FileUploadTikaAdapter {
 		}
 
 		return null;
+	}
+
+	@Override
+	public TikaMimeType getParentMimeType(TikaMimeType type) {
+		MediaType mediaType = type instanceof TikaMimeTypeImpl
+				// TikaMimeTypeImpl であれば、保持インスタンスの MediaType を取得
+				? ((TikaMimeTypeImpl) type).mimeType.getType()
+				// TikaMimeTypeImpl でなければ、this#getMimetype(String) で取得した値を利用する
+				: ((TikaMimeTypeImpl) getMimeType(type.getName())).mimeType.getType();
+
+		MediaType superMediaType = tikaConfig.getMediaTypeRegistry().getSupertype(mediaType);
+		return null == superMediaType ? null : getMimeType(superMediaType.toString());
 	}
 
 	/**

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/FileUploadTikaAdapterImpl.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/FileUploadTikaAdapterImpl.java
@@ -168,7 +168,7 @@ public class FileUploadTikaAdapterImpl implements FileUploadTikaAdapter {
 		private TikaConfig getTikaConfig(String tikaConfigXml) {
 			if (StringUtil.isNotBlank(tikaConfigXml)) {
 				// ログ
-				URL resource = this.getClass().getClassLoader().getResource(tikaConfigXml);
+				URL resource = FileUploadTikaAdapterImpl.class.getResource(tikaConfigXml);
 				try {
 					return new TikaConfig(resource);
 				} catch (TikaException | IOException | SAXException e) {

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/FileUploadTikaAdapterImpl.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/FileUploadTikaAdapterImpl.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2024 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.web.fileupload;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.tika.Tika;
+import org.apache.tika.config.TikaConfig;
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.mime.MimeType;
+import org.apache.tika.mime.MimeTypeException;
+import org.iplass.mtp.spi.ObjectBuilder;
+import org.iplass.mtp.spi.ServiceConfigrationException;
+import org.iplass.mtp.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+/**
+ * FileUpload機能で利用する Tika 機能アダプター実装クラス
+ *
+ * <p>
+ * FileUpload機能で利用する Tika インスタンスを共有する。
+ * </p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public class FileUploadTikaAdapterImpl implements FileUploadTikaAdapter {
+	/** ロガー */
+	private static Logger LOG = LoggerFactory.getLogger(FileUploadTikaAdapterImpl.class);
+	/** tika 設定 */
+	private TikaConfig tikaConfig;
+	/** tika 本体 */
+	private Tika tika;
+
+	/**
+	 * コンストラクタ
+	 * @param tikaConfig tika 設定
+	 * @param tika tika 本体
+	 */
+	public FileUploadTikaAdapterImpl(TikaConfig tikaConfig, Tika tika) {
+		this.tikaConfig = tikaConfig;
+		this.tika = tika;
+	}
+
+	@Override
+	public String detect(InputStream in, String name) throws IOException {
+		return tika.detect(in, name);
+	}
+
+	@Override
+	public TikaMimeType getMimeType(String type) {
+		try {
+			MimeType registered = tikaConfig.getMimeRepository().getRegisteredMimeType(type);
+			if (null != registered) {
+				return new TikaMimeTypeImpl(registered);
+			}
+
+			// このポイントに来たら、type に対応する MimeType の定義が存在しない。
+			LOG.warn("MimeType does not exist. (type = {})", type);
+
+		} catch (MimeTypeException e) {
+			// MimeType 取得時に例外発生
+			LOG.warn("An exception occurred when acquiring MimeType. (type = {})", type, e);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Tike MimeType 実装クラス
+	 *
+	 * <p>
+	 * apache tika への依存を解消するクラス
+	 * </p>
+	 */
+	public static class TikaMimeTypeImpl implements TikaMimeType {
+		/** apache tika の MimeType インスタンス */
+		private MimeType mimeType;
+
+		/**
+		 * コンストラクタ
+		 * @param mimeType MimeType インスタンス
+		 */
+		public TikaMimeTypeImpl(MimeType mimeType) {
+			this.mimeType = mimeType;
+		}
+
+		@Override
+		public String getName() {
+			return mimeType.getName();
+		}
+
+		@Override
+		public List<String> getExtensions() {
+			return mimeType.getExtensions();
+		}
+
+		@Override
+		public boolean hasMagic() {
+			return mimeType.hasMagic();
+		}
+
+		@Override
+		public boolean matchesMagic(byte[] magic) {
+			return mimeType.matchesMagic(magic);
+		}
+	}
+
+	/**
+	 * FileUploadTikaAdapterImpl ビルダークラス
+	 */
+	public static class Builder implements ObjectBuilder<FileUploadTikaAdapter> {
+		/**
+		 * tika-config.xml のシステムリソース位置
+		 *
+		 * @see https://tika.apache.org/
+		 * @see https://github.com/apache/any23/blob/any23-1.1/mime/src/main/resources/org/apache/any23/mime/tika-config.xml
+		 */
+		private String tikaConfigXml;
+
+		@Override
+		public void setProperties(Map<String, Object> properties) {
+			tikaConfigXml = (String) properties.get("tikaConfigXml");
+		}
+
+		@Override
+		public FileUploadTikaAdapter build() {
+			// Tika 設定
+			TikaConfig tikaConfig = getTikaConfig(tikaConfigXml);
+			// Tika インスタンス
+			Tika tika = new Tika(tikaConfig);
+			return new FileUploadTikaAdapterImpl(tikaConfig, tika);
+		}
+
+		/**
+		 * TikaConfig を取得する
+		 *
+		 * <p>
+		 * tikaConfigXml の指定が無い場合は、デフォルト設定とる。
+		 * tikaConfigXml の指定があり、ファイルが存在しない場合は例外がスローされる。
+		 * </p>
+		 *
+		 * @param tikaConfigXml tikaConfigXml のリソースパス
+		 * @return TikaConfig インスタンス
+		 */
+		private TikaConfig getTikaConfig(String tikaConfigXml) {
+			if (StringUtil.isNotBlank(tikaConfigXml)) {
+				// ログ
+				URL resource = this.getClass().getClassLoader().getResource(tikaConfigXml);
+				try {
+					return new TikaConfig(resource);
+				} catch (TikaException | IOException | SAXException e) {
+					throw new ServiceConfigrationException(e);
+				}
+			} else {
+				return TikaConfig.getDefaultConfig();
+			}
+		}
+
+	}
+}

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/MagicByteCheckApplicationException.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/MagicByteCheckApplicationException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.web.fileupload;
+
+import org.iplass.mtp.ApplicationException;
+
+/**
+ * マジックバイトチェック例外
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public class MagicByteCheckApplicationException extends ApplicationException {
+	/** serialVersionUID */
+	private static final long serialVersionUID = -7275133155110178901L;
+
+	/**
+	 * コンストラクタ
+	 * @param message メッセージ
+	 */
+	public MagicByteCheckApplicationException(String message) {
+		super(message);
+	}
+
+	/**
+	 * コンストラクタ
+	 * @param message メッセージ
+	 * @param cause 原因例外
+	 */
+	public MagicByteCheckApplicationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/TikaFileTypeDetector.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/TikaFileTypeDetector.java
@@ -24,7 +24,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.tika.Tika;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,11 +38,10 @@ import org.slf4j.LoggerFactory;
  * @author SEKIGUCHI Naoya
  */
 public class TikaFileTypeDetector implements FileTypeDetector {
-	/** Tikaデフォルトインスタンス */
-	private static final Tika TIKA = new Tika();
-
 	/** ロガー */
 	private Logger logger = LoggerFactory.getLogger(TikaFileTypeDetector.class);
+
+	private FileUploadTikaAdapter tikaAdapter;
 
 	@Override
 	public String detect(File file, String fileName, String type) {
@@ -57,11 +55,33 @@ public class TikaFileTypeDetector implements FileTypeDetector {
 
 	@Override
 	public String detect(InputStream input, String fileName, String type) {
+		// TODO 下位バージョン互換のロジック。下位バージョンでは、tikaAdapter を設定ないパターンもあり得る。設定することを推奨。次期バージョンで削除したい。。。
+		initTikaAdapter();
 		try {
-			return TIKA.detect(input, fileName);
+			return tikaAdapter.detect(input, fileName);
 		} catch (IOException e) {
 			logger.warn("Unable to retrieve media type.", e);
 			return type;
+		}
+	}
+
+	// TODO 次期バージョンで、設定を必須とする
+	/**
+	 * FileUploadTikaAdapter を設定する
+	 *
+	 * @param tikaAdapter FileUploadTikaAdapter
+	 */
+	public void setFileUploadTikaAdapter(FileUploadTikaAdapter tikaAdapter) {
+		this.tikaAdapter = tikaAdapter;
+	}
+
+	// TODO 下位バージョン互換のロジック。tikaAdapter の設定を必須としたら本ロジックを削除する
+	/**
+	 * FileUploadTikaAdapter を初期化する
+	 */
+	private void initTikaAdapter() {
+		if (null == tikaAdapter) {
+			tikaAdapter = new FileUploadTikaAdapterImpl.Builder().build();
 		}
 	}
 }

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/TikaMagicByteChecker.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/TikaMagicByteChecker.java
@@ -52,6 +52,8 @@ import org.slf4j.LoggerFactory;
  * @author SEKIGUCHI Naoya
  */
 public class TikaMagicByteChecker implements MagicByteChecker {
+	/** mime type "application/octet-stream" */
+	private static final String APPLICATION_OCTET_STERAM = "application/octet-stream";
 	/** ロガー */
 	private static Logger LOG = LoggerFactory.getLogger(TikaMagicByteChecker.class);
 
@@ -272,9 +274,19 @@ public class TikaMagicByteChecker implements MagicByteChecker {
 
 		// 親の MimeType を取得する
 		TikaMimeType parentMimeType = tikaAdapter.getParentMimeType(mimeType);
+
 		if (null != parentMimeType) {
+			// 親のMimeTypeが存在する
+
+			if (parentMimeType.getName().equals(APPLICATION_OCTET_STERAM) && !tikaAdapter.hasChild(parentMimeType, mimeType)) {
+				// 親 MimeType が "application/octet-stream" かつ、子 MimeTypte として定義されていない場合、
+				// MimeType として関連が無いのでチェックは実施しないで終了する。
+				// tikaAdapter.getParentMimeType の返却値として、親定義が無い場合に "application/octet-stream" が返却される為。
+				return isNeverTestedCurrent;
+			}
+
 			LOG.debug("Check with the parent MimeType. current = {}, parent = {}.", mimeType.getName(), parentMimeType.getName());
-			// 親のMimeTypeが存在すれば、親タイプでチェックを実施。
+			// 親タイプでチェックを実施。
 			return doCheckMagic(parentMimeType, magic, isNeverTestedCurrent);
 		}
 

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/TikaMagicByteChecker.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/TikaMagicByteChecker.java
@@ -273,15 +273,15 @@ public class TikaMagicByteChecker implements MagicByteChecker {
 		boolean isNeverTestedCurrent = isNeverTested && thisMimeTypeIsNotTested;
 
 		// 親の MimeType を取得する
+		// NOTE: 親定義が無い場合に "application/octet-stream" が返却される。
 		TikaMimeType parentMimeType = tikaAdapter.getParentMimeType(mimeType);
 
 		if (null != parentMimeType) {
 			// 親のMimeTypeが存在する
 
 			if (parentMimeType.getName().equals(APPLICATION_OCTET_STERAM) && !tikaAdapter.hasChild(parentMimeType, mimeType)) {
-				// 親 MimeType が "application/octet-stream" かつ、子 MimeTypte として定義されていない場合、
-				// MimeType として関連が無いのでチェックは実施しないで終了する。
-				// tikaAdapter.getParentMimeType の返却値として、親定義が無い場合に "application/octet-stream" が返却される為。
+				// 親 MimeType が "application/octet-stream" かつ、子 MimeTypte として定義されていない場合（MimeType として関連が無い）、処理を終了する。
+				LOG.debug("Complete the check. MimeType \"{}\" is not defined as a child of \"{}\".", mimeType.getName(), parentMimeType.getName());
 				return isNeverTestedCurrent;
 			}
 
@@ -421,14 +421,14 @@ public class TikaMagicByteChecker implements MagicByteChecker {
 					? StringUtil.isEmpty(extension)
 							// ファイル拡張子 = 無し
 							? EMPTY_MIMETYPE_EXTENSION_AND_NO_FILE_EXTENSION
-									// ファイル拡張子 = 有り
-									: EMPTY_MIMETYPE_EXTENSION_AND_FILE_EXTENSION_EXIST
-									// MimeType拡張子定義 = 有り
-									: StringUtil.isEmpty(extension)
-									// ファイル拡張子 = 無し
-									? MIMETYPE_EXTENSION_EXIST_AND_NO_FILE_EXTENSION
-											// ファイル拡張子 = 有り
-											: MIMETYPE_EXTENSION_EXIST_AND_FILE_EXTENSION_EXIST;
+							// ファイル拡張子 = 有り
+							: EMPTY_MIMETYPE_EXTENSION_AND_FILE_EXTENSION_EXIST
+					// MimeType拡張子定義 = 有り
+					: StringUtil.isEmpty(extension)
+							// ファイル拡張子 = 無し
+							? MIMETYPE_EXTENSION_EXIST_AND_NO_FILE_EXTENSION
+							// ファイル拡張子 = 有り
+							: MIMETYPE_EXTENSION_EXIST_AND_FILE_EXTENSION_EXIST;
 		}
 	}
 

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/TikaMagicByteChecker.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/TikaMagicByteChecker.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright (C) 2024 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.web.fileupload;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.iplass.mtp.impl.util.CoreResourceBundleUtil;
+import org.iplass.mtp.impl.web.fileupload.FileUploadTikaAdapter.TikaMimeType;
+import org.iplass.mtp.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Apache Tika を利用したマジックバイトチェック処理
+ *
+ * <p>
+ * 引数で取得した contentType (MimeType) を利用して、ファイルのマジックバイトをチェックする。
+ * オプションでファイル拡張子もチェックする。
+ * </p>
+ *
+ * <p>
+ * 本チェック機能を利用する場合は、MimeType検出とMagicByteチェック処理を Tika を利用することを推奨する。
+ * MimeType検出機能で tika を利用する為には WebFrontendService の uploadFileTypeDetector を TikaFileTypeDetector に変更する。
+ * </p>
+ *
+ * @see {@link org.iplass.mtp.impl.web.WebFrontendService}
+ * @see {@link org.iplass.mtp.impl.web.fileupload.TikaFileTypeDetector}
+ * @author SEKIGUCHI Naoya
+ */
+public class TikaMagicByteChecker implements MagicByteChecker {
+	/** ロガー */
+	private static Logger LOG = LoggerFactory.getLogger(TikaMagicByteChecker.class);
+
+	/** FileUploadTikaAdapter */
+	private FileUploadTikaAdapter tikaAdapter;
+	/** 拡張子チェックの実施設定（true の場合チェックを実施する） */
+	private boolean isCheckExtension = true;
+	/** マジックバイトの読み込みサイズ */
+	private int readMagicLength = 64 * 1024;
+
+	/** MimeTypeが取得できない場合に例外をスローするか */
+	private boolean isThrowExceptionIfMimeTypeIsNull = false;
+	/** チェック対象ファイルを読み取ることができない場合に例外をスローするか */
+	private boolean isThrowExceptionIfFileCannotRead = false;
+
+	@Override
+	public void checkMagicByte(File tempFile, String contentType, String fileName) {
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Check magic bytes. Args is tempFile = {}, contentType = {}, fileName = {}.", tempFile.getAbsolutePath(), contentType, fileName);
+		}
+
+		// MimeType に対するファイルルール定義を取得
+		TikaMimeType mimeType = tikaAdapter.getMimeType(contentType);
+
+		if (mimeType == null) {
+			// mimeType が存在しない
+			LOG.warn("Undefined MimeType. mediaType = {}, filename = {}.", contentType, fileName);
+
+			if (isThrowExceptionIfMimeTypeIsNull) {
+				throw new MagicByteCheckApplicationException(getCheckExceptionMessage());
+			}
+
+			return;
+		}
+
+		// 拡張子チェック
+		if (isCheckExtension) {
+			checkExtension(mimeType, fileName);
+		}
+
+		// マジックバイトチェック
+		checkMagic(mimeType, fileName, tempFile);
+	}
+
+	/**
+	 * FileUploadTikaAdapter を設定する
+	 *
+	 * <p>
+	 * 設定必須のプロパティ。
+	 * </p>
+	 *
+	 * @param tikaAdapter FileUploadTikaAdapter
+	 */
+	public void setFileUploadTikaAdapter(FileUploadTikaAdapter tikaAdapter) {
+		this.tikaAdapter = tikaAdapter;
+	}
+
+	/**
+	 * 拡張子チェックの実施設定を設定する
+	 *
+	 * <p>
+	 * true の場合、拡張子チェックを実施する。
+	 * </p>
+	 *
+	 * @param isCheckExtension
+	 */
+	public void setCheckExtension(boolean isCheckExtension) {
+		this.isCheckExtension = isCheckExtension;
+	}
+
+	/**
+	 * マジックバイトの読み込みサイズを設定する
+	 *
+	 * <p>
+	 * MimeType 定義の全体を通した最小のマジックバイトサイズを設定する。チェックの為にはある程度大きなサイズが必要となる。
+	 * </p>
+	 *
+	 * <p>
+	 * デフォルト値は 65536 ( = 64 * 1024 ) 。
+	 * Tika のマジックバイト最小値を利用。( {@link org.apache.tika.mime.MimeTypes#getMinLength()} )
+	 * </p>
+	 *
+	 * @param readMagicLength マジックバイトの読み込みサイズ
+	 */
+	public void setReadMagicLength(int readMagicLength) {
+		this.readMagicLength = readMagicLength;
+	}
+
+	/**
+	 * MimeTypeが取得できない場合に例外をスローするか
+	 *
+	 * <p>
+	 * 設定値が true の場合、MimeTypeが取得できない場合に例外をスローする。
+	 * デフォルト値は false です。
+	 * </p>
+	 *
+	 * @param isThrowExceptionIfMimeTypeIsNull MimeTypeが取得できない場合に例外をスローするか
+	 */
+	public void setThrowExceptionIfMimeTypeIsNull(boolean isThrowExceptionIfMimeTypeIsNull) {
+		this.isThrowExceptionIfMimeTypeIsNull = isThrowExceptionIfMimeTypeIsNull;
+	}
+
+	/**
+	 * チェック対象ファイルを読み取ることができない場合に例外をスローするか
+	 *
+	 * <p>
+	 * 設定値が true の場合、チェック対象ファイルを読み取ることができない場合に例外をスローする。
+	 * デフォルト値は false です。
+	 * </p>
+	 *
+	 * @param isThrowExceptionIfFileCannotRead チェック対象ファイルを読み取ることができない場合に例外をスローするか
+	 */
+	public void setThrowExceptionIfFileCannotRead(boolean isThrowExceptionIfFileCannotRead) {
+		this.isThrowExceptionIfFileCannotRead = isThrowExceptionIfFileCannotRead;
+	}
+
+	/**
+	 * 拡張子チェックを実施する
+	 *
+	 * @param mimeType MimeType
+	 * @param fileName ファイル名
+	 */
+	private void checkExtension(TikaMimeType mimeType, String fileName) {
+		// ファイル名から拡張子を取得
+		String extension = getExtension(fileName);
+		// 拡張子チェック
+		ExtensionCheckStrategy strategy = ExtensionCheckStrategy.getStrategy(mimeType, extension);
+		LOG.debug("ExtensionCheckStrategy = {}.", strategy);
+		strategy.performCheck(mimeType, extension, fileName, this);
+	}
+
+	/**
+	 * マジックバイトをチェックする
+	 * @param mimeType MimeType
+	 * @param filename ファイル名
+	 * @param file チェック対象ファイル
+	 */
+	private void checkMagic(TikaMimeType mimeType, String filename, File file) {
+		if (!mimeType.hasMagic()) {
+			LOG.debug("No magic byte is defined for the MimeType. (MimeType = {})", mimeType.getName());
+			return;
+		}
+
+		try {
+			byte[] magic = readMagic(file);
+			if (!mimeType.matchesMagic(magic)) {
+				// magic byte が一致しない
+				LOG.error("Magic bytes did not match. ( filename = {}, MimeType = {} )", filename, mimeType.getName());
+				// ファイル名の拡張子が存在しなければ、チェックエラー
+				throw new MagicByteCheckApplicationException(getCheckExceptionMessage());
+
+			}
+		} catch (IOException e) {
+			// DefaultMagicByteChecker では、正常終了している。。。
+			// ファイル入出力例外。ファイルが存在しない場合
+			LOG.warn("Cannot read file. ( error message = {}, filename = {}, File = {} )", e.getMessage(), filename, file.getAbsolutePath());
+
+			if (isThrowExceptionIfFileCannotRead) {
+				throw new MagicByteCheckApplicationException(getCheckExceptionMessage(), e);
+			}
+		}
+	}
+
+	/**
+	 * ファイルからマジックバイトを読み取る
+	 * @param file 読み取り対象ファイル
+	 * @return マジックバイト
+	 * @throws FileNotFoundException ファイルが存在しない場合の例外
+	 * @throws IOException 入出力例外
+	 */
+	private byte[] readMagic(File file) throws FileNotFoundException, IOException {
+		try (InputStream input = new BufferedInputStream(new FileInputStream(file))) {
+			byte[] magic = new byte[readMagicLength];
+			int read = input.read(magic);
+
+			if (-1 == read) {
+				return new byte[0];
+			}
+
+			if (read != magic.length) {
+				byte[] readMagic = new byte[read];
+				System.arraycopy(magic, 0, readMagic, 0, read);
+				magic = readMagic;
+			}
+
+			return magic;
+		}
+	}
+
+	/**
+	 * ファイルから拡張子を取得する
+	 * @param filename ファイル名
+	 * @return ファイルに設定されている拡張子
+	 */
+	private String getExtension(String filename) {
+		int extPos = filename.lastIndexOf('.');
+		if (0 > extPos) {
+			return null;
+		}
+
+		return filename.substring(extPos);
+	}
+
+	/**
+	 * チェック例外メッセージを取得する
+	 * @return チェック例外メッセージ
+	 */
+	private String getCheckExceptionMessage() {
+		return CoreResourceBundleUtil.resourceString("impl.web.fileupload.UploadFileHandleImpl.invalidFileMsg");
+	}
+
+	/**
+	 * ファイル拡張子チェック処理
+	 *
+	 * <p>
+	 * チェックパターンは以下の４種類。MimeType は必ず設定されていることを前提とする。
+	 *
+	 * <ul>
+	 * <li>MimeType拡張子定義 = 空、 ファイル拡張子 = 無し</li>
+	 * <li>MimeType拡張子定義 = 空、 ファイル拡張子 = 有り</li>
+	 * <li>MimeType拡張子定義 = 有り、 ファイル拡張子 = 無し</li>
+	 * <li>MimeType拡張子定義 = 有り、 ファイル拡張子 = 有り</li>
+	 * </ul>
+	 * </p>
+	 */
+	private static enum ExtensionCheckStrategy {
+		/** MimeType拡張子定義 = 空、 ファイル拡張子 = 無し */
+		EMPTY_MIMETYPE_EXTENSION_AND_NO_FILE_EXTENSION {
+			@Override
+			public void performCheck(TikaMimeType mimeType, String extension, String fileName, TikaMagicByteChecker checker) {
+				// チェック無し
+			}
+		},
+		/** MimeType拡張子定義 = 空、 ファイル拡張子 = 有り */
+		EMPTY_MIMETYPE_EXTENSION_AND_FILE_EXTENSION_EXIST {
+			@Override
+			public void performCheck(TikaMimeType mimeType, String extension, String fileName, TikaMagicByteChecker checker) {
+				// ログ出力のみ
+				LOG.info(
+						"The check was skipped because the extension to be checked does not exist in the MimeType. filename = {}, MimeType = {}.",
+						fileName, mimeType.getName());
+			}
+		},
+		/** MimeType拡張子定義 = 有り、 ファイル拡張子 = 無し */
+		MIMETYPE_EXTENSION_EXIST_AND_NO_FILE_EXTENSION {
+			@Override
+			public void performCheck(TikaMimeType mimeType, String extension, String fileName, TikaMagicByteChecker checker) {
+				// 警告ログ出力のみ
+				LOG.warn(
+						"File inspection cannot be performed because the file name does not have an extension. filename = {}, MimeType = {}.",
+						fileName, mimeType.getName());
+
+			}
+		},
+		/** MimeType拡張子定義 = 有り、 ファイル拡張子 = 有り */
+		MIMETYPE_EXTENSION_EXIST_AND_FILE_EXTENSION_EXIST {
+			@Override
+			public void performCheck(TikaMimeType mimeType, String extension, String fileName, TikaMagicByteChecker checker) {
+				// mimeType で管理している拡張子に、ファイル名の拡張子が存在するか確認
+				if (!mimeType.getExtensions().contains(extension)) {
+					LOG.error("Does not match the extension defined for the MimeType. filename = {}, extension = {}, MimeType = {}, define extensions = {}",
+							fileName, extension, mimeType.getName(), mimeType.getExtensions());
+					// ファイル名の拡張子が存在しなければ、チェックエラー
+					throw new MagicByteCheckApplicationException(checker.getCheckExceptionMessage());
+
+				}
+			}
+		};
+
+		/**
+		 * チェックを実施する
+		 * @param mimeType MimeType
+		 * @param extension ファイル拡張子
+		 * @param fileName ファイル名
+		 * @param checker TikaMagicByteChecker インスタンス
+		 */
+		abstract void performCheck(TikaMimeType mimeType, String extension, String fileName, TikaMagicByteChecker checker);
+
+		/**
+		 * チェックパターンに適合した拡張子チェック処理を取得する
+		 * @param mimeType MimeType
+		 * @param extension ファイル拡張子
+		 * @return 拡張子チェック処理
+		 */
+		public static ExtensionCheckStrategy getStrategy(TikaMimeType mimeType, String extension) {
+			return mimeType.getExtensions().isEmpty()
+					// MimeType拡張子定義 = 空
+					? StringUtil.isEmpty(extension)
+							// ファイル拡張子 = 無し
+							? EMPTY_MIMETYPE_EXTENSION_AND_NO_FILE_EXTENSION
+							// ファイル拡張子 = 有り
+							: EMPTY_MIMETYPE_EXTENSION_AND_FILE_EXTENSION_EXIST
+					// MimeType拡張子定義 = 有り
+					: StringUtil.isEmpty(extension)
+							// ファイル拡張子 = 無し
+							? MIMETYPE_EXTENSION_EXIST_AND_NO_FILE_EXTENSION
+							// ファイル拡張子 = 有り
+							: MIMETYPE_EXTENSION_EXIST_AND_FILE_EXTENSION_EXIST;
+		}
+	}
+
+}

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/TikaMagicByteChecker.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/TikaMagicByteChecker.java
@@ -76,7 +76,7 @@ public class TikaMagicByteChecker implements MagicByteChecker {
 
 		if (mimeType == null) {
 			// mimeType が存在しない
-			LOG.warn("Undefined MimeType. mediaType = {}, filename = {}.", contentType, fileName);
+			LOG.warn("Undefined MimeType. contentType = {}, filename = {}.", contentType, fileName);
 
 			if (isThrowExceptionIfMimeTypeIsNull) {
 				throw new MagicByteCheckApplicationException(getCheckExceptionMessage());
@@ -189,7 +189,7 @@ public class TikaMagicByteChecker implements MagicByteChecker {
 	 */
 	private void checkMagic(TikaMimeType mimeType, String filename, File file) {
 		if (!mimeType.hasMagic()) {
-			LOG.debug("No magic byte is defined for the MimeType. (MimeType = {})", mimeType.getName());
+			LOG.debug("No magic byte is defined for the MimeType. ( MimeType = {} )", mimeType.getName());
 			return;
 		}
 
@@ -310,7 +310,7 @@ public class TikaMagicByteChecker implements MagicByteChecker {
 			public void performCheck(TikaMimeType mimeType, String extension, String fileName, TikaMagicByteChecker checker) {
 				// mimeType で管理している拡張子に、ファイル名の拡張子が存在するか確認
 				if (!mimeType.getExtensions().contains(extension)) {
-					LOG.error("Does not match the extension defined for the MimeType. filename = {}, extension = {}, MimeType = {}, define extensions = {}",
+					LOG.error("Does not match the extension defined for the MimeType. filename = {}, extension = {}, MimeType = {}, defined extension settings = {}",
 							fileName, extension, mimeType.getName(), mimeType.getExtensions());
 					// ファイル名の拡張子が存在しなければ、チェックエラー
 					throw new MagicByteCheckApplicationException(checker.getCheckExceptionMessage());

--- a/iplass-web/src/main/resources/mtp-web-service-config.xml
+++ b/iplass-web/src/main/resources/mtp-web-service-config.xml
@@ -452,6 +452,9 @@
 			<property name="readMagicLength" value="65536" />
 			<property name="throwExceptionIfMimeTypeIsNull" value="false" />
 			<property name="throwExceptionIfFileCannotRead" value="false" />
+			<property name="substitutionMediaType">
+				<property name="source/MediaType" value="dest/MediaType" />
+			</property>
 		</property>
 		-->
 

--- a/iplass-web/src/main/resources/mtp-web-service-config.xml
+++ b/iplass-web/src/main/resources/mtp-web-service-config.xml
@@ -337,14 +337,28 @@
 		</property>
 		 -->
 
+		<!--
+		FileUpload機能用の Tika アダプタ。
+		
+		TikaFileTypeDetector、TikaMagicByteChecker でインスタンスを共有することを想定。
+		tikaConfigXml を指定しない場合は、apache tika のデフォルト設定で動作します。 
+		-->
+		<!--
+		<bean name="tikaAdapter" builder="org.iplass.mtp.impl.web.fileupload.FileUploadTikaAdapterImpl$Builder">
+			<property name="tikaConfigXml" value="tika-config.xml" />
+		</bean>
+		-->
+
 		<!-- ファイルタイプ（MIME Type・メディアタイプ）検出機能 -->
 		<!-- デフォルト。未指定の場合も以下のインスタンスが設定される -->
 		<!-- 
 		<property name="uploadFileTypeDetector" class="org.iplass.mtp.impl.web.fileupload.DefaultFileTypeDetector" />
 		-->
-		<!-- Apache Tika を利用したファイルタイプ（MIME Type・メディアタイプ）検出機能 -->
+		<!-- Apache Tika を利用したファイルタイプ（MIME Type・メディアタイプ）検出機能。bean tikaAdapter を有効化すること。 -->
 		<!--
-		<property name="uploadFileTypeDetector" class="org.iplass.mtp.impl.web.fileupload.TikaFileTypeDetector" />
+		<property name="uploadFileTypeDetector" class="org.iplass.mtp.impl.web.fileupload.TikaFileTypeDetector">
+			<property name="fileUploadTikaAdapter" ref="tikaAdapter" />
+		</property>
 		-->
 
 		<!-- MagicByteCheck実行するか -->
@@ -425,6 +439,21 @@
 				<property name="magicByte" value="504B030414000000" />
 			</property>
 		</property>
+
+		<!--
+		Apache Tika を利用した MagicByteCheck 処理。bean tikaAdapter を有効化する。
+		本チェック機能を利用する場合は、MimeType検出とMagicByteチェック処理を Tika を利用することを推奨する。
+		MimeType検出機能で tika を利用する為には property uploadFileTypeDetector を TikaFileTypeDetector に変更する。
+		-->
+		<!--
+		<property name="magicByteChecker" class="org.iplass.mtp.impl.web.fileupload.TikaMagicByteChecker" >
+			<property name="fileUploadTikaAdapter" ref="tikaAdapter" />
+			<property name="checkExtension" value="true" />
+			<property name="readMagicLength" value="65536" />
+			<property name="throwExceptionIfMimeTypeIsNull" value="false" />
+			<property name="throwExceptionIfFileCannotRead" value="false" />
+		</property>
+		-->
 
 		<!-- マルチパートリクエストのパラメータ最大数 未指定時はデフォルト値（10000）を適用 -->
 		<!-- 

--- a/iplass-web/src/main/resources/mtp-web-service-config.xml
+++ b/iplass-web/src/main/resources/mtp-web-service-config.xml
@@ -344,7 +344,7 @@
 		tikaConfigXml を指定しない場合は、apache tika のデフォルト設定で動作します。 
 		-->
 		<!--
-		<bean name="tikaAdapter" builder="org.iplass.mtp.impl.web.fileupload.FileUploadTikaAdapterImpl$Builder">
+		<bean name="tikaAdapter" class="org.iplass.mtp.impl.web.fileupload.FileUploadTikaAdapterImpl">
 			<property name="tikaConfigXml" value="/tika-config.xml" />
 		</bean>
 		-->
@@ -453,7 +453,7 @@
 			<property name="throwExceptionIfMimeTypeIsNull" value="false" />
 			<property name="throwExceptionIfFileCannotRead" value="false" />
 			<property name="substitutionMediaType">
-				<property name="source/MediaType" value="dest/MediaType" />
+				<property name="application/vnd.apple.keynote.13" value="application/vnd.apple.keynote" />
 			</property>
 		</property>
 		-->

--- a/iplass-web/src/main/resources/mtp-web-service-config.xml
+++ b/iplass-web/src/main/resources/mtp-web-service-config.xml
@@ -345,7 +345,7 @@
 		-->
 		<!--
 		<bean name="tikaAdapter" builder="org.iplass.mtp.impl.web.fileupload.FileUploadTikaAdapterImpl$Builder">
-			<property name="tikaConfigXml" value="tika-config.xml" />
+			<property name="tikaConfigXml" value="/tika-config.xml" />
 		</bean>
 		-->
 


### PR DESCRIPTION
- Apache Tika を利用したマジックバイトチェック処理の実装
- TikaFileTypeDetector で利用する Tika インスタンスをマジックバイトチェック処理と共有する
- service-config 設定例を記載