### PR TITLE
GEM、多重度複数のプロパティに対してRichTextEditorを使用している場合に、追加ボタンで表示されるEditorにOptionが適用されない

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/string/StringPropertyEditor_Edit.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/string/StringPropertyEditor_Edit.jsp
@@ -410,9 +410,12 @@ $(function() {
 					});
 
 					$(elem).attr("id", "id_<%=escapedPropName%>" + count);
-					$(elem).ckeditor(
-						function() {}, { allowedContent:<%=allowedContent%> }
-					);
+<%					if (StringUtil.isNotBlank(editor.getRichtextEditorOption())) { %>
+					var opt = <%=editor.getRichtextEditorOption()%>;
+<%					} else { %>
+					var opt = { allowedContent:<%=allowedContent%> };
+<%					} %>
+					$(elem).ckeditor(function() {}, opt);
 					<%=toggleAddBtnFunc%>();
 				}
 <%


### PR DESCRIPTION
## 対応内容
多重度複数のLongTextプロパティなどに対して、LongTextPropertyEditorの RICHTEXTタイプを指定している場合に、
編集画面で「追加」ボタンで追加した結果表示されるEditorに対しても RickText Editor Option を適用する。

close #1568