### PR TITLE
lucene、バージョンアップ（4.0）

### DIFF
--- a/iplass-core/libs.gradle
+++ b/iplass-core/libs.gradle
@@ -19,8 +19,6 @@ dependencies {
 	implementation sharedLib('org.apache.lucene:lucene-queryparser')
 	implementation sharedLib('org.apache.lucene:lucene-analysis-kuromoji')
 	runtimeOnly sharedLib('org.apache.lucene:lucene-backward-codecs')
-	// migration 9.1: Lucene Core now depends on java.logging (JUL) module (LUCENE-10342)
-	runtimeOnly sharedLib('org.slf4j:jul-to-slf4j')
 
 	//tika(依存関係多いので明示的に指定する)
 	implementation(sharedLib('org.apache.tika:tika-core'))

--- a/iplass-core/libs.gradle
+++ b/iplass-core/libs.gradle
@@ -16,20 +16,11 @@ dependencies {
 	implementation sharedLib('org.apache.httpcomponents:httpclient')
 	
 	//lucene
-	implementation(sharedLib('org.apache.lucene:lucene-queryparser')) {
-		//TODO 必要？？
-		exclude(group: 'org.apache.lucene', module: 'lucene-queries')
-		exclude(group: 'org.apache.lucene', module: 'lucene-sandbox')
-	}
-	implementation sharedLib('org.apache.lucene:lucene-analyzers-kuromoji')
-	runtimeOnly sharedLib('org.apache.lucene:lucene-analyzers-smartcn')
+	implementation sharedLib('org.apache.lucene:lucene-queryparser')
+	implementation sharedLib('org.apache.lucene:lucene-analysis-kuromoji')
 	runtimeOnly sharedLib('org.apache.lucene:lucene-backward-codecs')
-	runtimeOnly(sharedLib('org.apache.lucene:lucene-highlighter')) {
-		//TODO 必要？？
-		exclude(group: 'org.apache.lucene', module: 'lucene-join')
-		exclude(group: 'org.apache.lucene', module: 'lucene-queries')
-		exclude(group: 'org.apache.lucene', module: 'lucene-memory')
-	}
+	// migration 9.1: Lucene Core now depends on java.logging (JUL) module (LUCENE-10342)
+	runtimeOnly sharedLib('org.slf4j:jul-to-slf4j')
 
 	//tika(依存関係多いので明示的に指定する)
 	implementation(sharedLib('org.apache.tika:tika-core'))

--- a/sharedlibs.gradle
+++ b/sharedlibs.gradle
@@ -105,11 +105,9 @@ ext {
 		'org.apache.httpcomponents:httpmime': '4.5.13',
 		
 		//lucene
-		'org.apache.lucene:lucene-queryparser': '8.11.2',
-		'org.apache.lucene:lucene-analyzers-kuromoji': '8.11.2',
-		'org.apache.lucene:lucene-analyzers-smartcn': '8.11.2',
-		'org.apache.lucene:lucene-backward-codecs': '8.11.2',
-		'org.apache.lucene:lucene-highlighter': '8.11.2',
+		'org.apache.lucene:lucene-queryparser': '9.11.1',
+		'org.apache.lucene:lucene-analysis-kuromoji': '9.11.1',
+		'org.apache.lucene:lucene-backward-codecs': '9.11.1',
 		
 		//tika(依存関係多いので明示的に指定する)
 		'org.apache.tika:tika-core': '1.28.5',
@@ -139,6 +137,7 @@ ext {
 		
 		'org.slf4j:slf4j-api': '2.0.13',
 		'org.slf4j:jcl-over-slf4j': '2.0.13',
+		'org.slf4j:jul-to-slf4j': '2.0.13',
 		'org.slf4j:log4j-over-slf4j': '2.0.13',
 		'org.apache.logging.log4j:log4j-to-slf4j': '2.23.1',
 		'ch.qos.logback:logback-classic': '1.5.6',

--- a/sharedlibs.gradle
+++ b/sharedlibs.gradle
@@ -137,7 +137,6 @@ ext {
 		
 		'org.slf4j:slf4j-api': '2.0.13',
 		'org.slf4j:jcl-over-slf4j': '2.0.13',
-		'org.slf4j:jul-to-slf4j': '2.0.13',
 		'org.slf4j:log4j-over-slf4j': '2.0.13',
 		'org.apache.logging.log4j:log4j-to-slf4j': '2.23.1',
 		'ch.qos.logback:logback-classic': '1.5.6',


### PR DESCRIPTION
## 対応内容
- lucene-queryparser 8.11.2 -> 9.11.1
- lucene-queryparser の exclude 指定を除去
- lucene-analyzers-kuromoji 8.11.2 -> lucene-analysis-kuromoji 9.11.1
- lucene-backward-codecs 8.11.2 -> 9.11.1
- lucene-highlighter を削除
- lucene-analyzers-smartcn (lucene-analysis-smartcn) を削除
- MMapDirectory.DEFAULT_MAX_CHUNK_SIZE のデータ型 long に変更に伴うコード修正
- deprecated メソッド StopwordAnalyzerBase.loadStopwordSet ⇒ WordlistLoader.getWordSet へ変更
- deprecated メソッド IndexSearcher.doc ⇒ IndexSearcher.storedFields(), StoredFields.document へ変更

## 動作確認・スクリーンショット（任意）
- AdminConsoleよりクロール実施（index バージョン 8, 9 両方）
- インデックスより検索（index バージョン 8, 9 両方）
- バッチ経由のクロール
- 修正箇所確認（stopwords, stoptags の読み込み）

## レビュー観点・補足情報（任意）
特になし