### PR TITLE
JakartaEE10/Tomcat10.1、Java 21対応 - Javadoc 生成できない

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,8 @@ subprojects { subproject ->
 		options.memberLevel = 'PACKAGE'
 		options.jFlags "-Duser.language=${javadocLang}"
 
+		classpath += project.sourceSets['main'].compileClasspath
+
 		// https://issues.gradle.org/browse/GRADLE-1228
 		if (System.properties['http.proxyHost'] != null ) {
 			options.jFlags(

--- a/sharedlibs.gradle
+++ b/sharedlibs.gradle
@@ -304,11 +304,7 @@ dependencies {
 	jakartaImplRest 'org.glassfish.jersey.media:jersey-media-json-jackson'
 	jakartaImplRest 'org.glassfish.jersey.media:jersey-media-multipart'
 	jakartaImplRest 'org.glassfish.jersey.inject:jersey-hk2'
+	jakartaImplRest platform(sharedLib('com.fasterxml.jackson:jackson-bom'))
 	jakartaImplRest 'com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider'
 	//jakartaImplAnnotations
-
-
-	// Jakarta EE 10 runtime for tomcat10.1
-	// jackson management
-	jeeruntime4tomcat platform(sharedLib('com.fasterxml.jackson:jackson-bom'))
 }


### PR DESCRIPTION
## 対応内容
- JavaDoc 生成時に classpath を設定しないと出力できない問題の対応
- jackson-bom の依存関係を jakartaImplRest に追加、jeeruntime4tomcat から削除

## 動作確認・スクリーンショット（任意）
- Javadoc 生成実行（ `.\gradlew.bat javadocI18n` )

## レビュー観点・補足情報（任意）
特になし