### PR TITLE
commons-text、バージョンアップ（4.0）

### DIFF
--- a/iplass-core/src/main/java/org/iplass/mtp/impl/properties/extend/BinaryType.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/properties/extend/BinaryType.java
@@ -22,7 +22,7 @@ package org.iplass.mtp.impl.properties.extend;
 
 import java.util.List;
 
-import org.apache.commons.text.StrTokenizer;
+import org.apache.commons.text.StringTokenizer;
 import org.apache.commons.text.StringEscapeUtils;
 import org.iplass.mtp.entity.BinaryReference;
 import org.iplass.mtp.entity.Entity;
@@ -250,7 +250,7 @@ public class BinaryType extends ComplexWrapperType {
 				stringExpression = stringExpression.substring(0, tIndex);
 			}
 			
-			StrTokenizer st = StrTokenizer.getCSVInstance(stringExpression);
+			StringTokenizer st = StringTokenizer.getCSVInstance(stringExpression);
 			List<String> line = null;
 			line = st.getTokenList();
 			if (line != null) {

--- a/iplass-gem/src/main/java/org/iplass/gem/command/calendar/GetCalendarCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/calendar/GetCalendarCommand.java
@@ -33,10 +33,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.commons.text.StrTokenizer;
+import org.apache.commons.text.StringTokenizer;
 import org.iplass.gem.command.Constants;
 import org.iplass.mtp.ManagerLocator;
-import org.iplass.mtp.auth.NoPermissionException;
 import org.iplass.mtp.command.Command;
 import org.iplass.mtp.command.RequestContext;
 import org.iplass.mtp.command.annotation.CommandClass;
@@ -638,7 +637,7 @@ public final class GetCalendarCommand implements Command {
 				filter =new Paren(new Not(new Like(property, (String) value, Like.MatchPattern.PARTIAL)));
 				break;
 			case IN:
-				StrTokenizer st = StrTokenizer.getCSVInstance((String) value);
+				StringTokenizer st = StringTokenizer.getCSVInstance((String) value);
 				String[] values = st.getTokenArray();
 				Object[] ret = new Object[values.length];
 				for (int i = 0; i < values.length; i++) {

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/BooleanPropertySearchCondition.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/BooleanPropertySearchCondition.java
@@ -20,7 +20,7 @@
 
 package org.iplass.gem.command.generic.search.condition;
 
-import org.apache.commons.text.StrTokenizer;
+import org.apache.commons.text.StringTokenizer;
 import org.iplass.gem.command.Constants;
 import org.iplass.gem.command.GemResourceBundleUtil;
 import org.iplass.gem.command.generic.search.SearchConditionDetail;
@@ -54,7 +54,7 @@ public class BooleanPropertySearchCondition extends PropertySearchCondition {
 				|| Constants.NULL.equals(detail.getPredicate())) {
 			return null;
 		} else if (Constants.IN.equals(detail.getPredicate())) {
-			StrTokenizer st = StrTokenizer.getCSVInstance(detail.getValue());
+			StringTokenizer st = StringTokenizer.getCSVInstance(detail.getValue());
 			String[] values = st.getTokenArray();
 			Boolean[] ret = new Boolean[values.length];
 			for (int i = 0; i < values.length; i++) {

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/DatePropertySearchCondition.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/DatePropertySearchCondition.java
@@ -24,7 +24,7 @@ import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.text.StrTokenizer;
+import org.apache.commons.text.StringTokenizer;
 import org.iplass.gem.command.CommandUtil;
 import org.iplass.gem.command.Constants;
 import org.iplass.gem.command.generic.search.SearchConditionDetail;
@@ -84,7 +84,7 @@ public class DatePropertySearchCondition extends PropertySearchCondition {
 				|| Constants.NULL.equals(detail.getPredicate())) {
 			return null;
 		} else if (Constants.IN.equals(detail.getPredicate())) {
-			StrTokenizer st = StrTokenizer.getCSVInstance(detail.getValue());
+			StringTokenizer st = StringTokenizer.getCSVInstance(detail.getValue());
 			String[] values = st.getTokenArray();
 			Date[] ret = new Date[values.length];
 			for (int i = 0; i < values.length; i++) {

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/PropertySearchCondition.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/PropertySearchCondition.java
@@ -23,7 +23,7 @@ package org.iplass.gem.command.generic.search.condition;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.text.StrTokenizer;
+import org.apache.commons.text.StringTokenizer;
 import org.iplass.gem.command.Constants;
 import org.iplass.gem.command.generic.search.SearchConditionDetail;
 import org.iplass.mtp.entity.definition.PropertyDefinition;
@@ -163,7 +163,7 @@ public abstract class PropertySearchCondition {
 				|| Constants.NULL.equals(detail.getPredicate())) {
 			return null;
 		} else if (Constants.IN.equals(detail.getPredicate())) {
-			StrTokenizer st = StrTokenizer.getCSVInstance(detail.getValue());
+			StringTokenizer st = StringTokenizer.getCSVInstance(detail.getValue());
 			String[] values = st.getTokenArray();
 			String[] ret = new String[values.length];
 			for (int i = 0; i < values.length; i++) {

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/SelectPropertySearchCondition.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/SelectPropertySearchCondition.java
@@ -23,7 +23,7 @@ package org.iplass.gem.command.generic.search.condition;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.text.StrTokenizer;
+import org.apache.commons.text.StringTokenizer;
 import org.iplass.gem.command.Constants;
 import org.iplass.gem.command.generic.search.SearchConditionDetail;
 import org.iplass.mtp.entity.SelectValue;
@@ -89,7 +89,7 @@ public class SelectPropertySearchCondition extends PropertySearchCondition {
 				|| Constants.NULL.equals(detail.getPredicate())) {
 			return null;
 		} else if (Constants.IN.equals(detail.getPredicate())) {
-			StrTokenizer st = StrTokenizer.getCSVInstance(detail.getValue());
+			StringTokenizer st = StringTokenizer.getCSVInstance(detail.getValue());
 			String[] values = st.getTokenArray();
 			String[] ret = new String[values.length];
 			for (int i = 0; i < values.length; i++) {

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/TimePropertySearchCondition.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/TimePropertySearchCondition.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
-import org.apache.commons.text.StrTokenizer;
+import org.apache.commons.text.StringTokenizer;
 import org.iplass.gem.command.CommandUtil;
 import org.iplass.gem.command.Constants;
 import org.iplass.gem.command.generic.search.SearchConditionDetail;
@@ -110,7 +110,7 @@ public class TimePropertySearchCondition extends PropertySearchCondition {
 				|| Constants.NULL.equals(detail.getPredicate())) {
 			return null;
 		} else if (Constants.IN.equals(detail.getPredicate())) {
-			StrTokenizer st = StrTokenizer.getCSVInstance(detail.getValue());
+			StringTokenizer st = StringTokenizer.getCSVInstance(detail.getValue());
 			String[] values = st.getTokenArray();
 			Time[] ret = new Time[values.length];
 			for (int i = 0; i < values.length; i++) {

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/TimestampPropertySearchCondition.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/TimestampPropertySearchCondition.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
-import org.apache.commons.text.StrTokenizer;
+import org.apache.commons.text.StringTokenizer;
 import org.iplass.gem.command.Constants;
 import org.iplass.gem.command.generic.search.SearchConditionDetail;
 import org.iplass.mtp.entity.definition.PropertyDefinition;
@@ -116,7 +116,7 @@ public class TimestampPropertySearchCondition extends PropertySearchCondition {
 				|| Constants.NULL.equals(detail.getPredicate())) {
 			return null;
 		} else if (Constants.IN.equals(detail.getPredicate())) {
-			StrTokenizer st = StrTokenizer.getCSVInstance(detail.getValue());
+			StringTokenizer st = StringTokenizer.getCSVInstance(detail.getValue());
 			String[] values = st.getTokenArray();
 			Timestamp[] ret = new Timestamp[values.length];
 			for (int i = 0; i < values.length; i++) {

--- a/sharedlibs.gradle
+++ b/sharedlibs.gradle
@@ -94,7 +94,7 @@ ext {
 		//3rd party libs
 		//apache commons
 		'org.apache.commons:commons-lang3': '3.14.0',
-		'org.apache.commons:commons-text': '1.2',
+		'org.apache.commons:commons-text': '1.12.0',
 		'org.apache.commons:commons-collections4': '4.4',
 		'org.apache.commons:commons-pool2': '2.11.1',
 		'commons-io:commons-io': '2.15.1',


### PR DESCRIPTION
## 対応内容
- commons-text 1.2 -> 1.12.0
- 非推奨クラスの変更 ( org.apache.commons.text.StrTokenizer -> org.apache.commons.text.StringTokenizer )

## 動作確認・スクリーンショット（任意）
- 画面動作確認
- カレンダー、いずれかと等しい条件指定
- 汎用検索、いずれかと等しい詳細条件指定（文字列）
- 汎用エンティティ、バイナリデータ保存、表示

## レビュー観点・補足情報（任意）
特になし
