### PR TITLE
jQuery、その他のWebJars管理のJavaScriptライブラリバージョンアップ

### DIFF
--- a/iplass-gem/libs.gradle
+++ b/iplass-gem/libs.gradle
@@ -14,11 +14,11 @@ configurations {
 	all*.exclude group: 'org.webjars.bower', module: 'jquery'
 	all*.exclude group: 'org.webjars.bowergithub.jquery', module: 'jquery-dist'
 	
-	// jquery-uiはorg.webjars.bowergithub.jquery:jquery-uiを利用。
+	// jquery-uiはorg.webjars.npm:jquery-uiを利用。
 	// org.webjars:jquery-uiは除外(org.webjars:jQuery-Timepicker-Addonで参照)
 	all*.exclude group: 'org.webjars', module: 'jquery-ui'
 
-	// momentはorg.webjars:momentjsを利用。
+	// momentはorg.webjars.npm:momentを利用。
 	// org.webjars.bower:momentは除外(org.webjars.bower:fullcalendarで参照)
 	all*.exclude group: 'org.webjars.bower', module: 'moment'
 }
@@ -36,17 +36,17 @@ dependencies {
 	wjRuntime sharedLib('org.webjars:ckeditor')
 	wjRuntime sharedLib('org.webjars:jquery-blockui')
 	wjRuntime sharedLib('org.webjars:jQuery-Timepicker-Addon')
-	wjRuntime sharedLib('org.webjars:momentjs')
+	wjRuntime sharedLib('org.webjars.npm:moment')
 
 	wjRuntime sharedLib('org.webjars.npm:free-jqgrid')
 	wjRuntime sharedLib('org.webjars.npm:jqtree')
 	wjRuntime sharedLib('org.webjars.npm:viewerjs')
 
-	wjRuntime sharedLib('org.webjars.bower:blueimp-file-upload')
-	wjRuntime sharedLib('org.webjars.bower:fullcalendar')
-	wjRuntime sharedLib('org.webjars.bower:mediaelement')
+	wjRuntime sharedLib('org.webjars.npm:blueimp-file-upload')
+	wjRuntime sharedLib('org.webjars.npm:fullcalendar')
+	wjRuntime sharedLib('org.webjars.npm:mediaelement')
 
-	wjRuntime sharedLib('org.webjars.bowergithub.jquery:jquery-ui')
+	wjRuntime sharedLib('org.webjars.npm:jquery-ui')
 
 	//css
 	wjRuntime sharedLib('org.webjars:font-awesome')

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/binary/pdfviewer.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/binary/pdfviewer.jsp
@@ -34,14 +34,14 @@ See https://github.com/adobe-type-tools/cmap-resources
     <title>PDF.js viewer</title>
 
     <!-- This snippet is used in production (included from viewer.html) -->
-    <link rel="resource" type="application/l10n" href="${m:esc(staticContentPath)}/webjars/pdf-js/4.2.67/web/locale/locale.json">
-    <script src="${m:esc(staticContentPath)}/webjars/pdf-js/4.2.67/build/pdf.mjs" type="module"></script>
+    <link rel="resource" type="application/l10n" href="${m:esc(staticContentPath)}/webjars/pdf-js/4.4.168/web/locale/locale.json">
+    <script src="${m:esc(staticContentPath)}/webjars/pdf-js/4.4.168/build/pdf.mjs" type="module"></script>
 
-    <link rel="stylesheet" href="${m:esc(staticContentPath)}/webjars/pdf-js/4.2.67/web/viewer.css">
+    <link rel="stylesheet" href="${m:esc(staticContentPath)}/webjars/pdf-js/4.4.168/web/viewer.css">
 
     <script type="module">
-    import {PDFViewerApplicationOptions} from "${m:esc(staticContentPath)}/webjars/pdf-js/4.2.67/web/viewer.mjs";
-    PDFViewerApplicationOptions.set("workerSrc", "${m:esc(staticContentPath)}/webjars/pdf-js/4.2.67/build/pdf.worker.mjs");
+    import {PDFViewerApplicationOptions} from "${m:esc(staticContentPath)}/webjars/pdf-js/4.4.168/web/viewer.mjs";
+    PDFViewerApplicationOptions.set("workerSrc", "${m:esc(staticContentPath)}/webjars/pdf-js/4.4.168/build/pdf.worker.mjs");
     </script>
   </head>
 

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/binary/pdfviewer.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/binary/pdfviewer.jsp
@@ -454,8 +454,8 @@ See https://github.com/adobe-type-tools/cmap-resources
             <button id="documentPropertiesClose" class="dialogButton"><span data-l10n-id="pdfjs-document-properties-close-button">Close</span></button>
           </div>
         </dialog>
-        <dialog id="altTextDialog" aria-labelledby="dialogLabel" aria-describedby="dialogDescription">
-          <div id="altTextContainer">
+        <dialog class="dialog altText" id="altTextDialog" aria-labelledby="dialogLabel" aria-describedby="dialogDescription">
+          <div id="altTextContainer" class="mainContainer">
             <div id="overallDescription">
               <span id="dialogLabel" data-l10n-id="pdfjs-editor-alt-text-dialog-label" class="title">Choose an option</span>
               <span id="dialogDescription" data-l10n-id="pdfjs-editor-alt-text-dialog-description">
@@ -492,8 +492,8 @@ See https://github.com/adobe-type-tools/cmap-resources
               </div>
             </div>
             <div id="buttons">
-              <button id="altTextCancel" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-cancel-button">Cancel</span></button>
-              <button id="altTextSave" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-save-button">Save</span></button>
+              <button id="altTextCancel" class="secondaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-cancel-button">Cancel</span></button>
+              <button id="altTextSave" class="primaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-save-button">Save</span></button>
             </div>
           </div>
         </dialog>

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/binary/BinaryPropertyEditor_Edit.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/binary/BinaryPropertyEditor_Edit.jsp
@@ -152,8 +152,8 @@
 		if (request.getAttribute(Constants.UPLOAD_LIB_LOADED) == null) {
 			request.setAttribute(Constants.UPLOAD_LIB_LOADED, true);
 %>
-<script type="text/javascript" src="${m:esc(staticContentPath)}/webjars/blueimp-file-upload/10.30.1/js/jquery.fileupload.js?cv=<%=TemplateUtil.getAPIVersion()%>"></script>
-<script type="text/javascript" src="${m:esc(staticContentPath)}/webjars/blueimp-file-upload/10.30.1/js/jquery.iframe-transport.js?cv=<%=TemplateUtil.getAPIVersion()%>"></script>
+<script type="text/javascript" src="${m:esc(staticContentPath)}/webjars/blueimp-file-upload/10.32.0/js/jquery.fileupload.js?cv=<%=TemplateUtil.getAPIVersion()%>"></script>
+<script type="text/javascript" src="${m:esc(staticContentPath)}/webjars/blueimp-file-upload/10.32.0/js/jquery.iframe-transport.js?cv=<%=TemplateUtil.getAPIVersion()%>"></script>
 <%
 		}
 		if (!hideSelectButton){

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/layout/resource/calendarResource.inc.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/layout/resource/calendarResource.inc.jsp
@@ -28,8 +28,8 @@ if (StringUtil.isEmpty(language)) {
 	language = "ja";
 }
 %>
-<script type="text/javascript" src="${m:esc(staticContentPath)}/webjars/fullcalendar/3.10.2/dist/fullcalendar.js?cv=<%=TemplateUtil.getAPIVersion()%>"></script>
-<link rel="stylesheet" type="text/css" media="screen, print" href="${m:esc(staticContentPath)}/webjars/fullcalendar/3.10.2/dist/fullcalendar.css?cv=<%=TemplateUtil.getAPIVersion()%>" />
+<script type="text/javascript" src="${m:esc(staticContentPath)}/webjars/fullcalendar/3.10.5/dist/fullcalendar.js?cv=<%=TemplateUtil.getAPIVersion()%>"></script>
+<link rel="stylesheet" type="text/css" media="screen, print" href="${m:esc(staticContentPath)}/webjars/fullcalendar/3.10.5/dist/fullcalendar.css?cv=<%=TemplateUtil.getAPIVersion()%>" />
 <script type="text/javascript" src="${m:esc(staticContentPath)}/scripts/gem/module/calendar/calendar.js?cv=<%=TemplateUtil.getAPIVersion()%>"></script>
 <%
 if (!"en".equals(language)) { //enの場合はデフォルトを利用

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/layout/resource/coreResource.inc.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/layout/resource/coreResource.inc.jsp
@@ -57,16 +57,16 @@ dType="/gem";
 scriptContext.locale.showPulldownPleaseSelectLabel = <%=ViewUtil.isShowPulldownPleaseSelectLabel()%>;
 </script>
 
-<script src="${staticContentPath}/webjars/jquery/3.5.1/jquery.min.js?cv=${apiVersion}"></script>
+<script src="${staticContentPath}/webjars/jquery/3.7.1/jquery.min.js?cv=${apiVersion}"></script>
 <script>$.uiBackCompat = false;</script>
-<script src="${staticContentPath}/webjars/jquery-ui/dist/jquery-ui.min.js?cv=${apiVersion}"></script>
+<script src="${staticContentPath}/webjars/jquery-ui/1.13.3/dist/jquery-ui.min.js?cv=${apiVersion}"></script>
 <script src="${staticContentPath}/scripts/gem/functions.js?cv=${apiVersion}"></script>
 <script src="${staticContentPath}/scripts/gem/common.js?cv=${apiVersion}"></script>
 <script src="${staticContentPath}/scripts/gem/webapi.js?cv=${apiVersion}"></script>
 <script src="${staticContentPath}/scripts/gem/plugin/fixHeight.js?cv=${apiVersion}"></script>
-<script src="${staticContentPath}/webjars/momentjs/2.29.4/min/moment-with-locales.min.js?cv=${apiVersion}"></script>
+<script src="${staticContentPath}/webjars/moment/2.30.1/min/moment-with-locales.min.js?cv=${apiVersion}"></script>
 <script src="${staticContentPath}/webjars/font-awesome/5.13.1/js/all.min.js?cv=${apiVersion}"></script>
 
-<link rel="stylesheet" href="${staticContentPath}/webjars/jquery-ui/dist/themes/base/jquery-ui.min.css?cv=${apiVersion}" />
+<link rel="stylesheet" href="${staticContentPath}/webjars/jquery-ui/1.13.3/dist/themes/base/jquery-ui.min.css?cv=${apiVersion}" />
 
 <%@include file="./datepickerResource.inc.jsp" %> 

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/layout/resource/datepickerResource.inc.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/layout/resource/datepickerResource.inc.jsp
@@ -32,7 +32,7 @@
 
 <%-- enの場合はデフォルトを利用 --%>
 <c:if test="${language != 'en'}" >
-<script src="${staticContentPath}/webjars/jquery-ui/ui/i18n/datepicker-${language}.js?cv=${apiVersion}"></script>
+<script src="${staticContentPath}/webjars/jquery-ui/1.13.3/ui/i18n/datepicker-${language}.js?cv=${apiVersion}"></script>
 <script src="${staticContentPath}/webjars/jQuery-Timepicker-Addon/1.6.3/i18n/jquery-ui-timepicker-${language}.js?cv=${apiVersion}"></script>
 </c:if>
 <script src="${staticContentPath}/scripts/gem/plugin/jQuery-Timepicker-Addon/jquery-ui-timepicker-addon-mtp.js?cv=${apiVersion}"></script>

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/layout/resource/mediaelementResource.inc.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/layout/resource/mediaelementResource.inc.jsp
@@ -21,5 +21,5 @@
 <%@ taglib prefix="m" uri="http://iplass.org/tags/mtp"%>
 <%@ page language="java" contentType="text/html; charset=utf-8" pageEncoding="utf-8" trimDirectiveWhitespaces="true" %>
 
-<script src="${staticContentPath}/webjars/mediaelement/4.2.5/build/mediaelement-and-player.min.js?cv=${apiVersion}"></script>
-<link rel="stylesheet" href="${staticContentPath}/webjars/mediaelement/4.2.5/build/mediaelementplayer.min.css?cv=${apiVersion}" />
+<script src="${staticContentPath}/webjars/mediaelement/4.2.17/build/mediaelement-and-player.min.js?cv=${apiVersion}"></script>
+<link rel="stylesheet" href="${staticContentPath}/webjars/mediaelement/4.2.17/build/mediaelementplayer.min.css?cv=${apiVersion}" />

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/layout/resource/viewerjsResource.inc.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/layout/resource/viewerjsResource.inc.jsp
@@ -20,5 +20,5 @@
 
 <%@ page language="java" contentType="text/html; charset=utf-8" pageEncoding="utf-8" trimDirectiveWhitespaces="true" %>
 
-<link rel="stylesheet" href="${staticContentPath}/webjars/viewerjs/1.9.0/dist/viewer.min.css?cv=${apiVersion}" />
-<script src="${staticContentPath}/webjars/viewerjs/1.9.0/dist/viewer.min.js?cv=${apiVersion}"></script>
+<link rel="stylesheet" href="${staticContentPath}/webjars/viewerjs/1.11.1/dist/viewer.min.css?cv=${apiVersion}" />
+<script src="${staticContentPath}/webjars/viewerjs/1.11.1/dist/viewer.min.js?cv=${apiVersion}"></script>

--- a/sharedlibs.gradle
+++ b/sharedlibs.gradle
@@ -175,23 +175,24 @@ ext {
 		'org.webjars.npm:ace-builds': '1.12.3',
 		
 		//webjars(gem)
-		'org.webjars:jquery': '3.5.1',
-		'org.webjars:pdf-js': '4.2.67',
+		'org.webjars:jquery': '3.7.1',
+		'org.webjars:pdf-js': '4.4.168',
 		'org.webjars:ckeditor': '4.22.1',
 		'org.webjars:jquery-blockui': '2.70-1',
 		'org.webjars:jQuery-Timepicker-Addon': '1.6.3',
-		'org.webjars:momentjs': '2.29.4',
-		
+
+		'org.webjars.npm:moment': '2.30.1',
+
 		'org.webjars.npm:free-jqgrid': '4.15.5',
 		'org.webjars.npm:jqtree': '1.4.9',
-		'org.webjars.npm:viewerjs': '1.9.0',
-		
-		'org.webjars.bower:blueimp-file-upload': '10.30.1',
-		'org.webjars.bower:fullcalendar': '3.10.2',
-		'org.webjars.bower:mediaelement': '4.2.5',
-		
-		'org.webjars.bowergithub.jquery:jquery-ui': '1.13.2',
-		
+		'org.webjars.npm:viewerjs': '1.11.1',
+
+		'org.webjars.npm:blueimp-file-upload': '10.32.0',
+		'org.webjars.npm:fullcalendar': '3.10.5',
+		'org.webjars.npm:mediaelement': '4.2.17',
+
+		'org.webjars.npm:jquery-ui': '1.13.3',
+
 		'org.webjars:font-awesome': '5.13.1',
 	]
 	


### PR DESCRIPTION
## 対応内容
- org.webjars:jquery 3.5.1 -> 3.7.1
- org.webjars.bowergithub.jquery:jquery-ui 1.13.2 -> org.webjars.npm:jquery-ui 1.13.3
- org.webjars:pdf-js 4.2.67 -> 4.4.168
- org.webjars:momentjs 2.29.4 -> org.webjars.npm:moment 2.30.1
- org.webjars.npm:viewerjs 1.9.0 -> 1.11.1
- org.webjars.bower:blueimp-file-upload 10.30.1 -> org.webjars.npm:blueimp-file-upload 10.32.0
- org.webjars.bower:mediaelement 4.2.5 -> org.webjars.npm:mediaelement 4.2.17
- org.webjars.bower:fullcalendar 3.10.2 -> org.webjars.npm:fullcalendar 3.10.5

## 動作確認・スクリーンショット（任意）
- gemでEntityデータの検索、新規、編集、削除
- カレンダーにてデータの表示、登録、編集
- Entityデータ登録時にbinaryファイルのアップロードと登録後binaryファイルの表示
- gem/binary/pdfviewer経由でpdfの表示

## レビュー観点・補足情報（任意）
特になし