### PR TITLE
JakartaEE10/Tomcat10.1、Java 21対応 - ライブラリ最新化

### DIFF
--- a/sharedlibs.gradle
+++ b/sharedlibs.gradle
@@ -78,15 +78,14 @@ ext {
 		// Jakarta JSP - tomcat bundled
 		// apache tomcat bundled
 		// for jsp compilation
-		'org.apache.tomcat:tomcat-jasper': '10.1.20',
+		'org.apache.tomcat:tomcat-jasper': '10.1.26',
 
 		// Jakarta jstl
 		'org.glassfish.web:jakarta.servlet.jsp.jstl': '3.0.1',
 
-		// TODO 3.1.6 が最新。jackson が推移依存でバージョンアップされてしまい、インターフェースに影響があるので後で対応する。
 		// Jakarta rest
 		// https://eclipse-ee4j.github.io/jersey/
-		'org.glassfish.jersey:jersey-bom': '3.1.5',//by bom
+		'org.glassfish.jersey:jersey-bom': '3.1.7',//by bom
 
 		// Jakarta Annotations
 		// apache tomcat bundled
@@ -141,7 +140,7 @@ ext {
 		'ch.qos.logback:logback-classic': '1.5.6',
 		'net.logstash.logback:logstash-logback-encoder': '7.4',
 		
-		'org.bouncycastle:bcjmail-jdk18on': '1.78',
+		'org.bouncycastle:bcjmail-jdk18on': '1.78.1',
 		
 		'org.jgroups:jgroups': '5.3.6.Final',
 


### PR DESCRIPTION
## 対応内容
Jakarta EE 10, Tomcat 10.1 対応を実施した際に更新したライブラリバージョンの再チェックを実施する。

- org.apache.tomcat:tomcat-jasper 10.1.20 -> 10.1.26
- org.glassfish.jersey:jersey-bom 3.1.5 -> 3.1.7
- org.bouncycastle:bcjmail-jdk18on 1.78 -> 1.78.1

## 動作確認・スクリーンショット（任意）
- mdc 汎用エンティティ操作（新規登録、更新、参照、削除）
- WebAPI 操作

## レビュー観点・補足情報（任意）
特になし