### PR TITLE
Tika、バージョンアップ（4.0）

### DIFF
--- a/iplass-core/libs.gradle
+++ b/iplass-core/libs.gradle
@@ -34,7 +34,7 @@ dependencies {
 		exclude group: 'org.apache.tika', module: 'tika-parser-zip-commons'
 		// bcjmail を利用するため除外
 		exclude group: 'org.bouncycastle', module: 'bcmail-jdk18on'
-		// poi はライブラリ管理しているため runtime で明示的に指定する
+		// poi はライブラリ管理しているため runtime で明示的に指定するので除外
 		exclude group: 'org.apache.poi', module: 'poi'
 		exclude group: 'org.apache.poi', module: 'poi-scratchpad'
 		exclude group: 'org.apache.poi', module: 'poi-ooxml'
@@ -42,7 +42,7 @@ dependencies {
 	implementation(sharedLib('org.apache.tika:tika-parser-pdf-module')) {
 		// bcjmail を利用するため除外
 		exclude group: 'org.bouncycastle', module: 'bcmail-jdk18on'
-		// 参照バージョンが古い。Jakarta EE 8
+		// 参照バージョンが古い為除外。(Jakarta EE 8)
 		exclude group: 'org.glassfish.jaxb', module: 'jaxb-runtime'
 	}
 	runtimeOnly(sharedLib('org.apache.tika:tika-parser-zip-commons')) {
@@ -54,14 +54,6 @@ dependencies {
 	runtimeOnly sharedLib('org.apache.poi:poi')
 	runtimeOnly sharedLib('org.apache.poi:poi-scratchpad')
 	runtimeOnly sharedLib('org.apache.poi:poi-ooxml')
-//	runtimeOnly(sharedLib('org.apache.pdfbox:jempbox'))
-//	runtimeOnly(sharedLib('org.apache.pdfbox:pdfbox'))
-//	runtimeOnly(sharedLib('org.apache.pdfbox:pdfbox-tools')) {
-//		transitive = false
-//	}
-//	runtimeOnly sharedLib('org.ccil.cowan.tagsoup:tagsoup')
-//	// tika の依存関係。pptx 解析に必要。org.tallison:metadata-extractor は fork プロジェクトなので、バージョンアップ時にグループが変わらないか注意
-//	runtimeOnly sharedLib('org.tallison:metadata-extractor')
 
 	//groovy
 	implementation 'org.apache.groovy:groovy'

--- a/iplass-core/libs.gradle
+++ b/iplass-core/libs.gradle
@@ -20,24 +20,48 @@ dependencies {
 	implementation sharedLib('org.apache.lucene:lucene-analysis-kuromoji')
 	runtimeOnly sharedLib('org.apache.lucene:lucene-backward-codecs')
 
-	//tika(依存関係多いので明示的に指定する)
+	//tika
 	implementation(sharedLib('org.apache.tika:tika-core'))
-	implementation(sharedLib('org.apache.tika:tika-parsers')) {
-		transitive = false
+	implementation(sharedLib('org.apache.tika:tika-parser-html-module'))
+	implementation(sharedLib('org.apache.tika:tika-parser-xml-module')) {
+		// xml api の参照を外すため
+		exclude group: 'xerces', module: 'xercesImpl'
 	}
-	runtimeOnly(sharedLib('org.apache.commons:commons-compress'))
-	runtimeOnly(sharedLib('org.apache.pdfbox:jempbox'))
-	runtimeOnly(sharedLib('org.apache.pdfbox:pdfbox'))
-	runtimeOnly(sharedLib('org.apache.pdfbox:pdfbox-tools')) {
-		transitive = false
+	implementation(sharedLib('org.apache.tika:tika-parser-microsoft-module')) {
+		// xml api の参照を外すため除外（tika-parser-xml-module で xerces を除外）
+		exclude group: 'org.apache.tika', module: 'tika-parser-xml-module'
+		// tika-parser-zip-commons の commons-compress のバージョン指定する為除外
+		exclude group: 'org.apache.tika', module: 'tika-parser-zip-commons'
+		// bcjmail を利用するため除外
+		exclude group: 'org.bouncycastle', module: 'bcmail-jdk18on'
+		// poi はライブラリ管理しているため runtime で明示的に指定する
+		exclude group: 'org.apache.poi', module: 'poi'
+		exclude group: 'org.apache.poi', module: 'poi-scratchpad'
+		exclude group: 'org.apache.poi', module: 'poi-ooxml'
 	}
-	runtimeOnly sharedLib('org.ccil.cowan.tagsoup:tagsoup')
-	// tika の依存関係。pptx 解析に必要。org.tallison:metadata-extractor は fork プロジェクトなので、バージョンアップ時にグループが変わらないか注意
-	runtimeOnly sharedLib('org.tallison:metadata-extractor')
-
+	implementation(sharedLib('org.apache.tika:tika-parser-pdf-module')) {
+		// bcjmail を利用するため除外
+		exclude group: 'org.bouncycastle', module: 'bcmail-jdk18on'
+		// 参照バージョンが古い。Jakarta EE 8
+		exclude group: 'org.glassfish.jaxb', module: 'jaxb-runtime'
+	}
+	runtimeOnly(sharedLib('org.apache.tika:tika-parser-zip-commons')) {
+		// commons-compress のバージョン指定する為除外
+		exclude group: 'org.apache.commons', module: 'commons-compress'
+	}
+	// specify runtimes version for tika.
+	runtimeOnly sharedLib('org.apache.commons:commons-compress')
 	runtimeOnly sharedLib('org.apache.poi:poi')
 	runtimeOnly sharedLib('org.apache.poi:poi-scratchpad')
 	runtimeOnly sharedLib('org.apache.poi:poi-ooxml')
+//	runtimeOnly(sharedLib('org.apache.pdfbox:jempbox'))
+//	runtimeOnly(sharedLib('org.apache.pdfbox:pdfbox'))
+//	runtimeOnly(sharedLib('org.apache.pdfbox:pdfbox-tools')) {
+//		transitive = false
+//	}
+//	runtimeOnly sharedLib('org.ccil.cowan.tagsoup:tagsoup')
+//	// tika の依存関係。pptx 解析に必要。org.tallison:metadata-extractor は fork プロジェクトなので、バージョンアップ時にグループが変わらないか注意
+//	runtimeOnly sharedLib('org.tallison:metadata-extractor')
 
 	//groovy
 	implementation 'org.apache.groovy:groovy'

--- a/iplass-web/libs.gradle
+++ b/iplass-web/libs.gradle
@@ -14,9 +14,6 @@ dependencies {
 	implementation sharedLib('commons-io:commons-io')
 
 	implementation(sharedLib('org.apache.tika:tika-core'))
-	implementation(sharedLib('org.apache.tika:tika-parsers')) {
-		transitive = false
-	}
 
 	//apache POI
 	api sharedLib('org.apache.poi:poi')

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/TikaFileTypeDetector.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/fileupload/TikaFileTypeDetector.java
@@ -45,29 +45,13 @@ public class TikaFileTypeDetector implements FileTypeDetector, ServiceInitListen
 	private Logger logger = LoggerFactory.getLogger(TikaFileTypeDetector.class);
 	/** FileUploadTikaAdapter */
 	private FileUploadTikaAdapter tikaAdapter;
-	/** Listener内でインスタンス生成を実施したか */
-	private boolean isCreateTikaAadpter = false;
 
 	@Override
 	public void inited(Service service, Config config) {
-		// TODO 下位バージョン互換のロジック。下位バージョンでは、tikaAdapter を設定ないパターンもあり得る。設定することを推奨。次期バージョンで削除したい。。。
-		if (null == tikaAdapter) {
-			// tikaAdapter が設定されていなければデフォルトインスタンスを生成する。
-			FileUploadTikaAdapterImpl adapter = new FileUploadTikaAdapterImpl();
-			adapter.inited(service, config);
-			tikaAdapter = adapter;
-			// インスタンス生成をマーク
-			isCreateTikaAadpter = true;
-		}
 	}
 
 	@Override
 	public void destroyed() {
-		// TODO 下位バージョン互換のロジック。次期バージョンで削除したい。。。
-		if (isCreateTikaAadpter) {
-			// インタンス生成していたら、本リスナ経由で破棄する。
-			((FileUploadTikaAdapterImpl) this.tikaAdapter).destroyed();
-		}
 	}
 
 	@Override
@@ -90,7 +74,6 @@ public class TikaFileTypeDetector implements FileTypeDetector, ServiceInitListen
 		}
 	}
 
-	// TODO 次期バージョンで、設定を必須とする
 	/**
 	 * FileUploadTikaAdapter を設定する
 	 *

--- a/sharedlibs.gradle
+++ b/sharedlibs.gradle
@@ -116,7 +116,7 @@ ext {
 		'org.apache.tika:tika-parser-microsoft-module': '2.9.2',
 		'org.apache.tika:tika-parser-pdf-module': '2.9.2',
 		'org.apache.tika:tika-parser-zip-commons': '2.9.2',
-		// commons-compress は tika に関連した競合ライブ理の為、個別定義しバージョンを管理
+		// commons-compress は tika に関連した競合ライブラリの為、個別定義しバージョンを管理
 		'org.apache.commons:commons-compress': '1.26.2',
 		
 		'org.apache.poi:poi': '5.3.0',

--- a/sharedlibs.gradle
+++ b/sharedlibs.gradle
@@ -109,16 +109,15 @@ ext {
 		'org.apache.lucene:lucene-analysis-kuromoji': '9.11.1',
 		'org.apache.lucene:lucene-backward-codecs': '9.11.1',
 		
-		//tika(依存関係多いので明示的に指定する)
-		'org.apache.tika:tika-core': '1.28.5',
-		'org.apache.tika:tika-parsers': '1.28.5',
-		'org.apache.commons:commons-compress': '1.26.0',
-		'org.apache.pdfbox:jempbox': '1.8.16',
-		'org.apache.pdfbox:pdfbox': '2.0.24',
-		'org.apache.pdfbox:pdfbox-tools': '2.0.24',
-		'org.ccil.cowan.tagsoup:tagsoup': '1.2.1',
-		// tika の依存関係。pptx 解析に必要。org.tallison:metadata-extractor は fork プロジェクトなので、バージョンアップ時にグループが変わらないか注意
-		'org.tallison:metadata-extractor': '2.17.1.0',
+		//tika
+		'org.apache.tika:tika-core': '2.9.2',
+		'org.apache.tika:tika-parser-html-module': '2.9.2',
+		'org.apache.tika:tika-parser-xml-module': '2.9.2',
+		'org.apache.tika:tika-parser-microsoft-module': '2.9.2',
+		'org.apache.tika:tika-parser-pdf-module': '2.9.2',
+		'org.apache.tika:tika-parser-zip-commons': '2.9.2',
+		// commons-compress は tika に関連した競合ライブ理の為、個別定義しバージョンを管理
+		'org.apache.commons:commons-compress': '1.26.2',
 		
 		'org.apache.poi:poi': '5.3.0',
 		'org.apache.poi:poi-scratchpad': '5.3.0',


### PR DESCRIPTION
## 対応内容
- org.apache.tika:tika-core 1.28.5 -> 2.9.2
- org.apache.tika:tika-parsers 1.28.5 は以下のモジュールに変更
 -> org.apache.tika:tika-parser-html-module 2.9.2
 -> org.apache.tika:tika-parser-xml-module 2.9.2
 -> org.apache.tika:tika-parser-microsoft-module 2.9.2
 -> org.apache.tika:tika-parser-pdf-module 2.9.2
 -> org.apache.tika:tika-parser-zip-commons 2.9.2
- parser 用に個別に追加していた依存関係の整理
- TikaFileTypeDetector で FileUploadTikaAdapter の設定を必須とする

## 動作確認・スクリーンショット（任意）
- 汎用エンティティ操作（新規登録、更新、表示、削除）
- 全文検索バイナリファイルクロール実行、検索実行
- Tika を利用したファイルアップロード実施

## レビュー観点・補足情報（任意）
- parser については service-config で解析可能なファイルタイプを確認し必要最低限の設定としてあります。