### PR TITLE
AdminConsole、プロパティのRangeタイプのValidator設定でMin/Maxに負の数や小数を指定できない

### DIFF
--- a/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/entity/property/validation/RangeAttributePane.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/entity/property/validation/RangeAttributePane.java
@@ -43,15 +43,15 @@ public class RangeAttributePane extends ValidationAttributePane {
 
 		minItem = new MtpTextItem("minValue");
 		minItem.setTitle("Min");
-		minItem.setKeyPressFilter("[0-9]");
+		minItem.setKeyPressFilter("[0-9.-]");
 
 		minExcludeItem = new CheckboxItem();
-		minExcludeItem.setTitle("grater than min value");
+		minExcludeItem.setTitle("greater than min value");
 		SmartGWTUtil.addHoverToFormItem(minExcludeItem, rs("ui_metadata_entity_PropertyListGrid_minExclude"));
 
 		maxItem = new MtpTextItem("maxValue");
 		maxItem.setTitle("Max");
-		maxItem.setKeyPressFilter("[0-9]");
+		maxItem.setKeyPressFilter("[0-9.-]");
 
 		maxExcludeItem = new CheckboxItem();
 		maxExcludeItem.setTitle("less than max value");


### PR DESCRIPTION
AdminConsole、プロパティのValidator設定はRangeタイプのMin/Maxに負の数や小数を指定できない不具合を修正する。