### PR TITLE
GEM: CKEditor利用時に警告メッセージが表示されるのを抑制する

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/layout/resource/ckeditorResource.inc.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/layout/resource/ckeditorResource.inc.jsp
@@ -25,5 +25,5 @@
 <script type="text/javascript" src="${m:esc(staticContentPath)}/webjars/ckeditor/4.22.1/full/ckeditor.js?cv=<%=TemplateUtil.getAPIVersion()%>"></script>
 <script type="text/javascript" src="${m:esc(staticContentPath)}/webjars/ckeditor/4.22.1/full/adapters/jquery.js?cv=<%=TemplateUtil.getAPIVersion()%>"></script>
 <script type="text/javascript">
-CKEDITOR.config.customConfig = "${m:esc(staticContentPath)}/scripts/gem/plugin/ckeditor/mtpconfig.js";
+CKEDITOR.config.customConfig = "${m:esc(staticContentPath)}/scripts/gem/plugin/ckeditor/mtpconfig.js?cv=<%=TemplateUtil.getAPIVersion()%>";
 </script>

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/plugin/ckeditor/mtpconfig.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/plugin/ckeditor/mtpconfig.js
@@ -5,6 +5,7 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 
 CKEDITOR.editorConfig = function( config )
 {
+	config.versionCheck = false;
 	config.language = scriptContext.locale.defaultLocale;
 	//config.skin = 'office2003';
 	config.uiColor = '';


### PR DESCRIPTION
## 対応内容
CKEditorのデフォルト設定で「versionCheck: false」を指定することで警告メッセージを抑制する。

close #1554