### PR TITLE
AdminConsole、ファイルアップロード処理の変更、gwtuploadライブラリの利用停止（バグ修正）

### DIFF
--- a/iplass-admin/src/main/java/org/iplass/adminconsole/client/base/io/upload/AdminUploadActionResponseParser.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/client/base/io/upload/AdminUploadActionResponseParser.java
@@ -95,11 +95,23 @@ public class AdminUploadActionResponseParser {
 	 */
 	private static String extractJsonString(String eventResult) {
 		// content-type: application/json を指定しているが、以下のような形式になってしまう。そのため、テキストの json 部分を抽出
-		// e.getResults() = <pre style="word-wrap: break-word; white-space: pre-wrap;">${JSON文字列}</pre>
-		Document resultDocument = XMLParser.parse(eventResult);
+		// Firefox, Edge
+		//   e.getResults() = <pre style="word-wrap: break-word; white-space: pre-wrap;">${JSON文字列}</pre>
+		// Chrome
+		//   e.getResults() = <pre>${JSON文字列}</pre><div></div>
+
+		// ルートノードを response とする。
+		String parseTarget = "<response>" + eventResult + "</response>";
+		Document parsedDocument = XMLParser.parse(parseTarget);
 
 		// JSON文字列を抽出する
-		return resultDocument.getFirstChild().getFirstChild().getNodeValue();
+		return parsedDocument
+				// <response>
+				.getFirstChild()
+				// <pre>
+				.getFirstChild()
+				// #text
+				.getFirstChild().getNodeValue();
 	}
 
 }

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/server/base/io/upload/AdminUploadAction.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/server/base/io/upload/AdminUploadAction.java
@@ -20,12 +20,12 @@
 
 package org.iplass.adminconsole.server.base.io.upload;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -37,6 +37,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import org.apache.poi.util.IOUtils;
 import org.iplass.adminconsole.server.base.i18n.AdminResourceBundleUtil;
 import org.iplass.adminconsole.server.base.service.AdminConsoleService;
 import org.iplass.adminconsole.shared.base.io.AdminUploadConstant;
@@ -244,37 +245,11 @@ public abstract class AdminUploadAction extends XsrfProtectedMultipartServlet {
 
 	// TODO このメソッドはユーティリティ。
 	protected final byte[] convertFileToByte(File file) {
-		byte[] bytes = null;
-		FileInputStream is = null;
-		FileChannel channel = null;
-		try {
-			is = new FileInputStream(file);
-			channel = is.getChannel();
-			ByteBuffer buffer = ByteBuffer.allocate((int) channel.size());
-			channel.read(buffer);
-			buffer.clear();
-			bytes = new byte[buffer.capacity()];
-			buffer.get(bytes);
+		try (InputStream input = new BufferedInputStream(new FileInputStream(file))) {
+			return IOUtils.toByteArray(input);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
-		} finally {
-			if (channel != null) {
-				try {
-					channel.close();
-				} catch (IOException e) {
-					throw new RuntimeException(e);
-				}
-			}
-			if (is != null) {
-				try {
-					is.close();
-				} catch (IOException e) {
-					throw new RuntimeException(e);
-				}
-			}
 		}
-
-		return bytes;
 	}
 
 	/**


### PR DESCRIPTION
- レスポンスのXMLパース時に結果文字列にルートノードを付与する
- ファイルからbyte配列への変換ロジックを見直し