### PR TITLE
AdminConsole、gemのTopViewでseparatorで分割している場合に、ダブルクリックで編集ダイアログが２つ開く

### DIFF
--- a/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/top/item/PartsItem.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/top/item/PartsItem.java
@@ -67,6 +67,9 @@ public abstract class PartsItem extends AbstractWindow {
 
 			@Override
 			public void onDoubleClick(DoubleClickEvent event) {
+				//上位のControlにイベントを発生させない
+				event.cancel();
+
 				onOpen();
 			}
 		});


### PR DESCRIPTION
https://github.com/dentsusoken/iPLAss/issues/1446 対応