### PR TITLE
Entity CRUD WebAPI：csv形式で結果取得の際にfooter行を出力可能にするの対応

### DIFF
--- a/iplass-core/src/main/java/org/iplass/mtp/impl/entity/csv/EntityCsvWriter.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/entity/csv/EntityCsvWriter.java
@@ -559,5 +559,13 @@ public class EntityCsvWriter implements AutoCloseable, Flushable {
 		return timeFormat;
 
 	}
+	
+	public void writeFooter(String csvDownloadFooter) {
+		try {
+			writer.write(csvDownloadFooter);
+		} catch (IOException e) {
+			throw new EntityCsvException(e);
+		}
+	}
 
 }

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/entity/csv/EntitySearchCsvWriter.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/entity/csv/EntitySearchCsvWriter.java
@@ -374,5 +374,9 @@ public class EntitySearchCsvWriter implements AutoCloseable {
 		}
 
 	}
+	
+	public void writeFooter(String csvDownloadFooter) {
+		writer.writeFooter(csvDownloadFooter);
+	}
 
 }

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/entity/csv/QueryCsvWriter.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/entity/csv/QueryCsvWriter.java
@@ -56,7 +56,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * <p>QueryのCsvファイル出力クラス</p>
+ * <p>
+ * QueryのCsvファイル出力クラス
+ * </p>
  */
 public class QueryCsvWriter implements AutoCloseable {
 
@@ -94,7 +96,7 @@ public class QueryCsvWriter implements AutoCloseable {
 
 	public int write() throws IOException {
 
-		//Header出力
+		// Header出力
 		writeHeader();
 
 		// CSV レコードを出力
@@ -145,7 +147,7 @@ public class QueryCsvWriter implements AutoCloseable {
 		IntStream.range(0, values.length).forEach(i -> {
 			Object value = values[i];
 			if (value != null && value.getClass().isArray()) {
-				Object[] array = (Object[])value;
+				Object[] array = (Object[]) value;
 				List<String> valueList = new ArrayList<>();
 				for (int j = 0; j < array.length; j++) {
 					if (array[j] != null) {
@@ -178,7 +180,7 @@ public class QueryCsvWriter implements AutoCloseable {
 			return;
 		}
 
-		//BOM対応
+		// BOM対応
 		if ("UTF-8".equalsIgnoreCase(option.getCharset())) {
 			try {
 				writer.write(BOM);
@@ -223,33 +225,33 @@ public class QueryCsvWriter implements AutoCloseable {
 		}
 
 		if (value instanceof BigDecimal) {
-			BigDecimal bd = (BigDecimal)value;
+			BigDecimal bd = (BigDecimal) value;
 			return bd.toPlainString();
 		} else if (value instanceof Double) {
-			BigDecimal bd = BigDecimal.valueOf((Double)value);
+			BigDecimal bd = BigDecimal.valueOf((Double) value);
 			return bd.toPlainString();
 		} else if (value instanceof Float) {
-			BigDecimal bd = BigDecimal.valueOf((Float)value);
+			BigDecimal bd = BigDecimal.valueOf((Float) value);
 			return bd.toPlainString();
 		} else if (value instanceof Boolean) {
-			Boolean b = (Boolean)value;
+			Boolean b = (Boolean) value;
 			return b.booleanValue() ? "1" : "0";
 		} else if (value instanceof SelectValue) {
-			SelectValue sv = (SelectValue)value;
+			SelectValue sv = (SelectValue) value;
 			return sv.getValue();
 		} else if (value instanceof BinaryReference) {
-			BinaryReference br = (BinaryReference)value;
+			BinaryReference br = (BinaryReference) value;
 			Map<String, String> valueMap = new LinkedHashMap<>();
 			valueMap.put("lobid", String.valueOf((br.getLobId())));
 			valueMap.put("name", br.getName());
 			valueMap.put("type", br.getType());
 			return toJsonString(valueMap);
 		} else if (value instanceof java.sql.Date) {
-			return DateUtil.getSimpleDateFormat(getDateFormat(), false).format((java.sql.Date)value);
+			return DateUtil.getSimpleDateFormat(getDateFormat(), false).format((java.sql.Date) value);
 		} else if (value instanceof Timestamp) {
-			return DateUtil.getSimpleDateFormat(getDateTimeFormat(), false).format((Timestamp)value);
+			return DateUtil.getSimpleDateFormat(getDateTimeFormat(), false).format((Timestamp) value);
 		} else if (value instanceof Time) {
-			return DateUtil.getSimpleDateFormat(getTimeFormat(), false).format((Time)value);
+			return DateUtil.getSimpleDateFormat(getTimeFormat(), false).format((Time) value);
 		} else {
 			return value.toString();
 		}
@@ -259,8 +261,9 @@ public class QueryCsvWriter implements AutoCloseable {
 
 		if (mapper == null) {
 			mapper = new ObjectMapper();
-			//for backward compatibility
-			mapper.configOverride(java.sql.Date.class).setFormat(JsonFormat.Value.forPattern("yyyy-MM-dd").withTimeZone(TimeZone.getDefault()));
+			// for backward compatibility
+			mapper.configOverride(java.sql.Date.class)
+					.setFormat(JsonFormat.Value.forPattern("yyyy-MM-dd").withTimeZone(TimeZone.getDefault()));
 		}
 		try (StringWriter writer = new StringWriter()) {
 			mapper.writeValue(writer, value);
@@ -354,6 +357,15 @@ public class QueryCsvWriter implements AutoCloseable {
 		}
 		return timeFormat;
 
+	}
+
+	public void writeFooter(String csvDownloadFooter) {
+		try {
+			writer.write(csvDownloadFooter);
+		} catch (IOException e) {
+			throw new EntityCsvException(e);
+		}
+		newLine();
 	}
 
 }

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/EntityWebApiService.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/EntityWebApiService.java
@@ -64,6 +64,7 @@ public class EntityWebApiService extends AbstractTypedMetaDataService<MetaEntity
 	private String csvDateTimeFormat;
 	private String csvDateFormat;
 	private String csvTimeFormat;
+	private String csvDownloadFooter;
 	
 	private boolean enableNativeHint;
 
@@ -113,6 +114,10 @@ public class EntityWebApiService extends AbstractTypedMetaDataService<MetaEntity
 	public String getCsvTimeFormat() {
 		return csvTimeFormat;
 	}
+	
+	public String getCsvDownloadFooter() {
+		return csvDownloadFooter;
+	}
 
 	/**
 	 * EntityCRUD APIで制御オプションが許可されたロールか
@@ -147,6 +152,7 @@ public class EntityWebApiService extends AbstractTypedMetaDataService<MetaEntity
 		csvDateTimeFormat = config.getValue("csvDateTimeFormat", String.class, null);
 		csvDateFormat = config.getValue("csvDateFormat", String.class, null);
 		csvTimeFormat = config.getValue("csvTimeFormat", String.class, null);
+		csvDownloadFooter = config.getValue("csvDownloadFooter", String.class, null);
 		
 		listWithMappedByReference = config.getValue("listWithMappedByReference", Boolean.TYPE, Boolean.FALSE).booleanValue();
 		

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/command/entity/GetEntityCommand.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/command/entity/GetEntityCommand.java
@@ -73,19 +73,16 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@WebApi(name="mtp/entity/GET",
-		accepts={RequestType.REST_FORM},
-		methods={MethodType.GET},
-		results={GetEntityCommand.RESULT_ENTITY_LIST, GetEntityCommand.RESULT_COUNT, GetEntityCommand.RESULT_ENTITY,
-				GetEntityCommand.RESULT_CSV, GetEntityCommand.RESULT_JSON, GetEntityCommand.RESULT_XML},
-		responseType="application/json, application/xml, text/csv;charset=utf-8",
-		supportBearerToken = true,
-		overwritable=false)
-@CommandClass(name="mtp/entity/GetEntityCommand", displayName="Entity Query/Load Web API", overwritable=false)
+@WebApi(name = "mtp/entity/GET", accepts = { RequestType.REST_FORM }, methods = { MethodType.GET }, results = {
+		GetEntityCommand.RESULT_ENTITY_LIST, GetEntityCommand.RESULT_COUNT, GetEntityCommand.RESULT_ENTITY,
+		GetEntityCommand.RESULT_CSV, GetEntityCommand.RESULT_JSON,
+		GetEntityCommand.RESULT_XML }, responseType = "application/json, application/xml, text/csv;charset=utf-8", supportBearerToken = true, overwritable = false)
+@CommandClass(name = "mtp/entity/GetEntityCommand", displayName = "Entity Query/Load Web API", overwritable = false)
 public final class GetEntityCommand extends AbstractEntityCommand {
 	private static final Logger logger = LoggerFactory.getLogger(GetEntityCommand.class);
 
 	public static final String PARAM_QUERY = "query";
+	public static final String CSV_DOWNLOAD_WITH_FOOTER = "csvDownloadWithFooter";
 	public static final String PARAM_TABLE_MODE = "tabular";
 	public static final String PARAM_COUNT_TOTAL = "countTotal";
 	public static final String PARAM_FILTER = "filter";
@@ -98,12 +95,8 @@ public final class GetEntityCommand extends AbstractEntityCommand {
 	public static final String RESULT_JSON = "json";
 	public static final String RESULT_XML = "xml";
 
-
 	private enum ResType {
-		CSV,
-		JSON,
-		XML,
-		OTHER
+		CSV, JSON, XML, OTHER
 	}
 
 	private final JAXBContext context;
@@ -134,7 +127,7 @@ public final class GetEntityCommand extends AbstractEntityCommand {
 		Element element = doc.getDocumentElement();
 		NamedNodeMap namedNodeMap = element.getAttributes();
 
-		for(int i=0;i<namedNodeMap.getLength();i++) {
+		for (int i = 0; i < namedNodeMap.getLength(); i++) {
 			String[] str = namedNodeMap.item(i).getNodeName().split(":");
 			nameSpaceMap.put(str[1], namedNodeMap.item(i).getNodeValue());
 		}
@@ -155,7 +148,8 @@ public final class GetEntityCommand extends AbstractEntityCommand {
 	private void list(String entityDef, RequestContext request) {
 		ResType resType = resType(request);
 		boolean withMappedBy = withMappedByReference(request,
-				resType == ResType.CSV ? entityWebApiService.isCsvListWithMappedByReference(): entityWebApiService.isListWithMappedByReference());
+				resType == ResType.CSV ? entityWebApiService.isCsvListWithMappedByReference()
+						: entityWebApiService.isListWithMappedByReference());
 		Query query = new Query().selectAll(entityDef, false, true, false, withMappedBy);
 		String filter = request.getParam(PARAM_FILTER);
 		if (filter != null) {
@@ -165,7 +159,8 @@ public final class GetEntityCommand extends AbstractEntityCommand {
 		queryImpl(query, request, false, resType, withMappedBy);
 	}
 
-	private void queryImpl(Query query, RequestContext request, boolean byQuery, ResType resType, boolean withMappedBy) {
+	private void queryImpl(Query query, RequestContext request, boolean byQuery, ResType resType,
+			boolean withMappedBy) {
 
 		checkPermission(query.getFrom().getEntityName(), def -> def.getMetaData().isQuery());
 
@@ -175,7 +170,7 @@ public final class GetEntityCommand extends AbstractEntityCommand {
 				public boolean visit(HintComment hintComment) {
 					if (hintComment.getHintList() != null) {
 						List<Hint> checked = new ArrayList<>();
-						for (Hint h: hintComment.getHintList()) {
+						for (Hint h : hintComment.getHintList()) {
 							if (h instanceof NativeHint) {
 								logger.warn("Native Hint is disable at Entity Web API, so remove hint: " + h);
 							} else {
@@ -235,10 +230,10 @@ public final class GetEntityCommand extends AbstractEntityCommand {
 
 		SearchResult<?> res = em.searchEntity(query, option);
 
-		if (entityWebApiService.isThrowSearchResultLimitExceededException()
-				&& noLimit
+		if (entityWebApiService.isThrowSearchResultLimitExceededException() && noLimit
 				&& res.getTotalCount() > entityWebApiService.getMaxLimit()) {
-			throw new SearchResultLimitExceededException(resourceString("impl.webapi.command.entity.GetEntityCommand.limitExceeded"));
+			throw new SearchResultLimitExceededException(
+					resourceString("impl.webapi.command.entity.GetEntityCommand.limitExceeded"));
 		}
 
 		request.setAttribute(RESULT_ENTITY_LIST, res.getList());
@@ -258,7 +253,12 @@ public final class GetEntityCommand extends AbstractEntityCommand {
 			option.setTimeSecFormat(entityWebApiService.getCsvTimeFormat());
 			try (QueryCsvWriter writer = new QueryCsvWriter(out, query, option)) {
 				writer.write();
+				if (request.getParam(CSV_DOWNLOAD_WITH_FOOTER, Boolean.class, false)) {
+					writer.writeFooter(entityWebApiService.getCsvDownloadFooter());
+				}
+
 			}
+
 		};
 		request.setAttribute(RESULT_CSV, stream);
 	}
@@ -267,19 +267,21 @@ public final class GetEntityCommand extends AbstractEntityCommand {
 
 		CsvUploadService csvUploadService = ServiceRegistry.getRegistry().getService(CsvUploadService.class);
 
-		//TODO EntitySearchCsvWriter使う場合、queryのselect項目利用できず再度EntitySearchCsvWriterで項目選択させる必要あり、、
+		// TODO
+		// EntitySearchCsvWriter使う場合、queryのselect項目利用できず再度EntitySearchCsvWriterで項目選択させる必要あり、、
 		StreamingOutput stream = out -> {
 
-			EntityWriteOption option = new EntityWriteOption()
-					.where(query.getWhere())
-					.orderBy(query.getOrderBy())
+			EntityWriteOption option = new EntityWriteOption().where(query.getWhere()).orderBy(query.getOrderBy())
 					.dateFormat(entityWebApiService.getCsvDateFormat())
 					.datetimeSecFormat(entityWebApiService.getCsvDateTimeFormat())
-					.timeSecFormat(entityWebApiService.getCsvTimeFormat())
-					.withMappedByReference(withMappedBy)
+					.timeSecFormat(entityWebApiService.getCsvTimeFormat()).withMappedByReference(withMappedBy)
 					.mustOrderByWithLimit(csvUploadService.isMustOrderByWithLimit());
-			try (EntitySearchCsvWriter writer = new EntitySearchCsvWriter(out, query.getFrom().getEntityName(), option)) {
+			try (EntitySearchCsvWriter writer = new EntitySearchCsvWriter(out, query.getFrom().getEntityName(),
+					option)) {
 				writer.write();
+				if (request.getParam(CSV_DOWNLOAD_WITH_FOOTER, Boolean.class, false)) {
+					writer.writeFooter(entityWebApiService.getCsvDownloadFooter());
+				}
 			}
 		};
 		request.setAttribute(RESULT_CSV, stream);
@@ -296,11 +298,12 @@ public final class GetEntityCommand extends AbstractEntityCommand {
 		request.setAttribute(RESULT_JSON, stream);
 	}
 
-	private void queryXml(Query query, RequestContext request,  boolean countTotal) {
+	private void queryXml(Query query, RequestContext request, boolean countTotal) {
 
 		StreamingOutput stream = out -> {
 
-			try (QueryXmlWriter writer = new QueryXmlWriter(out, query, countTotal, context, nameSpaceMap, new DateXmlAdapter())) {
+			try (QueryXmlWriter writer = new QueryXmlWriter(out, query, countTotal, context, nameSpaceMap,
+					new DateXmlAdapter())) {
 				writer.write();
 			}
 		};
@@ -308,7 +311,8 @@ public final class GetEntityCommand extends AbstractEntityCommand {
 	}
 
 	private ResType resType(RequestContext request) {
-		String accept = ((HttpServletRequest) request.getAttribute(WebApiRequestConstants.SERVLET_REQUEST)).getHeader("Accept");
+		String accept = ((HttpServletRequest) request.getAttribute(WebApiRequestConstants.SERVLET_REQUEST))
+				.getHeader("Accept");
 		if (accept != null) {
 			if (accept.startsWith("application/json")) {
 				return ResType.JSON;

--- a/iplass-web/src/main/resources/mtp-web-service-config.xml
+++ b/iplass-web/src/main/resources/mtp-web-service-config.xml
@@ -617,6 +617,8 @@
 	<service>
 		<interface>org.iplass.mtp.impl.webapi.EntityWebApiService</interface>
 		<property name="maxLimit" value="1000" />
+		<!-- Entity CRUD WebAPIのCSVダウンロードのフッター文言 -->
+		<property name="csvDownloadFooter" value=""/>
 		<!-- Date format when returning CSV results in Query search of Entity CRUD API. If not specified, the runtime LocaleFormat  is set -->
 		<!-- 
 		<property name="csvDateTimeFormat" value="yyyy/MM/dd HH:mm:ss" />


### PR DESCRIPTION
## 対応内容
XMLファイル中「csvDownloadFooter」という環境変数を追加します。
Entity CRUD WebAPIを呼び出しの時、もし出力タイプがCSV、かつqueryパラメータにて、csvDownloadWithFooter=trueが指定されたの場合、「csvDownloadFooter」の値はファイルの最後で出力します。

fixes #1519

## 動作確認・スクリーンショット（任意）
1、csvDownloadWithFooter存在かどうか、全部正常に出力できます。
2、データを出力途中、エラー発生する時、footerが出力しない。