### PR TITLE
大量データ参照セクション、検索結果で参照プロパティのネスト項目ソート時の動きを修正

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/GetMassReferencesCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/GetMassReferencesCommand.java
@@ -777,14 +777,20 @@ public final class GetMassReferencesCommand extends DetailCommandBase implements
 			// 参照の先の項目を取得
 			NestProperty subProp = opt.get();
 			if (subProp.getEditor() instanceof ReferencePropertyEditor) {
-				return getSubProperty(subPropName, ((ReferencePropertyEditor) subProp.getEditor()).getNestProperties());
+				return findLayoutNestPropertyRecursive(subPropName, ((ReferencePropertyEditor) subProp.getEditor()).getNestProperties());
 			}
 		}
 		
 		return null;
 	}
 
-	private NestProperty getSubProperty(String propName, List<NestProperty> properties) {
+	/**
+	 * プロパティ名に一致するネストプロパティを再帰的に検索し取得する
+	 * @param propertyName プロパティ名
+	 * @param editor 参照プロパティエディタ
+	 * @return ネストプロパティ
+	 */
+	private NestProperty findLayoutNestPropertyRecursive(String propName, List<NestProperty> properties) {
 		if (properties == null || properties.isEmpty()) {
 			return null;
 		}
@@ -801,7 +807,7 @@ public final class GetMassReferencesCommand extends DetailCommandBase implements
 
 			NestProperty subProp = opt.get();
 			if (subProp.getEditor() instanceof ReferencePropertyEditor) {
-				return getSubProperty(subPropName, ((ReferencePropertyEditor) subProp.getEditor()).getNestProperties());
+				return findLayoutNestPropertyRecursive(subPropName, ((ReferencePropertyEditor) subProp.getEditor()).getNestProperties());
 			}
 		}
 

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/GetMassReferencesCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/GetMassReferencesCommand.java
@@ -286,7 +286,7 @@ public final class GetMassReferencesCommand extends DetailCommandBase implements
 			List<SortSetting> setting = section.getSortSetting();
 			for (SortSetting ss : setting) {
 				if (ss.getSortKey() != null) {
-					String key = getSortSettingKey(section, red, ss.getSortKey());
+					String key = getSortKey(section, red, ss.getSortKey());
 					if (!addNames.contains(key)) {
 						orderBy.add(key, getSortType(ss.getSortType().name()), getNullOrderingSpec(ss.getNullOrderType()));
 						addNames.add(key);
@@ -322,7 +322,7 @@ public final class GetMassReferencesCommand extends DetailCommandBase implements
 			return Entity.OID;
 		}
 
-		PropertyDefinition pd = ed.getProperty(ret);
+		PropertyDefinition pd = ed.getProperty(property.getPropertyName());
 		if (pd == null) {
 			ret = Entity.OID;
 			pd = ed.getProperty(ret);
@@ -330,41 +330,22 @@ public final class GetMassReferencesCommand extends DetailCommandBase implements
 
 		if (pd instanceof ReferenceProperty) {
 			// 当該項目がセクション上表示される場合は、セクション上の表示項目でソート
-			if (property != null) {
+			if (property.getPropertyName().equals(sortKey)) {
 				ret = sortKey + "." + getDisplayNestProperty(property);
-			}
-		}
-
-		return ret;
-	}
-
-	/**
-	 * ソート設定キーを取得
-	 * @param section
-	 * @param ed
-	 * @param sortKey
-	 * @return
-	 */
-	private String getSortSettingKey(MassReferenceSection section, EntityDefinition ed, String sortKey) {
-		String ret = sortKey;
-		if (StringUtil.isBlank(ret)) {
-			ret =  Entity.OID;
-		}
-		PropertyDefinition pd = ed.getProperty(ret);
-		if (pd == null) {
-			ret = Entity.OID;
-			pd = ed.getProperty(ret);
-		}
-		if (pd instanceof ReferenceProperty) {
-			NestProperty property = getLayoutNestProperty(section, sortKey);
-			// 当該項目がセクション上表示される場合は、セクション上の表示項目でソート
-			if (property != null) {
-				ret = sortKey + "." + getDisplayNestProperty(property);
+			} else if (property.getEditor() != null && property.getEditor() instanceof ReferencePropertyEditor
+				&& !((ReferencePropertyEditor) property.getEditor()).getNestProperties().isEmpty()) {
+				// キーに差分がある、かつネスト項目ある場合は、ネスト項目の存在確認
+				int dotIndex = sortKey.indexOf(".");
+				String subPropName = sortKey.substring(dotIndex + 1);
+				NestProperty subProp = getSubProperty(subPropName, property);
+				if (subProp == null) {
+					ret = sortKey + "." + Entity.NAME;
+				}
 			} else {
-				// セクション上に表示されない場合は、Nameでソート
 				ret = sortKey + "." + Entity.NAME;
 			}
 		}
+
 		return ret;
 	}
 
@@ -789,6 +770,11 @@ public final class GetMassReferencesCommand extends DetailCommandBase implements
 	}
 
 	private NestProperty getLayoutNestProperty(MassReferenceSection section, String propName) {
+		int dotIndex = propName.indexOf(".");
+		if (dotIndex > -1) {
+			return getLayoutNestProperty(section, propName.substring(0, dotIndex));
+		}
+
 		Optional<NestProperty> property = section.getProperties().stream()
 				.filter(e -> propName.equals(e.getPropertyName())).findFirst();
 		if (property.isPresent()) {
@@ -811,6 +797,33 @@ public final class GetMassReferencesCommand extends DetailCommandBase implements
 			return Entity.NAME;
 		}
 		
+	}
+
+	private NestProperty getSubProperty(String propertyName, NestProperty nestProperty) {
+		ReferencePropertyEditor rpe = (ReferencePropertyEditor) nestProperty.getEditor();
+	
+		int dotIndex = propertyName.indexOf(".");
+		if (dotIndex > -1) {
+			// 子階層を再帰呼び出し
+			String topPropName = propertyName.substring(0, dotIndex);
+			String subPropName = propertyName.substring(dotIndex + 1);
+	
+			Optional<NestProperty> opt = rpe.getNestProperties().stream()
+					.filter(np -> np.getPropertyName().equals(topPropName)).findFirst();
+			if (!opt.isPresent()) return null;
+	
+			NestProperty subProp = opt.get();
+			if (subProp.getEditor() instanceof ReferencePropertyEditor
+					&& !((ReferencePropertyEditor) subProp.getEditor()).getNestProperties().isEmpty()) {
+				return getSubProperty(subPropName, opt.get());
+			}
+	
+			return null;
+		}
+	
+		// 一致するNestPropetyを取得
+		Optional<NestProperty> opt = rpe.getNestProperties().stream().filter(np -> np.getPropertyName().equals(propertyName)).findFirst();
+		return opt.orElse(null);
 	}
 
 	/**

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/GetMassReferencesCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/GetMassReferencesCommand.java
@@ -322,28 +322,14 @@ public final class GetMassReferencesCommand extends DetailCommandBase implements
 			return Entity.OID;
 		}
 
-		PropertyDefinition pd = ed.getProperty(property.getPropertyName());
+		PropertyDefinition pd = getPropertyDefinition(ed, sortKey);
 		if (pd == null) {
 			ret = Entity.OID;
 			pd = ed.getProperty(ret);
 		}
 
 		if (pd instanceof ReferenceProperty) {
-			// 当該項目がセクション上表示される場合は、セクション上の表示項目でソート
-			if (property.getPropertyName().equals(sortKey)) {
-				ret = sortKey + "." + getDisplayNestProperty(property);
-			} else if (property.getEditor() != null && property.getEditor() instanceof ReferencePropertyEditor
-				&& !((ReferencePropertyEditor) property.getEditor()).getNestProperties().isEmpty()) {
-				// キーに差分がある、かつネスト項目ある場合は、ネスト項目の存在確認
-				int dotIndex = sortKey.indexOf(".");
-				String subPropName = sortKey.substring(dotIndex + 1);
-				NestProperty subProp = getSubProperty(subPropName, property);
-				if (subProp == null) {
-					ret = sortKey + "." + Entity.NAME;
-				}
-			} else {
-				ret = sortKey + "." + Entity.NAME;
-			}
+			ret = sortKey + "." + getDisplayNestProperty(property);
 		}
 
 		return ret;
@@ -770,19 +756,60 @@ public final class GetMassReferencesCommand extends DetailCommandBase implements
 	}
 
 	private NestProperty getLayoutNestProperty(MassReferenceSection section, String propName) {
-		int dotIndex = propName.indexOf(".");
-		if (dotIndex > -1) {
-			return getLayoutNestProperty(section, propName.substring(0, dotIndex));
-		}
-
+		// 直下に指定されているかチェック
 		Optional<NestProperty> property = section.getProperties().stream()
 				.filter(e -> propName.equals(e.getPropertyName())).findFirst();
 		if (property.isPresent()) {
 			return property.get();
 		}
+
+		// プロパティ名で一致する列がない場合、参照の各階層をチェック
+		int dotIndex = propName.indexOf(".");
+		if (dotIndex > -1) {
+			String topPropName = propName.substring(0, dotIndex);
+			String subPropName = propName.substring(dotIndex + 1);
+
+			// セクション直下を取得
+			Optional<NestProperty> opt = section.getProperties().stream()
+					.filter(np -> np.getPropertyName().equals(topPropName)).findFirst();
+			if (!opt.isPresent()) return null;
+
+			// 参照の先の項目を取得
+			NestProperty subProp = opt.get();
+			if (subProp.getEditor() instanceof ReferencePropertyEditor) {
+				return getSubProperty(subPropName, ((ReferencePropertyEditor) subProp.getEditor()).getNestProperties());
+			}
+		}
+		
 		return null;
 	}
-	
+
+	private NestProperty getSubProperty(String propName, List<NestProperty> properties) {
+		if (properties == null || properties.isEmpty()) {
+			return null;
+		}
+
+		int dotIndex = propName.indexOf(".");
+		if (dotIndex > -1) {
+			// 子階層を再帰呼び出し
+			String topPropName = propName.substring(0, dotIndex);
+			String subPropName = propName.substring(dotIndex + 1);
+
+			Optional<NestProperty> opt = properties.stream()
+					.filter(np -> np.getPropertyName().equals(topPropName)).findFirst();
+			if (!opt.isPresent()) return null;
+
+			NestProperty subProp = opt.get();
+			if (subProp.getEditor() instanceof ReferencePropertyEditor) {
+				return getSubProperty(subPropName, ((ReferencePropertyEditor) subProp.getEditor()).getNestProperties());
+			}
+		}
+
+		// 一致するNestPropetyを取得
+		Optional<NestProperty> opt = properties.stream().filter(np -> np.getPropertyName().equals(propName)).findFirst();
+		return opt.orElse(null);
+	}
+
 	/**
 	 * 参照プロパティで、セクションに表示されている項目を取得します。
 	 * @return 表示項目
@@ -799,31 +826,23 @@ public final class GetMassReferencesCommand extends DetailCommandBase implements
 		
 	}
 
-	private NestProperty getSubProperty(String propertyName, NestProperty nestProperty) {
-		ReferencePropertyEditor rpe = (ReferencePropertyEditor) nestProperty.getEditor();
-	
-		int dotIndex = propertyName.indexOf(".");
-		if (dotIndex > -1) {
-			// 子階層を再帰呼び出し
-			String topPropName = propertyName.substring(0, dotIndex);
-			String subPropName = propertyName.substring(dotIndex + 1);
-	
-			Optional<NestProperty> opt = rpe.getNestProperties().stream()
-					.filter(np -> np.getPropertyName().equals(topPropName)).findFirst();
-			if (!opt.isPresent()) return null;
-	
-			NestProperty subProp = opt.get();
-			if (subProp.getEditor() instanceof ReferencePropertyEditor
-					&& !((ReferencePropertyEditor) subProp.getEditor()).getNestProperties().isEmpty()) {
-				return getSubProperty(subPropName, opt.get());
+	private PropertyDefinition getPropertyDefinition(EntityDefinition definition, String propName) {
+		int firstDotIndex = propName.indexOf('.');
+		if (firstDotIndex > 0) {
+			String topPropName = propName.substring(0, firstDotIndex);
+			String subPropName = propName.substring(firstDotIndex + 1);
+			PropertyDefinition topProperty = definition.getProperty(topPropName);
+			if (topProperty instanceof ReferenceProperty) {
+				EntityDefinition red = getReferenceEntityDefinition((ReferenceProperty) topProperty);
+				if (red != null) {
+					PropertyDefinition pd = getPropertyDefinition(red, subPropName);
+					return pd;
+				}
 			}
-	
-			return null;
+		} else {
+			return definition.getProperty(propName);
 		}
-	
-		// 一致するNestPropetyを取得
-		Optional<NestProperty> opt = rpe.getNestProperties().stream().filter(np -> np.getPropertyName().equals(propertyName)).findFirst();
-		return opt.orElse(null);
+		return null;
 	}
 
 	/**

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
@@ -427,9 +427,9 @@ public abstract class SearchContextBase implements SearchContext, CreateSearchRe
 	 * @return
 	 */
 	private NestProperty getLayoutNestProperty(PropertyColumn property, String propName) {
-		int dotIndex = propName.indexOf(".");
+		int dotIndex = propName.indexOf(property.getPropertyName() + ".");
 		if (dotIndex > -1) {
-			return getLayoutNestProperty(property, propName.substring(0, dotIndex));
+			return getLayoutNestProperty(property, propName.substring(dotIndex + property.getPropertyName().length() + 1));
 		}
 
 		if (property.getEditor() == null || !(property.getEditor() instanceof ReferencePropertyEditor)

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
@@ -233,7 +233,14 @@ public abstract class SearchContextBase implements SearchContext, CreateSearchRe
 					PropertyColumn property = getLayoutPropertyColumn(sortKey);
 					// 当該項目が画面上表示される場合は、画面上の表示項目でソート
 					if (property != null) {
-						sortKey = sortKey + "." + getDisplayNestProperty(property);
+						if (property.getPropertyName().equals(sortKey)) {
+							sortKey = sortKey + "." + getDisplayNestProperty(property);
+						} else if (!existNestProperty(property, sortKey)) {
+							// プロパティ名とキーに差分がある、かつネスト項目ある場合は、ネスト項目の存在確認、ネストがなければNameでソート
+							sortKey = property.getPropertyName() + "." + Entity.NAME;
+						} else {
+							sortKey = sortKey + "." + Entity.NAME;
+						}
 					} else {
 						// 画面上に表示されない場合は、Nameでソート
 						sortKey = sortKey + "." + Entity.NAME;
@@ -257,7 +264,14 @@ public abstract class SearchContextBase implements SearchContext, CreateSearchRe
 						PropertyDefinition pd = getPropertyDefinition(sortKey);
 						// 参照プロパティの場合、画面上の表示項目でソート
 						if (pd instanceof ReferenceProperty) {
-							sortKey = sortKey + "." + getDisplayNestProperty(property);
+							if (property.getPropertyName().equals(sortKey)) {
+								sortKey = sortKey + "." + getDisplayNestProperty(property);
+							} else if (!existNestProperty(property, sortKey)) {
+								// プロパティ名とキーに差分がある、かつネスト項目ある場合は、ネスト項目の存在確認、ネストがなければNameでソート
+								sortKey = property.getPropertyName() + "." + Entity.NAME;
+							} else {
+								sortKey = sortKey + "." + Entity.NAME;
+							}
 						}
 						NullOrderingSpec nullOrderingSpec = getNullOrderingSpec(property.getNullOrderType());
 						orderBy = new OrderBy();
@@ -268,6 +282,7 @@ public abstract class SearchContextBase implements SearchContext, CreateSearchRe
 		}
 		return orderBy;
 	}
+
 	@Override
 	public Limit getLimit() {
 		Limit limit = new Limit(getSearchLimit(), getOffset());
@@ -395,7 +410,95 @@ public abstract class SearchContextBase implements SearchContext, CreateSearchRe
 		if (property.isPresent()) {
 			return property.get();
 		}
+
+		// プロパティ名で一致する列がない場合、参照の各階層を下からチェック
+		int dotIndex = propName.lastIndexOf(".");
+		if (dotIndex > -1) {
+			return getLayoutPropertyColumn(propName.substring(0, dotIndex));
+		}
+
 		return null;
+	}
+
+	/**
+	 * プロパティからNestPropertyを取得
+	 * @param property
+	 * @param propName
+	 * @return
+	 */
+	private NestProperty getLayoutNestProperty(PropertyColumn property, String propName) {
+		int dotIndex = propName.indexOf(".");
+		if (dotIndex > -1) {
+			return getLayoutNestProperty(property, propName.substring(0, dotIndex));
+		}
+
+		if (property.getEditor() == null || !(property.getEditor() instanceof ReferencePropertyEditor)
+				|| ((ReferencePropertyEditor) property.getEditor()).getNestProperties().isEmpty()) {
+			return null;
+		}
+
+		ReferencePropertyEditor rp = (ReferencePropertyEditor) property.getEditor();
+		Optional<NestProperty> np = rp.getNestProperties().stream()
+				.filter(e -> propName.equals(e.getPropertyName())).findFirst();
+		if (np.isPresent()) {
+			return np.get();
+		}
+		return null;
+	}
+	
+	/**
+	 * プロパティに指定の名前のNestPropertyが存在するか
+	 * @param property プロパティ
+	 * @param checkName チェック対象の名前
+	 * @return 存在する場合true
+	 */
+	private boolean existNestProperty(PropertyColumn property, String checkName) {
+		if (property.getEditor() != null && property.getEditor() instanceof ReferencePropertyEditor) {
+			return false;
+		}
+	
+		ReferencePropertyEditor editor = (ReferencePropertyEditor) property.getEditor();
+		if (editor.getNestProperties().isEmpty()) {
+			return false;
+		}
+	
+		NestProperty np = getLayoutNestProperty(property, checkName);
+		if (np == null) {
+			return false;
+		}
+	
+		int dotIndex = checkName.indexOf(".");
+		String subPropName = checkName.substring(dotIndex + 1);
+		NestProperty subProp = getSubProperty(subPropName, np);
+	
+		return subProp != null;
+	}
+
+	private NestProperty getSubProperty(String propertyName, NestProperty nestProperty) {
+		ReferencePropertyEditor rpe = (ReferencePropertyEditor) nestProperty.getEditor();
+	
+		int dotIndex = propertyName.indexOf(".");
+		if (dotIndex > -1) {
+			// 子階層を再帰呼び出し
+			String topPropName = propertyName.substring(0, dotIndex);
+			String subPropName = propertyName.substring(dotIndex + 1);
+	
+			Optional<NestProperty> opt = rpe.getNestProperties().stream()
+					.filter(np -> np.getPropertyName().equals(topPropName)).findFirst();
+			if (!opt.isPresent()) return null;
+	
+			NestProperty subProp = opt.get();
+			if (subProp.getEditor() instanceof ReferencePropertyEditor
+					&& !((ReferencePropertyEditor) subProp.getEditor()).getNestProperties().isEmpty()) {
+				return getSubProperty(subPropName, opt.get());
+			}
+	
+			return null;
+		}
+	
+		// 一致するNestPropetyを取得
+		Optional<NestProperty> opt = rpe.getNestProperties().stream().filter(np -> np.getPropertyName().equals(propertyName)).findFirst();
+		return opt.orElse(null);
 	}
 
 	/**
@@ -418,6 +521,7 @@ public abstract class SearchContextBase implements SearchContext, CreateSearchRe
 	protected String getViewName() {
 		return request.getParam(Constants.VIEW_NAME);
 	}
+
 	/**
 	 * リクエストからソートキーを取得します。
 	 * ソートキーが指定されていない場合は、検索画面のデフォルトソートキーを取得します。
@@ -495,19 +599,31 @@ public abstract class SearchContextBase implements SearchContext, CreateSearchRe
 			PropertyColumn property = getLayoutPropertyColumn(sortKey);
 			// SearchResultに定義されているPropertyのみ許可
 			if (property != null) {
-				SortSetting ss = new SortSetting();
-				ss.setSortKey(sortKey);
-
-				String sortType = getRequest().getParam(Constants.SEARCH_SORTTYPE);
-				if (StringUtil.isBlank(sortType)) {
-					ss.setSortType(ConditionSortType.DESC);
+				SortSetting ss = null;
+				if (property.getPropertyName().equals(sortKey)) {
+					ss = new SortSetting();
+					ss.setSortKey(sortKey);
 				} else {
-					ss.setSortType(ConditionSortType.valueOf(sortType));
+					// ネストの存在確認
+					NestProperty np = getLayoutNestProperty(property, sortKey);
+					if (np != null) {
+						ss = new SortSetting();
+						ss.setSortKey(sortKey);
+					}
 				}
-
-				ss.setNullOrderType(property.getNullOrderType());
-
-				setting.add(ss);
+				
+				if (ss != null) {
+					String sortType = getRequest().getParam(Constants.SEARCH_SORTTYPE);
+					if (StringUtil.isBlank(sortType)) {
+						ss.setSortType(ConditionSortType.DESC);
+					} else {
+						ss.setSortType(ConditionSortType.valueOf(sortType));
+					}
+	
+					ss.setNullOrderType(property.getNullOrderType());
+	
+					setting.add(ss);
+				}
 			}
 		}
 


### PR DESCRIPTION
## 対応内容
ソート時に大量データ参照セクション、検索結果の表示プロパティまでしかソート対象としてチェックしていなかったのを、ReferencePropertyEditorの表示プロパティまでチェックするよう修正

close #1588
