### PR TITLE
JasperReports、バージョンアップ（4.0）

### DIFF
--- a/iplass-web/libs.gradle
+++ b/iplass-web/libs.gradle
@@ -35,20 +35,17 @@ dependencies {
 		exclude group: 'org.jxls', module: 'jxls'
 	}
 
-	//jasper reports
-	implementation(sharedLib('net.sf.jasperreports:jasperreports')) {
-		//define minimum dependency
+	// jasperreports
+	api(sharedLib('net.sf.jasperreports:jasperreports')) {
+		// define minimum dependency
 		exclude(group: 'org.eclipse.jdt', module: 'ecj')
 		exclude(group: 'org.jfree', module: 'jcommon')
 		exclude(group: 'org.jfree', module: 'jfreechart')
+		// 新しいバージョンを個別指定する
 		exclude(group: 'com.github.librepdf', module: 'openpdf')
 	}
 	// openpdf (for use JasperReports) 
 	runtimeOnly sharedLib('com.github.librepdf:openpdf')
-
-	api(sharedLib('net.sf.jasperreports:jasperreports')) {
-		transitive = false
-	}
 
 	implementation sharedLib('org.apache.commons:commons-fileupload2-jakarta-servlet6')
 

--- a/sharedlibs.gradle
+++ b/sharedlibs.gradle
@@ -158,8 +158,8 @@ ext {
 		
 		'io.lettuce:lettuce-core': '6.2.5.RELEASE',
 		
-		'net.sf.jasperreports:jasperreports': '6.20.6',
-		'com.github.librepdf:openpdf': '1.3.33',
+		'net.sf.jasperreports:jasperreports': '6.21.3',
+		'com.github.librepdf:openpdf': '2.0.2',
 
 		// FIXME version is miliestone
 		'org.apache.commons:commons-fileupload2-jakarta-servlet6': '2.0.0-M2',


### PR DESCRIPTION
## 対応内容
- net.sf.jasperreports:jasperreports 6.20.6 -> 6.21.3
- com.github.librepdf:openpdf 1.3.33 -> 2.0.2

## 動作確認・スクリーンショット（任意）
- 帳票テンプレート（JasperReports）を利用した帳票出力の実行

## レビュー観点・補足情報（任意）
特になし