### PR TITLE
jackson、バージョンアップ（4.0）

### DIFF
--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/jackson/WebApiParameterDeserializer.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/jackson/WebApiParameterDeserializer.java
@@ -1,19 +1,19 @@
 /*
  * Copyright (C) 2012 DENTSU SOKEN INC. All Rights Reserved.
- * 
+ *
  * Unless you have purchased a commercial license,
  * the following license terms apply:
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TreeTraversingParser;
 
@@ -39,7 +40,7 @@ public class WebApiParameterDeserializer extends JsonDeserializer<WebApiParamete
 	public static final String NAME_PROPERTY_NAME ="name";
 	public static final String VALUE_PROPERTY_NAME ="value";
 	public static final String VALUE_TYPE_PROPERTY_NAME ="valueType";
-	
+
 	private WebApiObjectMapperService mapperService;
 
 	WebApiParameterDeserializer () {
@@ -49,34 +50,36 @@ public class WebApiParameterDeserializer extends JsonDeserializer<WebApiParamete
 	@Override
 	public WebApiParameter deserialize(JsonParser jp, DeserializationContext ctxt)
 			throws IOException, JsonProcessingException {
-		
+
 		JsonToken t = jp.getCurrentToken();
 		if (t == JsonToken.START_OBJECT) {
 			jp.nextToken();
 		}
-		
+
 		WebApiParameter param = new WebApiParameter();
 		JsonNode valueNode = null;
 		for (; jp.getCurrentToken() != JsonToken.END_OBJECT; jp.nextToken()) {
-			String propName = jp.getCurrentName();
+			String propName = jp.currentName();
 			jp.nextToken();
 			if (NAME_PROPERTY_NAME.equals(propName)) {
 				String name = jp.getText();
+				// TODO dead code. name is not null. null or empty.
 				if (name == null) {
-					throw ctxt.mappingException("name is null.");
+					throw JsonMappingException.from(ctxt, "name is null.");
 				}
 				param.setName(name);
 			} else if (VALUE_TYPE_PROPERTY_NAME.equals(propName)) {
-					String valType = jp.getText();
-					if (valType == null) {
-						throw ctxt.mappingException("valueType is null.");
-					}
-					param.setValueType(valType);
+				String valType = jp.getText();
+				// TODO dead code. valType is not null. null or empty?
+				if (valType == null) {
+					throw JsonMappingException.from(ctxt, "valueType is null.");
+				}
+				param.setValueType(valType);
 			} else if (VALUE_PROPERTY_NAME.equals(propName)) {
 				if (param.getValueType() != null) {
 					//指定の型にマッピング
 					param.setValue(readValue(param.getValueType(), jp, ctxt));
-					
+
 				} else {
 					//この後に、valueTypeが指定されている可能性もあるので、一旦JsonNodeとして保持。
 					valueNode = jp.readValueAsTree();
@@ -86,7 +89,7 @@ public class WebApiParameterDeserializer extends JsonDeserializer<WebApiParamete
 				jp.skipChildren();
 			}
 		}
-		
+
 		if (valueNode != null) {
 			TreeTraversingParser ttp = new TreeTraversingParser(valueNode, jp.getCodec());
 			if (param.getValueType() != null) {
@@ -97,17 +100,17 @@ public class WebApiParameterDeserializer extends JsonDeserializer<WebApiParamete
 				param.setValue(ttp.readValueAs(Object.class));
 			}
 		}
-		
+
 		return param;
 	}
 
 	private Object readValue(String valueType, JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-		
+
 		Class<?> cl = mapperService.getMappedClass(valueType);
 		if (cl == null) {
-			throw ctxt.mappingException("unknown valueType:" + valueType);
+			throw JsonMappingException.from(ctxt, "unknown valueType:" + valueType);
 		}
-		
+
 		switch (jp.getCurrentToken()) {
 		case START_ARRAY:
 			jp.nextToken();

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/jackson/WebApiParameterDeserializer.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/jackson/WebApiParameterDeserializer.java
@@ -63,15 +63,13 @@ public class WebApiParameterDeserializer extends JsonDeserializer<WebApiParamete
 			jp.nextToken();
 			if (NAME_PROPERTY_NAME.equals(propName)) {
 				String name = jp.getText();
-				// TODO dead code. name is not null. null or empty.
-				if (name == null) {
+				if (JsonToken.VALUE_NULL == jp.currentToken()) {
 					throw JsonMappingException.from(ctxt, "name is null.");
 				}
 				param.setName(name);
 			} else if (VALUE_TYPE_PROPERTY_NAME.equals(propName)) {
 				String valType = jp.getText();
-				// TODO dead code. valType is not null. null or empty?
-				if (valType == null) {
+				if (JsonToken.VALUE_NULL == jp.currentToken()) {
 					throw JsonMappingException.from(ctxt, "valueType is null.");
 				}
 				param.setValueType(valType);

--- a/sharedlibs.gradle
+++ b/sharedlibs.gradle
@@ -131,7 +131,7 @@ ext {
 		
 		'org.apache.groovy:groovy-bom': '4.0.21', //by bom
 		
-		'com.fasterxml.jackson:jackson-bom': '2.15.2',//by bom
+		'com.fasterxml.jackson:jackson-bom': '2.17.2',//by bom
 		
 		'net.sf.supercsv:super-csv': '2.4.0',
 		


### PR DESCRIPTION
## 対応内容
- com.fasterxml.jackson:jackson-bom 2.15.2 -> 2.17.2
- フレームワークメソッド削除によるコンパイルエラー解消
- 動作確認後のコメントを追記

## 動作確認・スクリーンショット（任意）
- 汎用エンティティ操作（新規登録、更新、参照、削除）
- WebApiParameterMap Parameter タイプの WebAPI 動作検証（正常系、エラー系の確認）
- Entity Parameter タイプの WebAPI 動作確認（正常系、エラー系の確認）

## レビュー観点・補足情報（任意）
- ObjectMapper#configure で設定するパラメータの deprecated は最後に作業する