### PR TITLE
JakartaEE10/Tomcat10.1、Java 21対応 - webapi 実行エラー対応

### DIFF
--- a/sharedlibs.gradle
+++ b/sharedlibs.gradle
@@ -297,6 +297,7 @@ dependencies {
 	}
 	jakartaImplRest platform(sharedLib('org.glassfish.jersey:jersey-bom'))
 	jakartaImplRest 'org.glassfish.jersey.containers:jersey-container-servlet'
+	jakartaImplRest 'org.glassfish.jersey.media:jersey-media-jaxb'
 	jakartaImplRest 'org.glassfish.jersey.media:jersey-media-json-jackson'
 	jakartaImplRest 'org.glassfish.jersey.media:jersey-media-multipart'
 	jakartaImplRest 'org.glassfish.jersey.inject:jersey-hk2'


### PR DESCRIPTION
## 対応内容
- jakarta ee 10 対応時の jersey バージョンアップタイミングで不足していた 'org.glassfish.jersey.media:jersey-media-jaxb' を追加

## 動作確認・スクリーンショット（任意）
- WebAPI の実行確認

## レビュー観点・補足情報（任意）
- 特になし