### PR TITLE
PreparedQuery#condition、Queryテンプレートの実行結果がブランクだった場合にはnullを返すように

### DIFF
--- a/iplass-core/src/main/java/org/iplass/mtp/entity/query/condition/Condition.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/entity/query/condition/Condition.java
@@ -22,6 +22,7 @@ package org.iplass.mtp.entity.query.condition;
 
 import org.iplass.mtp.entity.query.ASTNode;
 import org.iplass.mtp.entity.query.QueryException;
+import org.iplass.mtp.impl.parser.ParseContext;
 import org.iplass.mtp.impl.parser.ParseException;
 import org.iplass.mtp.impl.query.QueryServiceHolder;
 import org.iplass.mtp.impl.query.condition.expr.OrSyntax;
@@ -37,6 +38,11 @@ public abstract class Condition implements ASTNode {
 	private static final long serialVersionUID = 7777497275666525341L;
 
 	public static Condition newCondition(String condition) {
+		ParseContext str = new ParseContext(condition);
+		str.consumeChars(ParseContext.WHITE_SPACES);
+		if (str.isEnd()) {
+			return null;
+		}
 		try {
 			return QueryServiceHolder.getInstance().getQueryParser().parse(condition, OrSyntax.class);
 		} catch (ParseException e) {

--- a/iplass-core/src/main/java/org/iplass/mtp/entity/query/condition/Condition.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/entity/query/condition/Condition.java
@@ -22,7 +22,6 @@ package org.iplass.mtp.entity.query.condition;
 
 import org.iplass.mtp.entity.query.ASTNode;
 import org.iplass.mtp.entity.query.QueryException;
-import org.iplass.mtp.impl.parser.ParseContext;
 import org.iplass.mtp.impl.parser.ParseException;
 import org.iplass.mtp.impl.query.QueryServiceHolder;
 import org.iplass.mtp.impl.query.condition.expr.OrSyntax;
@@ -38,11 +37,6 @@ public abstract class Condition implements ASTNode {
 	private static final long serialVersionUID = 7777497275666525341L;
 
 	public static Condition newCondition(String condition) {
-		ParseContext str = new ParseContext(condition);
-		str.consumeChars(ParseContext.WHITE_SPACES);
-		if (str.isEnd()) {
-			return null;
-		}
 		try {
 			return QueryServiceHolder.getInstance().getQueryParser().parse(condition, OrSyntax.class);
 		} catch (ParseException e) {

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/query/prepared/PreparedQueryTemplate.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/query/prepared/PreparedQueryTemplate.java
@@ -23,11 +23,11 @@ package org.iplass.mtp.impl.query.prepared;
 import java.io.IOException;
 import java.io.StringWriter;
 
+import org.apache.poi.util.StringUtil;
 import org.iplass.mtp.entity.query.Query;
 import org.iplass.mtp.entity.query.condition.Condition;
 import org.iplass.mtp.entity.query.value.ValueExpression;
 import org.iplass.mtp.impl.core.ExecuteContext;
-import org.iplass.mtp.impl.query.prepared.PreparedQueryBinding;
 import org.iplass.mtp.impl.script.GroovyScriptEngine;
 import org.iplass.mtp.impl.script.ScriptEngine;
 import org.iplass.mtp.impl.script.template.GroovyTemplate;
@@ -96,7 +96,11 @@ public class PreparedQueryTemplate {
 	 * @return
 	 */
 	public Condition condition(PreparedQueryBinding binding) {
-		return Condition.newCondition(doBind(binding));
+		String templateResult = doBind(binding);
+		if (StringUtil.isBlank(templateResult)) {
+			return null;
+		}
+		return Condition.newCondition(templateResult);
 	}
 	
 	/**

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/query/prepared/PreparedQueryTemplate.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/query/prepared/PreparedQueryTemplate.java
@@ -23,7 +23,6 @@ package org.iplass.mtp.impl.query.prepared;
 import java.io.IOException;
 import java.io.StringWriter;
 
-import org.apache.poi.util.StringUtil;
 import org.iplass.mtp.entity.query.Query;
 import org.iplass.mtp.entity.query.condition.Condition;
 import org.iplass.mtp.entity.query.value.ValueExpression;
@@ -32,6 +31,7 @@ import org.iplass.mtp.impl.script.GroovyScriptEngine;
 import org.iplass.mtp.impl.script.ScriptEngine;
 import org.iplass.mtp.impl.script.template.GroovyTemplate;
 import org.iplass.mtp.impl.script.template.GroovyTemplateCompiler;
+import org.iplass.mtp.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Queryテンプレートの実行結果がブランクだった場合にはnullを返すように修正