### PR TITLE
POI、バージョンアップ（4.0）

### DIFF
--- a/iplass-admin/src/main/java/org/iplass/adminconsole/server/base/io/upload/AdminUploadAction.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/server/base/io/upload/AdminUploadAction.java
@@ -31,13 +31,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import jakarta.servlet.ServletConfig;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
-
-import org.apache.poi.util.IOUtils;
+import org.apache.commons.io.IOUtils;
 import org.iplass.adminconsole.server.base.i18n.AdminResourceBundleUtil;
 import org.iplass.adminconsole.server.base.service.AdminConsoleService;
 import org.iplass.adminconsole.shared.base.io.AdminUploadConstant;
@@ -45,6 +39,12 @@ import org.iplass.mtp.impl.web.WebFrontendService;
 import org.iplass.mtp.spi.ServiceRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 
 /**

--- a/iplass-gem/src/main/java/org/iplass/gem/GemConfigService.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/GemConfigService.java
@@ -29,11 +29,11 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.apache.poi.util.StringUtil;
 import org.iplass.gem.AutoGenerateSetting.DisplayPosition;
 import org.iplass.mtp.entity.Entity;
 import org.iplass.mtp.spi.Config;
 import org.iplass.mtp.spi.Service;
+import org.iplass.mtp.util.StringUtil;
 
 /**
  * gem固有の設定など

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/WebApiService.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/WebApiService.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import org.apache.poi.util.StringUtil;
 import org.iplass.mtp.ManagerLocator;
 import org.iplass.mtp.definition.TypedDefinitionManager;
 import org.iplass.mtp.impl.definition.AbstractTypedMetaDataService;
@@ -34,6 +33,7 @@ import org.iplass.mtp.impl.metadata.MetaDataContext;
 import org.iplass.mtp.impl.webapi.MetaWebApi.WebApiRuntime;
 import org.iplass.mtp.spi.Config;
 import org.iplass.mtp.spi.Service;
+import org.iplass.mtp.util.StringUtil;
 import org.iplass.mtp.webapi.definition.WebApiDefinition;
 import org.iplass.mtp.webapi.definition.WebApiDefinitionManager;
 
@@ -98,7 +98,7 @@ public class WebApiService extends AbstractTypedMetaDataService<MetaWebApi, WebA
 		String acceptMimeTypesPatternInBinaryApi = config.getValue("acceptMimeTypesPatternInBinaryApi");
 		this.acceptMimeTypesPatternInBinaryApi = StringUtil.isNotBlank(acceptMimeTypesPatternInBinaryApi)
 				? Pattern.compile(acceptMimeTypesPatternInBinaryApi)
-				: null;
+						: null;
 	}
 
 	public boolean isEnableDefinitionApi() {

--- a/sharedlibs.gradle
+++ b/sharedlibs.gradle
@@ -122,9 +122,9 @@ ext {
 		// tika の依存関係。pptx 解析に必要。org.tallison:metadata-extractor は fork プロジェクトなので、バージョンアップ時にグループが変わらないか注意
 		'org.tallison:metadata-extractor': '2.17.1.0',
 		
-		'org.apache.poi:poi': '5.2.3',
-		'org.apache.poi:poi-scratchpad': '5.2.3',
-		'org.apache.poi:poi-ooxml': '5.2.3',
+		'org.apache.poi:poi': '5.3.0',
+		'org.apache.poi:poi-scratchpad': '5.3.0',
+		'org.apache.poi:poi-ooxml': '5.3.0',
 		
 		'org.jxls:jxls': '2.14.0',
 		'org.jxls:jxls-poi': '2.14.0',


### PR DESCRIPTION
## 対応内容
- org.apache.poi:poi 5.2.3 -> 5.3.0
- org.apache.poi:poi-scratchpad 5.2.3 -> 5.3.0
- org.apache.poi:poi-ooxml 5.2.3 -> 5.3.0
- org.apache.poi.util の参照を変更

## 動作確認・スクリーンショット（任意）
- JasperReport レポート出力テスト
- JXLS レポート出力表示テスト
- POI レポート出力テスト

## レビュー観点・補足情報（任意）
- web 以外のプロジェクトの org.apache.poi.util 参照を、適切なパッケージに変更