### PR TITLE
gem、CSVアップロード、バージョン管理されていて無効データしか存在しない場合に、NEW_VERSIONとして更新できるようにする（3.1）

### DIFF
--- a/iplass-web/src/main/java/org/iplass/mtp/impl/csv/CsvUploadService.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/csv/CsvUploadService.java
@@ -69,6 +69,8 @@ import org.iplass.mtp.entity.definition.properties.BinaryProperty;
 import org.iplass.mtp.entity.definition.properties.ExpressionProperty;
 import org.iplass.mtp.entity.definition.properties.ReferenceProperty;
 import org.iplass.mtp.entity.query.Query;
+import org.iplass.mtp.entity.query.SortSpec;
+import org.iplass.mtp.entity.query.SortSpec.SortType;
 import org.iplass.mtp.entity.query.condition.expr.And;
 import org.iplass.mtp.entity.query.condition.predicate.Equals;
 import org.iplass.mtp.impl.entity.csv.EntityCsvException;
@@ -637,7 +639,7 @@ public class CsvUploadService implements Service {
 							throw new ApplicationException(resourceString("impl.csv.CsvUploadService.denyUpdateError"));
 						}
 						em.update(entity, updateOption(TargetVersion.SPECIFIC));
-						//TODO storedTempOidMapを呼んでないが平気か？？？？？？
+						keyValueMap.put(uniqueKeyValue, entity.getOid());
 						updateCount++;
 						break;
 					case UPDATE_VALID:
@@ -652,7 +654,6 @@ public class CsvUploadService implements Service {
 						if(isDenyUpdate) {
 							throw new ApplicationException(resourceString("impl.csv.CsvUploadService.denyUpdateError"));
 						}
-						entity.setVersion(null);
 						em.update(entity, updateOption(TargetVersion.NEW));
 						keyValueMap.put(uniqueKeyValue, entity.getOid());
 						updateCount++;
@@ -685,37 +686,35 @@ public class CsvUploadService implements Service {
 			} else {
 				if (ed.getVersionControlType() != VersionControlType.NONE) {
 					// バージョン管理している
+
 					if (keyValueMap.containsKey(uniqueKeyValue)) {
-						execType = ExecType.UPDATE_NEW;
+						// 既にOIDはCSVの前行までに登録、更新済の状態
+
+						// UniqueKeyで指定している場合、またはINSERT時のOID採番値で置き換え(INSERT時はCSVのOIDとは異なる値で登録される)
 						entity.setOid(keyValueMap.get(uniqueKeyValue));
-					} else {
-						if (entity.getVersion() != null) {
-							Query q = onVersionQuery(ed.getName(), Entity.OID, uniqueKeyValue, entity.getVersion());
-							int count = em.count(q);
-							if (count > 0) {
-								execType = ExecType.UPDATE_SPECIFIC;
-							} else {
-								SearchResult<Entity> searchResult
-									= em.searchEntity(noVersionQuery(ed.getName(), uniqueKey, uniqueKeyValue), new SearchOption().countTotal());
-								if (searchResult.getTotalCount() > 0) {
-									execType = ExecType.UPDATE_NEW;
-									//UniqueKeyで検索している可能性があるので登録済のOIDをセット
-									entity.setOid(searchResult.getFirst().getOid());
-								} else {
-									execType = ExecType.INSERT;
-								}
-							}
+
+						// UniqueKeyを登録されているOIDにスイッチ
+						uniqueKey = Entity.OID;
+						uniqueKeyValue = entity.getOid();
+					}
+
+					if (entity.getVersion() != null) {
+						// 全バージョン含めて登録済のバージョンデータを検索
+						Query versionedQuery = onVersionQuery(ed.getName(), uniqueKey, uniqueKeyValue, entity.getVersion());
+						SearchResult<Entity> versionedResult = em.searchEntity(versionedQuery, new SearchOption().countTotal());
+						if (versionedResult.getTotalCount() > 0) {
+							// 指定バージョンが存在する場合は対象バージョンを更新
+							execType = ExecType.UPDATE_SPECIFIC;
+
+							// UniqueKeyで検索している可能性があるので登録済のOIDをセット
+							entity.setOid(versionedResult.getFirst().getOid());
 						} else {
-							SearchResult<Entity> searchResult
-								= em.searchEntity(noVersionQuery(ed.getName(), uniqueKey, uniqueKeyValue), new SearchOption().countTotal());
-							if (searchResult.getTotalCount() > 0) {
-								execType = ExecType.UPDATE_NEW;
-								//UniqueKeyで検索している可能性があるので登録済のOIDをセット
-								entity.setOid(searchResult.getFirst().getOid());
-							} else {
-								execType = ExecType.INSERT;
-							}
+							// Oidの登録状態で実行タイプを決定
+							execType = versionedExecType(ed, uniqueKey, uniqueKeyValue, entity);
 						}
+					} else {
+						// Oidの登録状態で実行タイプを決定
+						execType = versionedExecType(ed, uniqueKey, uniqueKeyValue, entity);
 					}
 				} else {
 					// バージョン管理していない
@@ -723,11 +722,50 @@ public class CsvUploadService implements Service {
 						= em.searchEntity(noVersionQuery(ed.getName(), uniqueKey, uniqueKeyValue), new SearchOption().countTotal());
 					if (searchResult.getTotalCount() > 0) {
 						execType = ExecType.UPDATE_VALID;
-						//UniqueKeyで検索している可能性があるので登録済のOIDをセット
+						// UniqueKeyで検索している可能性があるので登録済のOIDをセット
 						entity.setOid(searchResult.getFirst().getOid());
 					} else {
 						execType = ExecType.INSERT;
 					}
+				}
+			}
+
+			return execType;
+		}
+
+		private ExecType versionedExecType(EntityDefinition ed, String uniqueKey, Object uniqueKeyValue, Entity entity) {
+
+			ExecType execType = null;
+
+			// 有効データに登録済OIDが存在するか検索
+			Query validQuery = noVersionQuery(ed.getName(), uniqueKey, uniqueKeyValue);
+			SearchResult<Entity> validResult = em.searchEntity(validQuery, new SearchOption().countTotal());
+			if (validResult.getTotalCount() > 0) {
+				// 有効データに登録済OIDデータが存在する場合は、新しいバージョンとして追加
+				execType = ExecType.UPDATE_NEW;
+
+				// バージョン元として有効データを指定するためバージョンをクリア
+				entity.setVersion(null);
+
+				// UniqueKeyで検索している可能性があるので登録済のOIDをセット
+				entity.setOid(validResult.getFirst().getOid());
+			} else {
+				// 有効データに登録済OIDデータが存在しない場合は、全バージョン含めて登録済OIDデータを検索
+				Query versionedOidQuery = onVersionQuery(ed.getName(), uniqueKey, uniqueKeyValue, null);
+				SearchResult<Entity> versionedOidResult = em.searchEntity(versionedOidQuery, new SearchOption().countTotal());
+				if (versionedOidResult.getTotalCount() > 0) {
+					// 全バージョンに登録済OIDデータが存在する場合は、新しいバージョンとして追加
+					execType = ExecType.UPDATE_NEW;
+
+					// バージョン元として登録済データのMAXバージョンを指定
+					entity.setVersion(versionedOidResult.getFirst().getVersion());
+
+					// UniqueKeyで検索している可能性があるので登録済のOIDをセット
+					entity.setOid(versionedOidResult.getFirst().getOid());
+
+				} else {
+					// 登録済OIDデータが存在しない場合は、新規追加
+					execType = ExecType.INSERT;
 				}
 			}
 
@@ -742,11 +780,17 @@ public class CsvUploadService implements Service {
 		}
 
 		private Query onVersionQuery(String defName, String uniqueKey, Object uniqueKeyValue, Long version) {
-			return new Query()
-					.select(Entity.OID)
-					.from(ed.getName())
-					.where(new And(new Equals(uniqueKey, uniqueKeyValue), new Equals(Entity.VERSION, version)))
+			Query query = new Query()
+					.select(Entity.OID, Entity.VERSION)
+					.from(defName)
+					.order(new SortSpec(Entity.VERSION, SortType.DESC))
 					.versioned(true);
+			if (version != null) {
+				query.where(new And(new Equals(uniqueKey, uniqueKeyValue), new Equals(Entity.VERSION, version)));
+			} else {
+				query.where(new Equals(uniqueKey, uniqueKeyValue));
+			}
+			return query;
 		}
 
 		private UpdateOption updateOption(TargetVersion targetVersion) {


### PR DESCRIPTION
## 対応内容
同じOIDに対して無効データのみのEntityデータに対して、CSVアップロードを利用して、「新しいバージョンとして更新」しようとしても「新規追加」として、別のOIDデータとして登録されてしまう。
登録済の状態を判定する際に、無効データも含めたチェックを行う。
fixes #1625

## 補足情報
バージョン管理Entityに対して、

1. CSVでバージョンが指定されている場合
　全バージョン含めて指定された oid 、version のデータが存在するか検索
1.1. 指定バージョンが存在する場合は対象バージョンを更新 (**`UPDATE_SPECIFIC`**)
1.2. 指定バージョンが存在しない場合は、oid で登録状態をチェック
　有効データに指定された oid のデータが存在するか検索
1.2.1. 有効データに oid データが存在する場合は、新しいバージョンとして追加 (**`UPDATE_NEW`**)
　新しいバージョンの元となるバージョンは有効データとする（version=nullで更新）
1.2.2. 有効データに oid データが存在しない場合は、全バージョン含めて oid の登録状態をチェック
　全バージョン含めて指定された oid のデータが存在するか検索
1.2.2.1. 全バージョンに oid データが存在する場合は、新しいバージョンとして追加 (**`UPDATE_NEW`**)
　新しいバージョンの元となるバージョンは登録済 version のMAX値データとする
1.2.2.2 全バージョンに oid データが存在しない場合は、追加する (**`INSERT`**)

2. CSVでバージョンが指定されていない場合
　有効データに指定された oid のデータが存在するか検索。1.2と同様のチェックを行う。