### PR TITLE
commons-io、バージョンアップ（4.0）

### DIFF
--- a/iplass-admin/src/main/java/org/iplass/adminconsole/server/metadata/rpc/message/MessageItemCsvReader.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/server/metadata/rpc/message/MessageItemCsvReader.java
@@ -73,7 +73,11 @@ public class MessageItemCsvReader implements Iterable<MessageItem>, Closeable {
 		//BOM対応
 		InputStream is = inputStream;
 		if (!(inputStream instanceof BOMInputStream)) {
-			is = new BOMInputStream(inputStream, false);
+			try {
+				is = BOMInputStream.builder().setInputStream(inputStream).setInclude(false).get();
+			} catch (IOException e) {
+				throw new EntityDataPortingRuntimeException(e);
+			}
 		}
 
 		//CsvMapReaderの生成

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/server/tools/rpc/langexplorer/LangCsvReader.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/server/tools/rpc/langexplorer/LangCsvReader.java
@@ -61,7 +61,11 @@ public class LangCsvReader implements Iterable<Map<String, Object>>, Closeable {
 		//BOM対応
 		InputStream is = inputStream;
 		if (!(inputStream instanceof BOMInputStream)) {
-			is = new BOMInputStream(inputStream, false);
+			try {
+				is = BOMInputStream.builder().setInputStream(inputStream).setInclude(false).get();
+			} catch (IOException e) {
+				throw new EntityDataPortingRuntimeException(e);
+			}
 		}
 
 		//CsvMapReaderの生成

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EQLExecutor.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EQLExecutor.java
@@ -32,8 +32,8 @@ import org.iplass.mtp.impl.core.TenantContext;
 import org.iplass.mtp.impl.core.TenantContextService;
 import org.iplass.mtp.impl.tools.entity.EntityToolService;
 import org.iplass.mtp.spi.ServiceRegistry;
-import org.iplass.mtp.tools.batch.MtpCuiBase;
 import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
+import org.iplass.mtp.tools.batch.MtpCuiBase;
 import org.iplass.mtp.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -205,7 +205,7 @@ public class EQLExecutor extends MtpCuiBase {
 			}
 			break;
 		case SHOW_SEARCH_RESULT:
-			OutputStream out = new CloseShieldOutputStream(System.out);
+			OutputStream out = CloseShieldOutputStream.wrap(System.out);
 			if (StringUtil.isBlank(userId)) {
 				count = entityToolService.executeEQLWithAuth(out, System.getProperty("file.encoding"), eql, isSearchAllVersion);
 			} else {

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/RangeHeader.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/RangeHeader.java
@@ -23,15 +23,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import jakarta.servlet.http.HttpServletResponse;
-
 import org.apache.commons.io.input.BoundedInputStream;
+
+import jakarta.servlet.http.HttpServletResponse;
 
 public class RangeHeader {
 	static final long UNSPEC = -1;
 	static final long NAN = -2;
-	
-	
+
 	public static RangeHeader getRangeHeader(WebRequestStack req, long contentSize) {
 		String rangeValue = req.getRequest().getHeader("Range");
 		if (rangeValue != null) {
@@ -40,7 +39,7 @@ public class RangeHeader {
 			return null;
 		}
 	}
-	
+
 	public static long writeResponseHeader(WebRequestStack req, RangeHeader range, long contentSize) {
 		req.getResponse().setHeader("Accept-Ranges", "bytes");
 		if (range != null) {
@@ -56,11 +55,11 @@ public class RangeHeader {
 		}
 		return contentSize;
 	}
-	
+
 	public static void writeResponseBody(InputStream is, OutputStream os, RangeHeader range) throws IOException {
 		//Range指定の場合は、部分的な出力に
 		if (range != null && range.valid) {
-			is = new BoundedInputStream(is, range.end + 1);
+			is = BoundedInputStream.builder().setInputStream(is).setMaxCount(range.end + 1).get();;
 			is.skip(range.start);
 		}
 
@@ -74,13 +73,13 @@ public class RangeHeader {
 		}
 		os.flush();
 	}
-	
-	
+
+
 	public long start;
 	public long end;
 	public long totalSize;
 	public boolean valid;
-	
+
 	public RangeHeader(String value, long totalSize) {
 		this.totalSize = totalSize;
 		if (value != null) {
@@ -93,7 +92,7 @@ public class RangeHeader {
 				}
 			}
 		}
-		
+
 		if (start == NAN || end == NAN) {
 			valid = false;
 		} else {
@@ -110,7 +109,7 @@ public class RangeHeader {
 			}
 		}
 	}
-	
+
 	private long toLong(String val) {
 		if (val == null || val.length() == 0) {
 			return UNSPEC;

--- a/sharedlibs.gradle
+++ b/sharedlibs.gradle
@@ -97,7 +97,7 @@ ext {
 		'org.apache.commons:commons-text': '1.12.0',
 		'org.apache.commons:commons-collections4': '4.4',
 		'org.apache.commons:commons-pool2': '2.12.0',
-		'commons-io:commons-io': '2.15.1',
+		'commons-io:commons-io': '2.16.1',
 		'commons-beanutils:commons-beanutils': '1.9.4',
 		'commons-codec:commons-codec': '1.15',
 		


### PR DESCRIPTION
## 対応内容
- commons-io 2.15.1 -> 2.16.1
- BOMInputStream コンストラクタから builder に変更
- CloseShieldOutputStream コンストラクタから wrap に変更
- BoundedInputStream コンストラクタから builder に変更
- 
## 動作確認・スクリーンショット（任意）
- 汎用エンティティ動作確認（登録、変更、表示、削除）
- AdminConsole Lang CSV アップロード（BOM 有無）
- AdminConsoel Message CSV アップロード（BOM 有無）
- Batch EQLExecutor 実行確認（結果表示）
- RangeHeader 確認（StaticResource のGETで確認）

## レビュー観点・補足情報（任意）
特になし