### PR TITLE
テスト、JUnit5系へバージョンアップ

### DIFF
--- a/iplass-test/build.gradle
+++ b/iplass-test/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 sourceSets {
 	demo {
 		compileClasspath = main.output + configurations.compileClasspath + configurations.demoCompileClasspath
-		runtimeClasspath = output + compileClasspath + configurations.runtimeClasspath + configurations.demoRuntimeClasspath
+		runtimeClasspath = output + configurations.runtimeClasspath + configurations.demoRuntimeClasspath
 	}
 }
 

--- a/iplass-test/build.gradle
+++ b/iplass-test/build.gradle
@@ -6,7 +6,17 @@ dependencies {
 	api project(':iplass-core')
 	api project(':iplass-web')
 }
+
 sourceSets {
-	demo
+	demo {
+		compileClasspath = main.output + configurations.compileClasspath + configurations.demoCompileClasspath
+		runtimeClasspath = output + compileClasspath + configurations.runtimeClasspath + configurations.demoRuntimeClasspath
+	}
 }
 
+configurations {
+	// for demo
+	demoRuntimeOnly.extendsFrom jakartaImplXMLBinding
+	demoRuntimeOnly.extendsFrom jakartaImplEL
+	demoRuntimeOnly.extendsFrom jakartaImplRest
+}

--- a/iplass-test/libs.gradle
+++ b/iplass-test/libs.gradle
@@ -3,7 +3,9 @@ configurations {
 }
 
 dependencies {
-	api sharedLib('junit:junit')
+	implementation platform(sharedLib('org.junit:junit-bom'))
+	api 'org.junit.jupiter:junit-jupiter-engine'
+	api 'org.junit.vintage:junit-vintage-engine'
 
 	//groovy
 	implementation 'org.codehaus.groovy:groovy'

--- a/iplass-test/libs.gradle
+++ b/iplass-test/libs.gradle
@@ -4,7 +4,7 @@ configurations {
 
 dependencies {
 	implementation platform(sharedLib('org.junit:junit-bom'))
-	api 'org.junit.jupiter:junit-jupiter-engine'
+	api 'org.junit.jupiter:junit-jupiter'
 	api 'org.junit.vintage:junit-vintage-engine'
 
 	//groovy

--- a/iplass-test/src/demo/groovy/testsample/SampleGroovyTest.groovy
+++ b/iplass-test/src/demo/groovy/testsample/SampleGroovyTest.groovy
@@ -1,19 +1,19 @@
 /*
  * Copyright (C) 2016 DENTSU SOKEN INC. All Rights Reserved.
- * 
+ *
  * Unless you have purchased a commercial license,
  * the following license terms apply:
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -21,61 +21,52 @@
 package testsample
 
 import static org.junit.Assert.*;
-import org.iplass.mtp.auth.User;
-import org.iplass.mtp.entity.Entity;
-import org.iplass.mtp.entity.SearchResult;
+
 import org.iplass.mtp.test.AuthUser;
-import org.iplass.mtp.test.ConfigFile;
-import org.iplass.mtp.test.MTPJUnitTestRule;
+import org.iplass.mtp.test.MTPJUnitTestExtension
 import org.iplass.mtp.test.MTPTest;
 import org.iplass.mtp.test.TenantName;
 import org.iplass.mtp.test.TestRequestContext;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith
 
 @TenantName("testDemo1")
 @AuthUser(userId="testuser", password="testtest")
+@ExtendWith(MTPJUnitTestExtension.class)
 class SampleGroovyTest {
-	@Rule
-	public MTPJUnitTestRule rule = new MTPJUnitTestRule();
-	
+
 	@Test
-	public void testGroovyCommand() {
-		
+	void testGroovyCommand() {
+
 		TestRequestContext req = new TestRequestContext();
 		req.setParam("accountId", "testuser");
-		
+
 		String status = MTPTest.invokeCommand("testsample/command/TestSearchGroovyCommand", req);
-		
+
 		assertEquals("OK", status);
 		assertEquals("testuser", req.res.first.accountId);
 		assertEquals("stringFromTestUtil", req.utilClassRes);
-		
 	}
 
 	@Test
-	public void testUtilityClass() {
-		
+	void testUtilityClass() {
+
 		//call static method
 		Class testUtilClass = MTPTest.getUtilityClass("testsample.TestUtil");
 		assertEquals("stringFromTestUtil", testUtilClass.staticMethedCall());
-		
+
 		//create instance with args
 		def bean1 = MTPTest.newUC("testsample.TestUtil", "hoge");
 		assertEquals("hoge", bean1.strVal);
-		
+
 		def bean2 = MTPTest.newUC("testsample.TestUtil", 5);
 		assertEquals(5, bean2.intVal);
-		
+
 		def bean3 = MTPTest.newUC("testsample.TestUtil", "fuga", 10);
 		assertEquals("fuga", bean3.strVal);
 		assertEquals(10, bean3.intVal);
-		
+
 		bean3.addIntVal(5);
 		assertEquals(15, bean3.intVal);
-		
 	}
-
 }

--- a/iplass-test/src/demo/java/testsample/SampleJavaTest.java
+++ b/iplass-test/src/demo/java/testsample/SampleJavaTest.java
@@ -1,19 +1,19 @@
 /*
  * Copyright (C) 2016 DENTSU SOKEN INC. All Rights Reserved.
- * 
+ *
  * Unless you have purchased a commercial license,
  * the following license terms apply:
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -25,6 +25,9 @@ import static org.junit.Assert.*;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.iplass.mtp.ManagerLocator;
 import org.iplass.mtp.auth.AuthContext;
@@ -35,51 +38,49 @@ import org.iplass.mtp.entity.EntityManager;
 import org.iplass.mtp.entity.EntityValidationException;
 import org.iplass.mtp.entity.SearchResult;
 import org.iplass.mtp.test.AuthUser;
-import org.iplass.mtp.test.MTPJUnitTestRule;
+import org.iplass.mtp.test.MTPJUnitTestExtension;
 import org.iplass.mtp.test.MTPTest;
 import org.iplass.mtp.test.NoAuthUser;
 import org.iplass.mtp.test.TenantName;
 import org.iplass.mtp.test.TestRequestContext;
 import org.iplass.mtp.test.TestUploadFileHandle;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
 @TenantName("testDemo1")
 @AuthUser(userId="testuser", password="testtest")
-public class SampleJavaTest {
-	
+@ExtendWith(MTPJUnitTestExtension.class)
+class SampleJavaTest {
+
 	static final String COMMAND_NAME = "testsample/command/TestSearchCommand";
-	
-	@Rule
-	public MTPJUnitTestRule rule = new MTPJUnitTestRule();
-	
+
 	//for upload test
-	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
-	
+	@TempDir
+	Path tempFolder;
+
 	@Test
-	public void searchByCommand() throws IOException {
+	void searchByCommand() throws IOException {
 		TestRequestContext req = new TestRequestContext();
 		req.setParam("accountId", "testuser");
-		
+
 		//if test upload file, use TestUploadFileHandle
-		File upFile = tempFolder.newFile("upFile.txt");
+		File upFile = Files.createFile(Paths.get(tempFolder.toString(), "upFile.txt")).toFile();
 		TestUploadFileHandle uh = new TestUploadFileHandle(upFile, "upFile.txt", "text/plain");
 		req.setParam("upFile", uh);
-		
+
 		String status = MTPTest.invokeCommand(COMMAND_NAME, req);
-		
+
 		assertEquals("OK", status);
-		
+
 		@SuppressWarnings("unchecked")
 		SearchResult<Entity> res = (SearchResult<Entity>) req.getAttribute("res");
 		assertEquals("testuser", res.getFirst().getValue(User.ACCOUNT_ID));
 	}
-	
+
 	@Test
-	public void searchByCommandWithMock() {
-		
+	void searchByCommandWithMock() {
+
 		//Create and set mock
 		EntityManager mock = (EntityManager) Proxy.newProxyInstance(
 				Thread.currentThread().getContextClassLoader(), new Class<?>[]{EntityManager.class},
@@ -91,63 +92,63 @@ public class SampleJavaTest {
 		//Test
 		TestRequestContext req = new TestRequestContext();
 		req.setParam("accountId", "testuser");
-		
-		MTPTest.invokeCommand(COMMAND_NAME, req);
-		
-		assertNull(req.getAttribute("res"));
-	}
-	
-	@Test(expected = EntityValidationException.class)
-	public void testWithTransaction() {
-		
-		//MTPTest#invokeCommand is automatically begin/end transaction
-		TestRequestContext req = new TestRequestContext();
-		req.setParam("accountId", "testuser");
+
 		MTPTest.invokeCommand(COMMAND_NAME, req);
 
-		
-		//if you need to transaction-ed test code, use MTPTest#transaction
-		MTPTest.transaction(() -> {
-			
-			EntityManager em = ManagerLocator.getInstance().getManager(EntityManager.class);
-			Group g = new Group();
-			g.setCode("testGroup");
-			em.insert(g);
-			
-		});
-		
+		assertNull(req.getAttribute("res"));
 	}
-	
+
 	@Test
-    @AuthUser(userId="testuser2", password="testtest")
-	public void runAnotherUser() {
-		
+	void testWithTransaction() {
+		assertThrows(EntityValidationException.class, () -> {
+			//MTPTest#invokeCommand is automatically begin/end transaction
+			TestRequestContext req = new TestRequestContext();
+			req.setParam("accountId", "testuser");
+			MTPTest.invokeCommand(COMMAND_NAME, req);
+
+
+			//if you need to transaction-ed test code, use MTPTest#transaction
+			MTPTest.transaction(() -> {
+
+				EntityManager em = ManagerLocator.getInstance().getManager(EntityManager.class);
+				Group g = new Group();
+				g.setCode("testGroup");
+				em.insert(g);
+
+			});
+		});
+	}
+
+	@Test
+	@AuthUser(userId="testuser2", password="testtest")
+	void runAnotherUser() {
+
 		AuthContext auth = AuthContext.getCurrentContext();
 		assertEquals("testuser2", auth.getUser().getAccountId());
 	}
-	
+
 	@Test
 	@NoAuthUser
-	public void runNoAuth() {
-		
+	void runNoAuth() {
+
 		AuthContext auth = AuthContext.getCurrentContext();
 		assertFalse(auth.isAuthenticated());
 	}
-	
+
 	@Test
 	@TenantName("testDemo2")
 	@AuthUser(userId="test", password="testtest")
-	public void runAnotherTenant() {
+	void runAnotherTenant() {
 		TestRequestContext req = new TestRequestContext();
 		req.setParam("accountId", "test");
-		
+
 		String status = MTPTest.invokeCommand(COMMAND_NAME, req);
-		
+
 		assertEquals("OK", status);
-		
+
 		@SuppressWarnings("unchecked")
 		SearchResult<Entity> res = (SearchResult<Entity>) req.getAttribute("res");
 		assertEquals("test", res.getFirst().getValue(User.ACCOUNT_ID));
 	}
-	
+
 }

--- a/iplass-test/src/demo/resources/testsample/test-sample-metadata.xml
+++ b/iplass-test/src/demo/resources/testsample/test-sample-metadata.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE metaDataList>
 <metaDataList>
 <contextPath name="/commandClass">
-<metaDataEntry overwritable="false" sharable="false" dataSharable="false" permissionSharable="false">
+<metaDataEntry name="/commandClass/testsample/command/TestSearchGroovyCommand" overwritable="false" sharable="false" dataSharable="false" permissionSharable="false">
     <metaData xsi:type="metaMetaScriptingCommand" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         <id>2b91ecca-f50a-46c1-9d4d-71bb3c7eb8af</id>
         <name>testsample/command/TestSearchGroovyCommand</name>
@@ -24,7 +24,7 @@ request.utilClassRes = TestUtil.staticMethedCall();
 </metaDataEntry>
 </contextPath>
 <contextPath name="/utilityClass">
-<metaDataEntry overwritable="false" sharable="false" dataSharable="false" permissionSharable="false">
+<metaDataEntry name="/utilityClass/testsample/TestUtil" overwritable="false" sharable="false" dataSharable="false" permissionSharable="false">
     <metaData xsi:type="metaUtilityClass" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         <id>2bf94091-6785-40b2-9fc9-b7f7cd6ed95a</id>
         <name>testsample.TestUtil</name>

--- a/iplass-test/src/demo/resources/testsample/test-sample-service-config.xml
+++ b/iplass-test/src/demo/resources/testsample/test-sample-service-config.xml
@@ -4,9 +4,9 @@
 	<inherits>/mtp-web-service-config.xml</inherits>
 	
 	<inherits>/mtp-core-service-config-oracle.xml</inherits>
-	<!-- If use mysql, inherits mtp-service-config-mysql.xml for convenience. -->
+	<!-- If use mysql, inherits mtp-core-service-config-mysql.xml for convenience. -->
 	<!--
-	<inherits>/mtp-service-config-mysql.xml</inherits>
+	<inherits>/mtp-core-service-config-mysql.xml</inherits>
 	-->
 
 	<!-- Rdb Connection Settings -->

--- a/iplass-test/src/demo/resources/testsample/test-sample-service-config.xml
+++ b/iplass-test/src/demo/resources/testsample/test-sample-service-config.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!DOCTYPE serviceDefinition>
 <serviceDefinition>
-	<inherits>/mtp-service-config-oracle.xml</inherits>
+	<inherits>/mtp-web-service-config.xml</inherits>
+	
+	<inherits>/mtp-core-service-config-oracle.xml</inherits>
 	<!-- If use mysql, inherits mtp-service-config-mysql.xml for convenience. -->
 	<!--
 	<inherits>/mtp-service-config-mysql.xml</inherits>

--- a/iplass-test/src/main/java/org/iplass/mtp/test/MTPJUnitTestExtension.java
+++ b/iplass-test/src/main/java/org/iplass/mtp/test/MTPJUnitTestExtension.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2024 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.test;
+
+import java.lang.reflect.Method;
+
+import org.iplass.mtp.test.impl.test.MTPTestConfig;
+import org.iplass.mtp.test.impl.test.MTPTestConfigReader;
+import org.iplass.mtp.test.impl.test.MTPTestInvoker;
+import org.iplass.mtp.test.impl.test.MTPTestInvokerDecorator;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+
+/**
+ * <p>
+ * JUnitに単体テスト用のユーティリティ処理を組み込むための JUnit5 Extension です。
+ * </p>
+ * <p>
+ * MTPJUnitTestExtension を組み込むことにより、容易な方法により、iPLAssの設定ファイルの指定、テナント、テストユーザーの設定、トランザクション制御を行うことが可能です。
+ * 設定方法は以下のいずれかの方法、またその組み合わせで行うことが可能です。
+ * </p>
+ * <dl>
+ * <dt>プロパティファイルによる指定</dt><dd>テスト全体にわたり設定が適用されます</dd>
+ * <dt>クラスレベルアノテーションによる指定</dt><dd>当該クラスに限り設定が適用されます</dd>
+ * <dt>メソッドレベルアノテーションによる指定</dt><dd>当該メソッドに限り設定が適用されます</dd>
+ * </dl>
+ * <p>
+ * 上記の指定方法は混在可能です。
+ * 指定の優先度は、
+ * </p>
+ * <blockquote>メソッドレベルアノテーション ＞ クラスレベルアノテーション ＞ プロパティファイル</blockquote>
+ * <p>
+ * となります。
+ * </p>
+ * <h3>プロパティファイルによる指定方法</h3>
+ * <p>
+ * プロパティファイルは、"/mtptest.properties"として、クラスパスからロードされます。
+ * プロパティファイルをロードするパスを変更する場合は、システムプロパティ"mtp.test.config"にて指定可能です。
+ * 次の項目をプロパティファイルにて指定可能です。
+ * </p>
+ * <table border="1">
+ * <caption>プロパティファイルの項目の説明</caption>
+ * <tr><th>項目名</th><th>説明</th></tr>
+ * <tr>
+ * <td>configFileName</td>
+ * <td>テスト実行時のiPLAssの設定ファイルのパスを指定します。<br>
+ * 設定例：<br>
+ * configFileName=/testsample/test-sample-service-config.xml</td>
+ * </tr>
+ * <tr>
+ * <td>rollbackTransaction</td>
+ * <td>テスト実行時のトランザクションをロールバックするか否かを指定します。<br>
+ * 設定例：<br>
+ * rollbackTransaction=true</td>
+ * </tr>
+ * <tr>
+ * <td>tenantName</td>
+ * <td>テスト実行時のテナント名を指定します。<br>
+ * 設定例：<br>
+ * tenantName=testDemo1</td>
+ * </tr>
+ * <tr>
+ * <td>userId</td>
+ * <td>テスト実行時のユーザーのaccountIdを指定します。<br>
+ * 設定例：<br>
+ * userId=testUser</td>
+ * </tr>
+ * <tr>
+ * <td>password</td>
+ * <td>テスト実行時のユーザーのパスワードを指定します。<br>
+ * 設定例：<br>
+ * password=testUserPass</td>
+ * </tr>
+ * </table>
+ *
+ * <h3>クラスレベルアノテーションによる指定、及びメソッドレベルアノテーションによる指定方法</h3>
+ * <p>
+ * アノテーションにより、クラス単位、メソッド単位でテナント、ユーザーなどの指定が可能です。
+ * 指定可能なアノテーションは以下です。
+ * </p>
+ * <ul>
+ * <li>{@link ConfigFile}</li>
+ * <li>{@link TenantName}</li>
+ * <li>{@link AuthUser}</li>
+ * <li>{@link NoAuthUser}</li>
+ * <li>{@link Commit}</li>
+ * <li>{@link Rollback}</li>
+ * </ul>
+ * <p>
+ * 以下にアノテーション記述されたテストクラスの例を示します。
+ * </p>
+ * <pre>
+ * //アノテーションで指定されていない設定はプロパティファイルの設定値が適用されます。
+ * {@literal @}TenantName("testDemo1")
+ * {@literal @}AuthUser(userId="testuser", password="testtest")
+ * {@literal @}ExtendWith( MTPJUnitTestExtension.class )
+ * public class SampleJavaTest {
+ *   {@literal @}org.junit.jupiter.api.Test
+ *   public void testHogeHoge() throws IOException {
+ *     //do test...
+ *     :
+ *     :
+ *   }
+ *
+ *   {@literal @}org.junit.jupiter.api.Test
+ *   {@literal @}TenantName("testDemo2")
+ *   {@literal @}AuthUser(userId="test2", password="testtest")
+ *   public void testHogeHoge() throws IOException {
+ *     //do test as tenant:testDemo2 user:test2 ...
+ *     :
+ *     :
+ *   }
+ *
+ *   :
+ *   :
+ * }
+ * </pre>
+ * <p>
+ * テストクラスは、Java、もしくはGroovyで記述可能です。
+ * Groovyで記述された、Command、UtilityClassをテストする場合は、Groovyでテストクラスを記述した方が記述が簡易になります。
+ * 詳しくはそれぞれのテストクラスのサンプル実装を参照下さい。
+ * </p>
+ *
+ * @author N.Sekiguchi
+ */
+public class MTPJUnitTestExtension implements InvocationInterceptor, BeforeAllCallback {
+	/** */
+	private MTPTestConfig fileAndClassConfig;
+
+	@Override
+	public void interceptTestMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext)
+			throws Throwable {
+
+		MTPTestConfig methodconConfig = MTPTestConfigReader.read(invocationContext.getExecutable(), fileAndClassConfig);
+
+		MTPTestInvoker<Void> test = MTPTestInvokerDecorator.decorate(config -> {
+			invocation.proceed();
+			return null;
+		});
+
+		// テスト実行
+		test.invoke(methodconConfig);
+	}
+
+	@Override
+	public void beforeAll(ExtensionContext context) throws Exception {
+		Class<?> testClass = context.getTestClass().get();
+		fileAndClassConfig = MTPTestConfigReader.read(testClass);
+	}
+}

--- a/iplass-test/src/main/java/org/iplass/mtp/test/MTPJUnitTestRule.java
+++ b/iplass-test/src/main/java/org/iplass/mtp/test/MTPJUnitTestRule.java
@@ -1,25 +1,23 @@
 /*
  * Copyright (C) 2016 DENTSU SOKEN INC. All Rights Reserved.
- * 
+ *
  * Unless you have purchased a commercial license,
  * the following license terms apply:
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.iplass.mtp.test;
-
-import groovy.lang.GroovyObject;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,9 +37,12 @@ import org.iplass.mtp.impl.rdb.connection.ResourceHolder;
 import org.iplass.mtp.impl.script.GroovyScriptEngine;
 import org.iplass.mtp.impl.transaction.TransactionService;
 import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.test.impl.test.TestTransactionService;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
+import groovy.lang.GroovyObject;
 
 /**
  * <p>
@@ -104,7 +105,7 @@ import org.junit.runners.model.Statement;
  * password=testUserPass</td>
  * </tr>
  * </table>
- * 
+ *
  * <h3>クラスレベルアノテーションによる指定、及びメソッドレベルアノテーションによる指定方法</h3>
  * <p>
  * アノテーションにより、クラス単位、メソッド単位でテナント、ユーザーなどの指定が可能です。
@@ -128,14 +129,14 @@ import org.junit.runners.model.Statement;
  * public class SampleJavaTest {
  *   {@literal @}Rule
  *   public MTPJUnitTestRule rule = new MTPJUnitTestRule();
- * 
+ *
  *   {@literal @}Test
  *   public void testHogeHoge() throws IOException {
  *     //do test...
  *     :
  *     :
  *   }
- *   
+ *
  *   {@literal @}Test
  *   {@literal @}TenantName("testDemo2")
  *   {@literal @}AuthUser(userId="test2", password="testtest")
@@ -144,7 +145,7 @@ import org.junit.runners.model.Statement;
  *     :
  *     :
  *   }
- *   
+ *
  *   :
  *   :
  * }
@@ -154,12 +155,14 @@ import org.junit.runners.model.Statement;
  * Groovyで記述された、Command、UtilityClassをテストする場合は、Groovyでテストクラスを記述した方が記述が簡易になります。
  * 詳しくはそれぞれのテストクラスのサンプル実装を参照下さい。
  * </p>
- * 
+ *
+ * @deprecated 本クラスは JUnit4 向けの機能となります。JUnit5 向けの {@link org.iplass.mtp.test.MTPJUnitTestExtension} を利用してください。
  * @author K.Higuchi
  *
  */
+@Deprecated
 public class MTPJUnitTestRule implements TestRule {
-	
+
 	public static final String TEST_CONFIG_FILE_NAME_SYSTEM_PROPERTY_NAME = "mtp.test.config";
 	public static final String DEFAULT_TEST_CONFIG_FILE_NAME = "/mtptest.properties";
 	public static final String PROP_CONFIG_FILE_NAME = "configFileName";
@@ -167,23 +170,23 @@ public class MTPJUnitTestRule implements TestRule {
 	public static final String PROP_USER_ID = "userId";
 	public static final String PROP_PASSWORD = "password";
 	public static final String PROP_TENANT_NAME = "tenantName";
-	
+
 	static {
 		System.setProperty(ManagerLocator.MANAGER_LOCATOR_SYSTEM_PROPERTY_NAME, TestManagerLocator.class.getName());
 	}
-	
+
 	private volatile String configFileName;
 	private volatile boolean rollbackTransaction = true;
 	private volatile String tenantName;
 	private volatile String userId;
 	private volatile String password;
-	
+
 	public MTPJUnitTestRule() {
 		String propPath = System.getProperty(TEST_CONFIG_FILE_NAME_SYSTEM_PROPERTY_NAME);
 		if (propPath == null) {
 			propPath = DEFAULT_TEST_CONFIG_FILE_NAME;
 		}
-		
+
 		Properties prop = null;
 		try (InputStream is = MTPJUnitTestRule.class.getResourceAsStream(propPath);
 				Reader r = new InputStreamReader(is, "UTF-8")) {
@@ -194,7 +197,7 @@ public class MTPJUnitTestRule implements TestRule {
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
-		
+
 		if (prop != null) {
 			String val = (String) prop.get(PROP_CONFIG_FILE_NAME);
 			if (val != null && val.length() > 0) {
@@ -218,10 +221,10 @@ public class MTPJUnitTestRule implements TestRule {
 			}
 		}
 	}
-	
+
 	/**
 	 * Ruleに直接configFileNameを設定します。
-	 * 
+	 *
 	 * @param configFileName
 	 * @return
 	 */
@@ -229,10 +232,10 @@ public class MTPJUnitTestRule implements TestRule {
 		this.configFileName = configFileName;
 		return this;
 	}
-	
+
 	/**
 	 * Ruleに直接rollbackTransactionを設定します。
-	 * 
+	 *
 	 * @param rollbackTransaction
 	 * @return
 	 */
@@ -240,10 +243,10 @@ public class MTPJUnitTestRule implements TestRule {
 		this.rollbackTransaction = rollbackTransaction;
 		return this;
 	}
-	
+
 	/**
 	 * Ruleに直接tenantを設定します。
-	 * 
+	 *
 	 * @param tenantName
 	 * @return
 	 */
@@ -251,10 +254,10 @@ public class MTPJUnitTestRule implements TestRule {
 		this.tenantName = tenantName;
 		return this;
 	}
-	
+
 	/**
 	 * Ruleに直接authUserを設定します。
-	 * 
+	 *
 	 * @param userId
 	 * @param password
 	 * @return
@@ -264,12 +267,12 @@ public class MTPJUnitTestRule implements TestRule {
 		this.password = password;
 		return this;
 	}
-	
+
 	@Override
 	public Statement apply(final Statement base, final Description description) {
 		return new ConfigStatement(base, description);
 	}
-	
+
 	private class ConfigStatement extends Statement {
 		private InitStatement base;
 		private String configFile;
@@ -279,7 +282,7 @@ public class MTPJUnitTestRule implements TestRule {
 			if (configFileName != null) {
 				configFile = configFileName;
 			}
-			
+
 			ConfigFile cf = description.getTestClass().getAnnotation(ConfigFile.class);
 			if (cf != null) {
 				configFile = cf.value();
@@ -289,33 +292,33 @@ public class MTPJUnitTestRule implements TestRule {
 				configFile = cf.value();
 			}
 		}
-		
+
 		@Override
 		public void evaluate() throws Throwable {
-			
+
 			if (configFile != null) {
 				if (BootstrapProps.getInstance().replaceProperty(BootstrapProps.CONFIG_FILE_NAME, configFile)) {
 					ServiceRegistry.getRegistry().reInit();
 				}
 			}
-			
+
 			base.evaluate();
 		}
 	}
-	
+
 	private class InitStatement extends Statement {
-		
+
 		private TransactionStatement base;
 		private boolean isGroovy;
 		private String tname;
-		
+
 		private InitStatement(Statement base, Description description) {
 			isGroovy = GroovyObject.class.isAssignableFrom(description.getTestClass());
 			this.base = new TransactionStatement(base, description);
 			if (tenantName != null) {
 				tname = tenantName;
 			}
-			
+
 			TenantName tn = description.getTestClass().getAnnotation(TenantName.class);
 			if (tn != null) {
 				tname = tn.value();
@@ -328,11 +331,11 @@ public class MTPJUnitTestRule implements TestRule {
 
 		@Override
 		public void evaluate() throws Throwable {
-			
+
 			boolean isInit = false;
 			try {
 				isInit = ResourceHolder.init();
-				
+
 				//ここでセットしておかないと、TransactionManagerが初期化されてしまう
 				TransactionService ts = ServiceRegistry.getRegistry().getService(TransactionService.class);
 				if (!(ts instanceof TestTransactionService)) {
@@ -353,7 +356,7 @@ public class MTPJUnitTestRule implements TestRule {
 									Thread.currentThread().setContextClassLoader(((GroovyScriptEngine) tc.getScriptEngine()).getSharedClassLoader());
 								}
 								base.evaluate();
-								
+
 							} finally {
 								if (replaceCl) {
 									Thread.currentThread().setContextClassLoader(cl);
@@ -374,18 +377,18 @@ public class MTPJUnitTestRule implements TestRule {
 			}
 		}
 	}
-	
+
 	private class TransactionStatement extends Statement {
-		
+
 		AuthStatement base;
 		boolean isRollback;
-		
+
 		TransactionStatement(Statement base, Description description) {
 			this.base = new AuthStatement(base, description);
-			
+
 			//default setting
 			isRollback = rollbackTransaction;
-			
+
 			//class level annotation
 			Commit tc = description.getTestClass().getAnnotation(Commit.class);
 			if (tc != null) {
@@ -395,7 +398,7 @@ public class MTPJUnitTestRule implements TestRule {
 			if (tr != null) {
 				isRollback = true;
 			}
-			
+
 			//method level annotation
 			tc = description.getAnnotation(Commit.class);
 			if (tc != null) {
@@ -416,22 +419,22 @@ public class MTPJUnitTestRule implements TestRule {
 			TestTransactionService.rollback = isRollback;
 			base.evaluate();
 		}
-		
+
 	}
-	
+
 	private class AuthStatement extends Statement {
-		
+
 		MockManagerStatement base;
 		String userId;
 		String password;
-		
+
 		AuthStatement(Statement base, Description description) {
 			this.base = new MockManagerStatement(base, description);
-			
+
 			//default setting
 			userId = MTPJUnitTestRule.this.userId;
 			password = MTPJUnitTestRule.this.password;
-			
+
 			//class level annotation
 			AuthUser au = description.getTestClass().getAnnotation(AuthUser.class);
 			if (au != null) {
@@ -443,7 +446,7 @@ public class MTPJUnitTestRule implements TestRule {
 				userId = null;
 				password = null;
 			}
-			
+
 			//method level annotation
 			au = description.getAnnotation(AuthUser.class);
 			if (au != null) {
@@ -459,7 +462,7 @@ public class MTPJUnitTestRule implements TestRule {
 
 		@Override
 		public void evaluate() throws Throwable {
-			
+
 			AuthService as = ServiceRegistry.getRegistry().getService(AuthService.class);
 			if (userId != null) {
 				as.login(new IdPasswordCredential(userId, password));
@@ -481,12 +484,12 @@ public class MTPJUnitTestRule implements TestRule {
 				throw e.getCause();
 			}
 		}
-		
+
 	}
-	
+
 	private class MockManagerStatement extends Statement {
 		Statement base;
-		
+
 		public MockManagerStatement(Statement base, Description description) {
 			this.base = base;
 		}
@@ -500,7 +503,7 @@ public class MTPJUnitTestRule implements TestRule {
 			}
 		}
 	}
-	
+
 	private static class WrapException extends RuntimeException {
 		private static final long serialVersionUID = -9157815643184354559L;
 
@@ -508,6 +511,6 @@ public class MTPJUnitTestRule implements TestRule {
 			super(cause);
 		}
 	}
-	
+
 
 }

--- a/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestConfig.java
+++ b/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestConfig.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2024 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.test.impl.test;
+
+/**
+ * テストユーティリティ設定インターフェース
+ *
+ * <p>
+ * テストユーティリティで利用する設定情報を管理する。
+ * </p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public interface MTPTestConfig {
+	/**
+	 * 設定ファイル名を取得する
+	 * @return 設定ファイル名
+	 */
+	String getConfigFileName();
+
+	/**
+	 * テナント名を取得する
+	 * @return テナント名
+	 */
+	String getTenantName();
+
+	/**
+	 * ログインユーザーIDを取得する
+	 * @return ユーザーID
+	 */
+	String getUserId();
+
+	/**
+	 * ログインパスワードを取得する
+	 * @return ログインパスワード
+	 */
+	String getPassword();
+
+	/**
+	 * トランザクションをロールバックするか
+	 * @return トランザクションをロールバックするか（ロールバックする場合 true）
+	 */
+	Boolean isRollbackTransaction();
+
+	/**
+	 *  &#64;NoAuth が付与されているか
+	 *
+	 * <p>
+	 * &#64;NoAuth は クラス、メソッドのいずれかに設定される。
+	 * </p>
+	 *
+	 * @return &#64;NoAuth が付与されているか（&#64;NoAuth が付与されている場合 true）
+	 */
+	Boolean isNoAuth();
+
+	/**
+	 * テストが groovy であるか
+	 * @return テストが groovy であるか（groovy テストの場合 true）
+	 */
+	Boolean isGroovy();
+}

--- a/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestConfigComposit.java
+++ b/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestConfigComposit.java
@@ -35,9 +35,11 @@ public class MTPTestConfigComposit extends MTPTestConfigImpl {
 
 	/**
 	 * コンストラクタ
+	 * @param layer テスト設定を取得したレイヤー情報（ファイル、クラス、メソッドのいずれか）
 	 * @param parent 親設定項目
 	 */
-	public MTPTestConfigComposit(MTPTestConfig parent) {
+	public MTPTestConfigComposit(Object layer, MTPTestConfig parent) {
+		super(layer);
 		this.parent = parent;
 	}
 

--- a/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestConfigComposit.java
+++ b/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestConfigComposit.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.test.impl.test;
+
+/**
+ * テストユーティリティコンポジットクラス
+ *
+ * <p>
+ * テスト設定は「設定ファイル＞クラス＞メソッド」で優先順位がある。
+ * 本クラスではそれぞれの設定を管理し、当該項目に設定がなければ親を参照する為のクラス。
+ * </p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public class MTPTestConfigComposit extends MTPTestConfigImpl {
+	/** 親設定項目 */
+	private MTPTestConfig parent;
+
+	/**
+	 * コンストラクタ
+	 * @param parent 親設定項目
+	 */
+	public MTPTestConfigComposit(MTPTestConfig parent) {
+		this.parent = parent;
+	}
+
+	@Override
+	public String getConfigFileName() {
+		if (null != super.getConfigFileName()) {
+			return super.getConfigFileName();
+		}
+		return parent.getConfigFileName();
+	}
+
+	@Override
+	public String getTenantName() {
+		if (null != super.getTenantName()) {
+			return super.getTenantName();
+		}
+		return parent.getTenantName();
+	}
+
+	@Override
+	public String getUserId() {
+		if (null != super.getUserId()) {
+			return super.getUserId();
+		}
+		return parent.getUserId();
+	}
+
+	@Override
+	public String getPassword() {
+		if (null != super.getPassword()) {
+			return super.getPassword();
+		}
+		return parent.getPassword();
+	}
+
+	@Override
+	public Boolean isRollbackTransaction() {
+		if (null != super.isRollbackTransaction()) {
+			return super.isRollbackTransaction();
+		}
+		return parent.isRollbackTransaction();
+	}
+
+	@Override
+	public Boolean isNoAuth() {
+		if (null != super.isNoAuth()) {
+			return super.isNoAuth();
+		}
+		return parent.isNoAuth();
+	}
+
+	@Override
+	public Boolean isGroovy() {
+		if (null != super.isGroovy()) {
+			return super.isGroovy();
+		}
+		return parent.isGroovy();
+	}
+
+}

--- a/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestConfigImpl.java
+++ b/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestConfigImpl.java
@@ -167,6 +167,17 @@ public class MTPTestConfigImpl implements MTPTestConfig {
 				.toString();
 	}
 
+	/**
+	 * toString 用文字列を生成する
+	 *
+	 * <p>
+	 * <code>"key": "value"</code> のような値を返却する。 value が null の場合は <code>"key": null</code> を返却する。
+	 * </p>
+	 * @param <T> valueデータ型
+	 * @param key キー
+	 * @param value 値
+	 * @return 連結文字列
+	 */
 	private <T> String stringValue(String key, T value) {
 		StringBuilder s = new StringBuilder("\"").append(key).append("\": ");
 		if (null == value) {

--- a/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestConfigImpl.java
+++ b/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestConfigImpl.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2024 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.test.impl.test;
+
+/**
+ * テストユーティリティ設定クラス
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public class MTPTestConfigImpl implements MTPTestConfig {
+	/** 設定ファイル名 */
+	private String configFileName;
+	/** テナント名 */
+	private String tenantName;
+	/** ログインユーザーID */
+	private String userId;
+	/** ログインパスワード */
+	private String password;
+	/** テストが groovy であるか */
+	private Boolean isGroovy;
+	/** トランザクションをロールバックするか */
+	private Boolean isRollbackTransaction;
+	/** &#64;NoAuth が付与されているか */
+	private Boolean isNoAuth;
+
+	@Override
+	public String getConfigFileName() {
+		return configFileName;
+	}
+
+	/**
+	 * 設定ファイル名を設定する
+	 * @param configFileName 設定ファイル名
+	 */
+	public void setConfigFileName(String configFileName) {
+		this.configFileName = configFileName;
+	}
+
+	@Override
+	public String getTenantName() {
+		return tenantName;
+	}
+
+	/**
+	 * テナント名を設定する
+	 * @param tenantName テナント名
+	 */
+	public void setTenantName(String tenantName) {
+		this.tenantName = tenantName;
+	}
+
+	@Override
+	public String getUserId() {
+		return userId;
+	}
+
+	/**
+	 * ログインユーザーIDを設定する
+	 * @param userId ログインユーザーID
+	 */
+	public void setUserId(String userId) {
+		this.userId = userId;
+	}
+
+	@Override
+	public String getPassword() {
+		return password;
+	}
+
+	/**
+	 * ログインパスワードを設定する
+	 * @param password ログインパスワード
+	 */
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	@Override
+	public Boolean isRollbackTransaction() {
+		return isRollbackTransaction;
+	}
+
+	/**
+	 * トランザクションをロールバックするかを設定する
+	 * @param isRollbackTransaction トランザクションをロールバックするか（ロールバックする場合 true）
+	 */
+	public void setRollbackTransaction(Boolean isRollbackTransaction) {
+		this.isRollbackTransaction = isRollbackTransaction;
+	}
+
+	@Override
+	public Boolean isNoAuth() {
+		return isNoAuth;
+	}
+
+	/**
+	 * &#64;NoAuth が付与されているか
+	 * @param isNoAuth &#64;NoAuth が付与されているか（&#64;NoAuth が付与されている場合 true）
+	 */
+	public void setNoAuth(Boolean isNoAuth) {
+		this.isNoAuth = isNoAuth;
+	}
+
+	@Override
+	public Boolean isGroovy() {
+		return isGroovy;
+	}
+
+	/**
+	 * テストが groovy であるかを設定する
+	 * @param isGroovy テストが groovy であるか
+	 */
+	public void setGroovy(Boolean isGroovy) {
+		this.isGroovy = isGroovy;
+	}
+}

--- a/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestConfigImpl.java
+++ b/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestConfigImpl.java
@@ -25,6 +25,9 @@ package org.iplass.mtp.test.impl.test;
  * @author SEKIGUCHI Naoya
  */
 public class MTPTestConfigImpl implements MTPTestConfig {
+	/** コンフィグレイヤー */
+	private Object layer;
+
 	/** 設定ファイル名 */
 	private String configFileName;
 	/** テナント名 */
@@ -39,6 +42,14 @@ public class MTPTestConfigImpl implements MTPTestConfig {
 	private Boolean isRollbackTransaction;
 	/** &#64;NoAuth が付与されているか */
 	private Boolean isNoAuth;
+
+	/**
+	 * コンストラクタ
+	 * @param layer テスト設定を取得したレイヤー情報（ファイル、クラス、メソッドのいずれか）
+	 */
+	public MTPTestConfigImpl(Object layer) {
+		this.layer = layer;
+	}
 
 	@Override
 	public String getConfigFileName() {
@@ -129,5 +140,43 @@ public class MTPTestConfigImpl implements MTPTestConfig {
 	 */
 	public void setGroovy(Boolean isGroovy) {
 		this.isGroovy = isGroovy;
+	}
+
+	@Override
+	public String toString() {
+		return new StringBuilder()
+				.append("{")
+				.append("\"configValue\": {")
+				.append(stringValue("configFileName", getConfigFileName())).append(", ")
+				.append(stringValue("tenantName", getTenantName())).append(", ")
+				.append(stringValue("userId", getUserId())).append(", ")
+				.append(stringValue("isRollbackTransaction", isRollbackTransaction())).append(", ")
+				.append(stringValue("isNoAuth", isNoAuth())).append(", ")
+				.append(stringValue("isGroovy", isGroovy()))
+				.append("},")
+				.append("\"layerValue\": {")
+				.append(stringValue("layer", layer.toString())).append(", ")
+				.append(stringValue("configFileName", configFileName)).append(", ")
+				.append(stringValue("tenantName", tenantName)).append(", ")
+				.append(stringValue("userId", userId)).append(", ")
+				.append(stringValue("isRollbackTransaction", isRollbackTransaction)).append(", ")
+				.append(stringValue("isNoAuth", isNoAuth)).append(", ")
+				.append(stringValue("isGroovy", isGroovy))
+				.append("}")
+				.append("}")
+				.toString();
+	}
+
+	private <T> String stringValue(String key, T value) {
+		StringBuilder s = new StringBuilder("\"").append(key).append("\": ");
+		if (null == value) {
+			s.append(value);
+		} else if (value instanceof String) {
+			s.append("\"").append(value).append("\"");
+		} else {
+			s.append(value);
+		}
+
+		return s.toString();
 	}
 }

--- a/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestConfigReader.java
+++ b/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestConfigReader.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2024 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.test.impl.test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.iplass.mtp.test.AuthUser;
+import org.iplass.mtp.test.Commit;
+import org.iplass.mtp.test.ConfigFile;
+import org.iplass.mtp.test.NoAuthUser;
+import org.iplass.mtp.test.Rollback;
+import org.iplass.mtp.test.TenantName;
+
+import groovy.lang.GroovyObject;
+
+/**
+ * テスト用設定読み取り機能
+ *
+ * <p>
+ * 設定ファイル、クラス、メソッドからテスト用設定を読み取る。
+ * </p>
+ *
+ * <h3>プロパティファイルによる指定</h3>
+ * <p>
+ * プロパティファイルは、"/mtptest.properties"として、クラスパスからロードされます。
+ * プロパティファイルをロードするパスを変更する場合は、システムプロパティ"mtp.test.config"にて指定可能です。
+ * 次の項目をプロパティファイルにて指定可能です。
+ * </p>
+ * <table border="1">
+ * <caption>プロパティファイルの項目の説明</caption>
+ * <tr><th>項目名</th><th>説明</th></tr>
+ * <tr>
+ * <td>configFileName</td>
+ * <td>テスト実行時のiPLAssの設定ファイルのパスを指定します。<br>
+ * 設定例：<br>
+ * configFileName=/testsample/test-sample-service-config.xml</td>
+ * </tr>
+ * <tr>
+ * <td>rollbackTransaction</td>
+ * <td>テスト実行時のトランザクションをロールバックするか否かを指定します。<br>
+ * 設定例：<br>
+ * rollbackTransaction=true</td>
+ * </tr>
+ * <tr>
+ * <td>tenantName</td>
+ * <td>テスト実行時のテナント名を指定します。<br>
+ * 設定例：<br>
+ * tenantName=testDemo1</td>
+ * </tr>
+ * <tr>
+ * <td>userId</td>
+ * <td>テスト実行時のユーザーのaccountIdを指定します。<br>
+ * 設定例：<br>
+ * userId=testUser</td>
+ * </tr>
+ * <tr>
+ * <td>password</td>
+ * <td>テスト実行時のユーザーのパスワードを指定します。<br>
+ * 設定例：<br>
+ * password=testUserPass</td>
+ * </tr>
+ * </table>
+ * </p>
+ *
+ * <h3>アノテーションによる指定</h3>
+ * <p>
+ * テストクラス、メソッドにアノテーションを指定することで設定を指定可能です。
+ * 指定可能なアノテーションは以下の通りです。
+ *
+ * <ul>
+ * <li>サービスコンフィグ：{@link org.iplass.mtp.test.ConfigFile}</li>
+ * <li>テナント： {@link org.iplass.mtp.test.TenantName}</li>
+ * <li>ログイン： {@link org.iplass.mtp.test.AuthUser}, {@link org.iplass.mtp.test.NoAuthUser}</li>
+ * <li>トランザクション制御： {@link org.iplass.mtp.test.Commit}, {@link org.iplass.mtp.test.Rollback}</li>
+ * </p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public class MTPTestConfigReader {
+	/** テストシステムプロパティ名 */
+	public static final String TEST_CONFIG_FILE_NAME_SYSTEM_PROPERTY_NAME = "mtp.test.config";
+	/** 設定ファイル名 デフォルト値 */
+	public static final String DEFAULT_TEST_CONFIG_FILE_NAME = "/mtptest.properties";
+
+	/** プロパティファイルキー：設定ファイル名 */
+	public static final String PROP_CONFIG_FILE_NAME = "configFileName";
+	/** プロパティファイルキー：テナント名 */
+	public static final String PROP_TENANT_NAME = "tenantName";
+	/** プロパティファイルキー：ログインユーザーID */
+	public static final String PROP_USER_ID = "userId";
+	/** プロパティファイルキー：ログインパスワード */
+	public static final String PROP_PASSWORD = "password";
+	/** プロパティファイルキー：トランザクションをロールバックするか（true|false の設定を想定） */
+	public static final String PROP_ROLLBACK_TRANSACTION = "rollbackTransaction";
+
+	/**
+	 * プライベートコンストラクタ
+	 */
+	private MTPTestConfigReader() {
+	}
+
+	/**
+	 * テスト設定ファイル、テストクラスの設定を読み取る
+	 *
+	 * <p>
+	 * 設定ファイル、クラスに設定されている設定を読み取る。
+	 * 設定情報は合成され、MTPTestConfig の getter から取得した値が利用する値となる。
+	 * </p>
+	 *
+	 * @param testClass テスト対象クラス
+	 * @return テスト設定ファイル、テストクラスを合成した設定情報
+	 */
+	public static MTPTestConfig read(Class<?> testClass) {
+		MTPTestConfig fileConfig = createFromFile(testClass);
+		MTPTestConfig classConfig = createFromClassOrMethod(testClass, fileConfig);
+		return classConfig;
+	}
+
+	/**
+	 * メソッド設定を読み取る
+	 *
+	 * <p>
+	 * 設定情報は親設定と合成され、MTPTestConfig の getter から取得した値が利用する値となる。
+	 * </p>
+	 *
+	 * @param method 対象メソッド
+	 * @param parent メソッド設定が存在しない場合の親設定
+	 * @return 親設定とメソッド設定を合成した設定情報
+	 */
+	public static MTPTestConfig read(Method method, MTPTestConfig parent) {
+		MTPTestConfig methodConfig = createFromClassOrMethod(method, parent);
+		return methodConfig;
+	}
+
+	/**
+	 * プロパティファイルから設定を読み取る
+	 *
+	 * <p>
+	 * プロパティファイルの設定値は最終的な設定値となるため、Boolean データ型には必ず値を設定する。
+	 * </p>
+	 *
+	 * @param testClass テスト対象クラス
+	 * @return テスト設定
+	 */
+	private static MTPTestConfig createFromFile(Class<?> testClass) {
+		String propPath = System.getProperty(TEST_CONFIG_FILE_NAME_SYSTEM_PROPERTY_NAME);
+		if (propPath == null) {
+			propPath = DEFAULT_TEST_CONFIG_FILE_NAME;
+		}
+
+		try (InputStream is = MTPTestConfigReader.class.getResourceAsStream(propPath);
+				Reader r = new InputStreamReader(is, StandardCharsets.UTF_8)) {
+			Properties prop = new Properties();
+			prop.load(r);
+
+			MTPTestConfigImpl config = new MTPTestConfigImpl();
+
+			// config 初期化
+			// ログイン無し： true
+			config.setNoAuth(Boolean.TRUE);
+			// ロールバック： true
+			config.setRollbackTransaction(Boolean.TRUE);
+
+			// プロパティファイルに基づいた設定
+			setValueIfNotEmpty((String) prop.get(PROP_CONFIG_FILE_NAME), v -> config.setConfigFileName(v));
+			setValueIfNotEmpty((String) prop.get(PROP_TENANT_NAME), v -> config.setTenantName(v));
+			setValueIfNotEmpty((String) prop.get(PROP_USER_ID), v -> {
+				config.setUserId(v);
+				// ユーザーIDが指定されていたら NoAuth は false に変更
+				config.setNoAuth(Boolean.FALSE);
+			});
+			setValueIfNotEmpty((String) prop.get(PROP_PASSWORD), v -> config.setPassword(v));
+			setValueIfNotEmpty((String) prop.get(PROP_ROLLBACK_TRANSACTION), v -> config.setRollbackTransaction(Boolean.valueOf(v)));
+
+			// テストクラスが groovy であるか判別
+			config.setGroovy(isTestClassGroovy(testClass));
+
+			return config;
+
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * クラスもしくはメソッドから設定情報を読み取る。
+	 * @param <T> Class もしくは Methodクラス
+	 * @param classOrMethod Class もしくは Method インスタンス
+	 * @param parent 親設定
+	 * @return テスト設定
+	 */
+	private static <T extends AnnotatedElement> MTPTestConfig createFromClassOrMethod(T classOrMethod, MTPTestConfig parent) {
+		MTPTestConfigImpl config = null == parent ? new MTPTestConfigImpl() : new MTPTestConfigComposit(parent);
+
+		String configFileName = getAnnotationValue(classOrMethod, ConfigFile.class, a -> a.value());
+		String tenantName = getAnnotationValue(classOrMethod, TenantName.class, a -> a.value());
+		String userId = getAnnotationValue(classOrMethod, AuthUser.class, a -> a.userId());
+		String password = getAnnotationValue(classOrMethod, AuthUser.class, a -> a.password());
+		String isRollback = getAnnotationValue(classOrMethod, Commit.class, a -> Boolean.FALSE.toString());
+		isRollback = getAnnotationValue(classOrMethod, Rollback.class, a -> Boolean.TRUE.toString(), isRollback);
+		Boolean isNoAuth = getAnnotationValue(classOrMethod, NoAuthUser.class, a -> Boolean.TRUE);
+
+		setValueIfNotEmpty(configFileName, v -> config.setConfigFileName(v));
+		setValueIfNotEmpty(tenantName, v -> config.setTenantName(v));
+		setValueIfNotEmpty(userId, v -> {
+			config.setUserId(v);
+			// ユーザーIDが指定されていたら NoAuth は false に変更
+			config.setNoAuth(Boolean.FALSE);
+		});
+		setValueIfNotEmpty(password, v -> config.setPassword(v));
+		setValueIfNotEmpty(isRollback, v -> config.setRollbackTransaction(Boolean.valueOf(v)));
+		if (null != isNoAuth) {
+			// 仮にユーザーIDが指定されていたとしても、NoAuth が設定されていれば未ログイン状態を優先する
+			config.setNoAuth(isNoAuth);
+		}
+
+		// NOTE groovy 判定はファイルで設定されているため何もしない
+
+		return config;
+	}
+
+	/**
+	 * 値が null もしくは空文字以外であれば設定ファンクションを実行する
+	 * @param value 値
+	 * @param valueSetFn 設定ファンクション
+	 */
+	private static void setValueIfNotEmpty(String value, Consumer<String> valueSetFn) {
+		if (null != value && 0 < value.length()) {
+			valueSetFn.accept(value);
+		}
+	}
+
+	/**
+	 * アノテーションの値を取得する
+	 * @param <A> アノテーション型
+	 * @param <T> アノテーション値データ型
+	 * @param elem Class もしくは Method
+	 * @param annotation 取得アノテーション
+	 * @param valueGetFn アノテーション値取得メソッド
+	 * @return アノテーション値
+	 */
+	private static <A extends Annotation, T> T getAnnotationValue(AnnotatedElement elem, Class<A> annotation, Function<A, T> valueGetFn) {
+		return getAnnotationValue(elem, annotation, valueGetFn, null);
+	}
+
+	/**
+	 * アノテーションの値を取得する
+	 * @param <A> アノテーション型
+	 * @param <T> アノテーション値データ型
+	 * @param elem Class もしくは Method
+	 * @param annotation 取得アノテーション
+	 * @param valueGetFn アノテーション値取得メソッド
+	 * @param defaultValue アノテーション指定がない場合のデフォルト値
+	 * @return アノテーション値
+	 */
+	private static <A extends Annotation, T> T getAnnotationValue(AnnotatedElement elem, Class<A> annotation, Function<A, T> valueGetFn, T defaultValue) {
+		A anno = elem.getAnnotation(annotation);
+		if (null != anno) {
+			return valueGetFn.apply(anno);
+		}
+
+		return defaultValue;
+	}
+
+	/**
+	 * テストクラスが groovy テストクラスであるか判定する
+	 * @param testClass 対象クラス
+	 * @return groovy テストクラスの場合 true
+	 */
+	private static Boolean isTestClassGroovy(Class<?> testClass) {
+		return Boolean.valueOf(GroovyObject.class.isAssignableFrom(testClass));
+	}
+}

--- a/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestInvoker.java
+++ b/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestInvoker.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.test.impl.test;
+
+/**
+ * テスト実行インターフェース
+ *
+ * <p>
+ * テスト実行時の前後処理拡張を行う際の、テスト実行処理を定義するインターフェース。
+ * </p>
+ *
+ * @param <T> 返却データ型
+ * @author SEKIGUCHI Naoya
+ */
+public interface MTPTestInvoker<T> {
+	/**
+	 * テストを実行する
+	 * @param config テスト設定
+	 * @return テスト実行後返却値
+	 * @throws Throwable 例外
+	 */
+	T invoke(MTPTestConfig config) throws Throwable;
+}

--- a/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestInvokerDecorator.java
+++ b/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/MTPTestInvokerDecorator.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) 2024 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.test.impl.test;
+
+import org.iplass.mtp.ManagerLocator;
+import org.iplass.mtp.auth.login.IdPasswordCredential;
+import org.iplass.mtp.impl.auth.AuthContextHolder;
+import org.iplass.mtp.impl.auth.AuthService;
+import org.iplass.mtp.impl.core.ExecuteContext;
+import org.iplass.mtp.impl.core.TenantContext;
+import org.iplass.mtp.impl.core.TenantContextService;
+import org.iplass.mtp.impl.core.config.BootstrapProps;
+import org.iplass.mtp.impl.rdb.connection.ResourceHolder;
+import org.iplass.mtp.impl.script.GroovyScriptEngine;
+import org.iplass.mtp.impl.transaction.TransactionService;
+import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.test.TestManagerLocator;
+
+/**
+ * テスト実施において前後処理拡張
+ *
+ * <p>
+ * テスト設定に基づいて前後処理の拡張を行う。
+ * </p>
+ *
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public class MTPTestInvokerDecorator {
+	/**
+	 * プライベートコンストラクタ
+	 */
+	private MTPTestInvokerDecorator() {
+	}
+
+	/**
+	 * テストの前後処理拡張する
+	 * @param <T> 返却データ型
+	 * @param testProcess テスト処理
+	 * @return 前後処理拡張したテスト処理
+	 */
+	public static <T> MTPTestInvoker<T> decorate(MTPTestInvoker<T> testProcess) {
+		// サービスコンフィグ初期化
+		return new ServiceConfigDecorator<T>(
+				// 初期化処理
+				new InitializeDecorator<T>(
+						// トランザクション制御
+						new TransactionDecorator<T>(
+								// 認証
+								new AuthenticationDecorator<T>(
+										// モックマネージャーリセット
+										new MockManagerDecorator<T>(testProcess)))));
+	}
+
+	/**
+	 * 機能拡張マーキングインターフェース
+	 * @param <T> 返却データ型
+	 */
+	private static interface Decorator<T> extends MTPTestInvoker<T> {
+	}
+
+	/**
+	 * サービスコンフィグ初期化
+	 *
+	 * <p>
+	 * サービスコンフィグが設定されていた場合初期化を行う
+	 * </p>
+	 */
+	private static class ServiceConfigDecorator<T> implements Decorator<T> {
+		/** テスト対象 */
+		private MTPTestInvoker<T> test;
+
+		/**
+		 * コンストラクタ
+		 * @param test テスト対象
+		 */
+		public ServiceConfigDecorator(MTPTestInvoker<T> test) {
+			this.test = test;
+		}
+
+		@Override
+		public T invoke(MTPTestConfig config) throws Throwable {
+			if (config.getConfigFileName() != null) {
+				if (BootstrapProps.getInstance().replaceProperty(BootstrapProps.CONFIG_FILE_NAME, config.getConfigFileName())) {
+					ServiceRegistry.getRegistry().reInit();
+				}
+			}
+
+			return test.invoke(config);
+		}
+	}
+
+	/**
+	 * 初期化処理
+	 *
+	 * <p>
+	 * ResourceHolder の初期化および破棄、ExecuteContext の設定を責務とする。
+	 * </p>
+	 */
+	private static class InitializeDecorator<T> implements Decorator<T> {
+		/** テスト対象 */
+		private MTPTestInvoker<T> test;
+
+		/**
+		 * コンストラクタ
+		 * @param test テスト対象
+		 */
+		public InitializeDecorator(MTPTestInvoker<T> test) {
+			this.test = test;
+		}
+
+		@Override
+		public T invoke(MTPTestConfig config) throws Throwable {
+			boolean isInit = false;
+			try {
+				isInit = ResourceHolder.init();
+
+				//ここでセットしておかないと、TransactionManagerが初期化されてしまう
+				TransactionService ts = ServiceRegistry.getRegistry().getService(TransactionService.class);
+				if (!(ts instanceof TestTransactionService)) {
+					ServiceRegistry.getRegistry().setService(TransactionService.class.getName(), new TestTransactionService());
+				}
+
+				TenantContext tc = ServiceRegistry.getRegistry().getService(TenantContextService.class).getTenantContext("/" + config.getTenantName());
+				if (tc == null) {
+					throw new IllegalArgumentException("tenantName:" + config.getTenantName() + " not found");
+				}
+				try {
+					return ExecuteContext.executeAs(tc, () -> {
+						try {
+							ClassLoader cl = Thread.currentThread().getContextClassLoader();
+							boolean replaceCl = config.isGroovy();
+							try {
+								if (replaceCl) {
+									Thread.currentThread().setContextClassLoader(((GroovyScriptEngine) tc.getScriptEngine()).getSharedClassLoader());
+								}
+								return test.invoke(config);
+
+							} finally {
+								if (replaceCl) {
+									Thread.currentThread().setContextClassLoader(cl);
+								}
+							}
+						} catch (Throwable e) {
+							throw new WrapException(e);
+						}
+					});
+				} catch (WrapException e) {
+					throw e.getCause();
+				}
+			} finally {
+				if (isInit) {
+					ResourceHolder.fin();
+				}
+			}
+		}
+	}
+
+	/**
+	 * トランザクション制御
+	 *
+	 * <p>
+	 * 設定に基づいて、TransactionService を設定する
+	 * </p>
+	 */
+	private static class TransactionDecorator<T> implements Decorator<T> {
+		/** テスト対象 */
+		private MTPTestInvoker<T> test;
+
+		/**
+		 * コンストラクタ
+		 * @param test テスト対象
+		 */
+		public TransactionDecorator(MTPTestInvoker<T> test) {
+			this.test = test;
+		}
+
+		@Override
+		public T invoke(MTPTestConfig config) throws Throwable {
+			TransactionService ts = ServiceRegistry.getRegistry().getService(TransactionService.class);
+			if (!(ts instanceof TestTransactionService)) {
+				ServiceRegistry.getRegistry().setService(TransactionService.class.getName(), new TestTransactionService());
+			}
+			TestTransactionService.rollback = config.isRollbackTransaction();;
+			return test.invoke(config);
+		}
+	}
+
+	/**
+	 * 認証
+	 *
+	 * <p>
+	 * ログイン情報が設定されていた場合、ログインする。
+	 * 認証無し設定がされていた場合は、ログアウトする。
+	 * </p>
+	 */
+	private static class AuthenticationDecorator<T> implements Decorator<T> {
+		/** テスト対象 */
+		private MTPTestInvoker<T> test;
+
+		/**
+		 * コンストラクタ
+		 * @param test テスト対象
+		 */
+		public AuthenticationDecorator(MTPTestInvoker<T> test) {
+			this.test = test;
+		}
+
+		@Override
+		public T invoke(MTPTestConfig config) throws Throwable {
+			AuthService as = ServiceRegistry.getRegistry().getService(AuthService.class);
+			if (Boolean.FALSE == config.isNoAuth()) {
+				as.login(new IdPasswordCredential(config.getUserId(), config.getPassword()));
+			} else {
+				if (as.isAuthenticate()) {
+					as.logout();
+				}
+			}
+			try {
+				return as.doSecuredAction(AuthContextHolder.getAuthContext(), () -> {
+					try {
+						return test.invoke(config);
+					} catch (Throwable e) {
+						throw new WrapException(e);
+					}
+				});
+			} catch (WrapException e) {
+				throw e.getCause();
+			}
+		}
+	}
+
+	/**
+	 * モックマネージャーリセット
+	 */
+	private static class MockManagerDecorator<T> implements Decorator<T> {
+		static {
+			System.setProperty(ManagerLocator.MANAGER_LOCATOR_SYSTEM_PROPERTY_NAME, TestManagerLocator.class.getName());
+		}
+		/** テスト対象 */
+		private MTPTestInvoker<T> test;
+
+		/**
+		 * コンストラクタ
+		 * @param test テスト対象
+		 */
+		public MockManagerDecorator(MTPTestInvoker<T> test) {
+			this.test = test;
+		}
+
+		@Override
+		public T invoke(MTPTestConfig config) throws Throwable {
+			try {
+				return test.invoke(config);
+			} finally {
+				((TestManagerLocator) ManagerLocator.getInstance()).reset();
+			}
+		}
+	}
+
+	/**
+	 * ラムダ式の例外を外部でハンドリングさせるためのラッパー例外クラス
+	 */
+	private static class WrapException extends RuntimeException {
+		/** serialVersionUID */
+		private static final long serialVersionUID = -4535302115540574513L;
+
+		/**
+		 * コンストラクタ
+		 * @param cause 原因例外
+		 */
+		public WrapException(Throwable cause) {
+			super(cause);
+		}
+	}
+
+}

--- a/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/TestTransactionService.java
+++ b/iplass-test/src/main/java/org/iplass/mtp/test/impl/test/TestTransactionService.java
@@ -1,23 +1,23 @@
 /*
  * Copyright (C) 2016 DENTSU SOKEN INC. All Rights Reserved.
- * 
+ *
  * Unless you have purchased a commercial license,
  * the following license terms apply:
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
-package org.iplass.mtp.test;
+package org.iplass.mtp.test.impl.test;
 
 import org.iplass.mtp.impl.transaction.LocalTransaction;
 import org.iplass.mtp.impl.transaction.LocalTransactionManager;
@@ -28,19 +28,19 @@ import org.iplass.mtp.transaction.TransactionManager;
 
 /**
  * テスト時に利用されるTransactionServiceの実装です。
- * 
+ *
  * @author K.Higuchi
  *
  */
-class TestTransactionService extends TransactionService {
-	
-	static volatile boolean rollback;
+public class TestTransactionService extends TransactionService {
+
+	public static volatile boolean rollback;
 	private TestTransactionManager tm;
-	
-	TestTransactionService() {
+
+	public TestTransactionService() {
 		tm = new TestTransactionManager();
 	}
-	
+
 	private class TestTransactionManager extends LocalTransactionManager {
 
 		@Override
@@ -51,7 +51,7 @@ class TestTransactionService extends TransactionService {
 			}
 			return t;
 		}
-		
+
 	}
 
 	@Override

--- a/sharedlibs.gradle
+++ b/sharedlibs.gradle
@@ -171,8 +171,7 @@ ext {
 		
 		'com.ibm.icu:icu4j': '69.1',
 		
-		
-		'junit:junit': '4.13.1',
+		'org.junit:junit-bom': '5.10.2',
 		
 		//webjars(admin)
 		'org.webjars.npm:ace-builds': '1.12.3',


### PR DESCRIPTION
- JUnit5 バージョンアップ（ 4.13.1 -> 5.10.2 ）。jupiter, vintage を追加
- JUnit4 向けテストサポート機能を JUnit5 向けにマイグレーション
- demo 実装・設定の見直し