### PR TITLE
GEM、大量データ用参照セクション、参照プロパティのソートの挙動修正

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/GetMassReferencesCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/GetMassReferencesCommand.java
@@ -753,23 +753,12 @@ public final class GetMassReferencesCommand extends DetailCommandBase implements
 	}
 
 	private NestProperty getLayoutNestProperty(MassReferenceSection section, String propName) {
-		Optional<NestProperty> property = getNestProperties(section).stream()
+		Optional<NestProperty> property = section.getProperties().stream()
 				.filter(e -> propName.equals(e.getPropertyName())).findFirst();
 		if (property.isPresent()) {
 			return property.get();
 		}
 		return null;
-	}
-
-	/**
-	 * セクションのプロパティを取得します。
-	 * @return
-	 */
-	protected List<NestProperty> getNestProperties(MassReferenceSection section) {
-		List<NestProperty> properties = section.getProperties().stream()
-				.filter(e -> e instanceof NestProperty).map(e -> (NestProperty) e)
-				.collect(Collectors.toList());
-		return properties;
 	}
 	
 	/**


### PR DESCRIPTION
ReferencePropertyEditorの「表示ラベルとして扱うプロパティ」が未設定の場合はname項目でソートし、設定された場合は、表示ラベルとして扱うプロパティでソートするように修正する。