### PR TITLE
gem、CSVアップロード、バージョン管理されていて無効データしか存在しない場合に、NEW_VERSIONとして更新できるようにする

### DIFF
--- a/iplass-web/src/main/java/org/iplass/mtp/impl/csv/CsvUploadService.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/csv/CsvUploadService.java
@@ -73,6 +73,8 @@ import org.iplass.mtp.entity.definition.properties.BinaryProperty;
 import org.iplass.mtp.entity.definition.properties.ExpressionProperty;
 import org.iplass.mtp.entity.definition.properties.ReferenceProperty;
 import org.iplass.mtp.entity.query.Query;
+import org.iplass.mtp.entity.query.SortSpec;
+import org.iplass.mtp.entity.query.SortSpec.SortType;
 import org.iplass.mtp.entity.query.condition.expr.And;
 import org.iplass.mtp.entity.query.condition.predicate.Equals;
 import org.iplass.mtp.impl.entity.csv.EntityCsvException;
@@ -947,60 +949,39 @@ public class CsvUploadService implements Service {
 			} else {
 				if (ed.getVersionControlType() != VersionControlType.NONE) {
 					// バージョン管理している
-					if (keyValueMap.containsKey(uniqueKeyValue)) {
-						// 既にOIDは登録済の状態
 
-						// UniqueKeyで指定している可能性があるので登録済のOIDをセット
+					if (keyValueMap.containsKey(uniqueKeyValue)) {
+						// 既にOIDはCSVの前行までに登録、更新済の状態
+
+						// UniqueKeyで指定している場合、またはINSERT時のOID採番値で置き換え(INSERT時はCSVのOIDとは異なる値で登録される)
 						entity.setOid(keyValueMap.get(uniqueKeyValue));
 
-						if (entity.getVersion() != null) {
-							Query q = onVersionQuery(ed.getName(), uniqueKey, uniqueKeyValue, entity.getVersion());
-							int count = em.count(q);
-							if (count > 0) {
-								// 登録済バージョンが存在する場合は対象バージョンを更新
-								execType = ExecType.UPDATE_SPECIFIC;
-							} else {
-								// 指定バージョンデータがない場合はエラー
-								throw new ApplicationException(resourceString("impl.csv.CsvUploadService.alreadyDeleted"));
-							}
+						// UniqueKeyを登録されているOIDにスイッチ
+						uniqueKey = Entity.OID;
+						uniqueKeyValue = entity.getOid();
+					}
+
+					if (entity.getVersion() != null) {
+						// 全バージョン含めて登録済のバージョンデータを検索
+						Query versionedQuery = onVersionQuery(ed.getName(), uniqueKey, uniqueKeyValue, entity.getVersion());
+						SearchResult<Entity> versionedResult = em.searchEntity(versionedQuery, new SearchOption().countTotal());
+						if (versionedResult.getTotalCount() > 0) {
+							// 指定バージョンが存在する場合は対象バージョンを更新
+							execType = ExecType.UPDATE_SPECIFIC;
+
+							// UniqueKeyで検索している可能性があるので登録済のOIDをセット
+							entity.setOid(versionedResult.getFirst().getOid());
 						} else {
-							// バージョン未指定の場合は新しいバージョンとして追加
-							execType = ExecType.UPDATE_NEW;
+							// Oidの登録状態で実行タイプを決定
+							execType = versionedExecType(ed, uniqueKey, uniqueKeyValue, entity);
 						}
 					} else {
-						if (entity.getVersion() != null) {
-							Query q = onVersionQuery(ed.getName(), uniqueKey, uniqueKeyValue, entity.getVersion());
-							int count = em.count(q);
-							if (count > 0) {
-								// 登録済バージョンが存在する場合は対象バージョンを更新
-								execType = ExecType.UPDATE_SPECIFIC;
-							} else {
-								SearchResult<Entity> searchResult
-									= em.searchEntity(noVersionQuery(ed.getName(), uniqueKey, uniqueKeyValue), new SearchOption().countTotal());
-								if (searchResult.getTotalCount() > 0) {
-									// 指定OIDデータが登録済で、指定バージョンデータがない場合はエラー
-									throw new ApplicationException(resourceString("impl.csv.CsvUploadService.alreadyDeleted"));
-								} else {
-									// 指定OID、バージョンが存在しないのでInsert
-									execType = ExecType.INSERT;
-								}
-							}
-						} else {
-							SearchResult<Entity> searchResult
-								= em.searchEntity(noVersionQuery(ed.getName(), uniqueKey, uniqueKeyValue), new SearchOption().countTotal());
-							if (searchResult.getTotalCount() > 0) {
-								// バージョン未指定の場合は新しいバージョンとして追加
-								execType = ExecType.UPDATE_NEW;
-								//UniqueKeyで検索している可能性があるので登録済のOIDをセット
-								entity.setOid(searchResult.getFirst().getOid());
-							} else {
-								// 指定OIDデータが存在しないのでInsert
-								execType = ExecType.INSERT;
-							}
-						}
+						// Oidの登録状態で実行タイプを決定
+						execType = versionedExecType(ed, uniqueKey, uniqueKeyValue, entity);
 					}
 				} else {
 					// バージョン管理していない
+
 					SearchResult<Entity> searchResult
 						= em.searchEntity(noVersionQuery(ed.getName(), uniqueKey, uniqueKeyValue), new SearchOption().countTotal());
 					if (searchResult.getTotalCount() > 0) {
@@ -1010,18 +991,57 @@ public class CsvUploadService implements Service {
 						if (updateTargetVersionForNoneVersionedEntity == TargetVersion.SPECIFIC) {
 							execType = ExecType.UPDATE_SPECIFIC;
 
-							//SPECIFICの場合、version必須のためセット
+							// SPECIFICの場合、version必須のためセット
 							entity.setVersion(0L);
 						} else {
 							execType = ExecType.UPDATE_VALID;
 						}
 
-						//UniqueKeyで検索している可能性があるので登録済のOIDをセット
+						// UniqueKeyで検索している可能性があるので登録済のOIDをセット
 						entity.setOid(searchResult.getFirst().getOid());
 					} else {
 						// 指定OIDデータが存在しないのでInsert
 						execType = ExecType.INSERT;
 					}
+				}
+			}
+
+			return execType;
+		}
+
+		private ExecType versionedExecType(EntityDefinition ed, String uniqueKey, Object uniqueKeyValue, Entity entity) {
+
+			ExecType execType = null;
+
+			// 有効データに登録済OIDが存在するか検索
+			Query validQuery = noVersionQuery(ed.getName(), uniqueKey, uniqueKeyValue);
+			SearchResult<Entity> validResult = em.searchEntity(validQuery, new SearchOption().countTotal());
+			if (validResult.getTotalCount() > 0) {
+				// 有効データに登録済OIDデータが存在する場合は、新しいバージョンとして追加
+				execType = ExecType.UPDATE_NEW;
+
+				// バージョン元として有効データを指定するためバージョンをクリア
+				entity.setVersion(null);
+
+				// UniqueKeyで検索している可能性があるので登録済のOIDをセット
+				entity.setOid(validResult.getFirst().getOid());
+			} else {
+				// 有効データに登録済OIDデータが存在しない場合は、全バージョン含めて登録済OIDデータを検索
+				Query versionedOidQuery = onVersionQuery(ed.getName(), uniqueKey, uniqueKeyValue, null);
+				SearchResult<Entity> versionedOidResult = em.searchEntity(versionedOidQuery, new SearchOption().countTotal());
+				if (versionedOidResult.getTotalCount() > 0) {
+					// 全バージョンに登録済OIDデータが存在する場合は、新しいバージョンとして追加
+					execType = ExecType.UPDATE_NEW;
+
+					// バージョン元として登録済データのMAXバージョンを指定
+					entity.setVersion(versionedOidResult.getFirst().getVersion());
+
+					// UniqueKeyで検索している可能性があるので登録済のOIDをセット
+					entity.setOid(versionedOidResult.getFirst().getOid());
+
+				} else {
+					// 登録済OIDデータが存在しない場合は、新規追加
+					execType = ExecType.INSERT;
 				}
 			}
 
@@ -1036,11 +1056,17 @@ public class CsvUploadService implements Service {
 		}
 
 		private Query onVersionQuery(String defName, String uniqueKey, Object uniqueKeyValue, Long version) {
-			return new Query()
-					.select(Entity.OID)
-					.from(ed.getName())
-					.where(new And(new Equals(uniqueKey, uniqueKeyValue), new Equals(Entity.VERSION, version)))
+			Query query = new Query()
+					.select(Entity.OID, Entity.VERSION)
+					.from(defName)
+					.order(new SortSpec(Entity.VERSION, SortType.DESC))
 					.versioned(true);
+			if (version != null) {
+				query.where(new And(new Equals(uniqueKey, uniqueKeyValue), new Equals(Entity.VERSION, version)));
+			} else {
+				query.where(new Equals(uniqueKey, uniqueKeyValue));
+			}
+			return query;
 		}
 
 		private UpdateOption updateOption(ExecType execType) {

--- a/iplass-web/src/main/resources/mtp-web-messages.properties
+++ b/iplass-web/src/main/resources/mtp-web-messages.properties
@@ -24,7 +24,6 @@ error.Error.retryMsg = Please check your entry again in the previous screen.
 impl.auth.authenticate.oidc.OIDCAuthenticationProvider.error      = Failed to single sign-on with OpenID Connect. Details: {0} ({1})
 impl.auth.authenticate.oidc.command.AbstractCallbackCommand.error = Connection via OpenID Connect failed. Details: {0} ({1})
 impl.auth.authenticate.oidc.command.AuthCallbackCommand.error     = Failed to single sign-on.
-impl.csv.CsvUploadService.alreadyDeleted                          = The data subject has already been deleted.
 impl.csv.CsvUploadService.ctrlFlgInsertError                      = Since the insert is set in the control flag and can not be updated.
 impl.csv.CsvUploadService.ctrlFlgUpdateError                      = Since the update is set by the control flag, you can not register.
 impl.csv.CsvUploadService.denyDeleteError                         = The delete is not allowed.

--- a/iplass-web/src/main/resources/mtp-web-messages_en.properties
+++ b/iplass-web/src/main/resources/mtp-web-messages_en.properties
@@ -24,7 +24,6 @@ error.Error.retryMsg = Please check your entry again in the previous screen.
 impl.auth.authenticate.oidc.OIDCAuthenticationProvider.error      = Failed to single sign-on with OpenID Connect. Details: {0} ({1})
 impl.auth.authenticate.oidc.command.AbstractCallbackCommand.error = Connection via OpenID Connect failed. Details: {0} ({1})
 impl.auth.authenticate.oidc.command.AuthCallbackCommand.error     = Failed to single sign-on.
-impl.csv.CsvUploadService.alreadyDeleted                          = The data subject has already been deleted.
 impl.csv.CsvUploadService.ctrlFlgInsertError                      = Since the insert is set in the control flag and can not be updated.
 impl.csv.CsvUploadService.ctrlFlgUpdateError                      = Since the update is set by the control flag, you can not register.
 impl.csv.CsvUploadService.denyDeleteError                         = The delete is not allowed.

--- a/iplass-web/src/main/resources/mtp-web-messages_ja.properties
+++ b/iplass-web/src/main/resources/mtp-web-messages_ja.properties
@@ -24,7 +24,6 @@ error.Error.retryMsg = 前画面での入力内容を再度ご確認ください
 impl.auth.authenticate.oidc.OIDCAuthenticationProvider.error      = OpenID Connectでのシングルサインオンに失敗しました。詳細：{0} ({1})
 impl.auth.authenticate.oidc.command.AbstractCallbackCommand.error = OpenID Connectによる接続に失敗しました。詳細：{0} ({1})
 impl.auth.authenticate.oidc.command.AuthCallbackCommand.error     = シングルサインオンに失敗しました。
-impl.csv.CsvUploadService.alreadyDeleted                          = 対象のデータは、既に削除されました。
 impl.csv.CsvUploadService.ctrlFlgInsertError                      = 制御フラグでインサートが設定されている為、更新できません。
 impl.csv.CsvUploadService.ctrlFlgUpdateError                      = 制御フラグでアップデートが設定されている為、登録できません。
 impl.csv.CsvUploadService.denyDeleteError                         = 削除は許可されていません。

--- a/iplass-web/src/main/resources/mtp-web-messages_th.properties
+++ b/iplass-web/src/main/resources/mtp-web-messages_th.properties
@@ -24,7 +24,6 @@ error.Error.retryMsg = กรุณาตรวจสอบข้อมูลท
 impl.auth.authenticate.oidc.OIDCAuthenticationProvider.error      = ไม่สามารถลงชื่อเพียงครั้งเดียวด้วย OpenID Connect รายละเอียด: {0} ({1})
 impl.auth.authenticate.oidc.command.AbstractCallbackCommand.error = การเชื่อมต่อผ่าน OpenID Connect ล้มเหลว รายละเอียด: {0} ({1})
 impl.auth.authenticate.oidc.command.AuthCallbackCommand.error     = การลงชื่อแบบครั้งเดียวล้มเหลว
-impl.csv.CsvUploadService.alreadyDeleted                          = ข้อมูลที่ต้องการถูกลบไปแล้ว
 impl.csv.CsvUploadService.ctrlFlgInsertError                      = ไม่สามารถแก้ไขได้
 impl.csv.CsvUploadService.ctrlFlgUpdateError                      = ไม่สามารถแก้ไขได้
 impl.csv.CsvUploadService.denyDeleteError                         = ไม่อนุญาตให้ลบ

--- a/iplass-web/src/main/resources/mtp-web-messages_zh.properties
+++ b/iplass-web/src/main/resources/mtp-web-messages_zh.properties
@@ -24,7 +24,6 @@ error.Error.retryMsg = 请在上一个页面再次检查您的输入。
 impl.auth.authenticate.oidc.OIDCAuthenticationProvider.error      = 无法使用 OpenID Connect 进行单点登录。详细信息：{0} ({1})
 impl.auth.authenticate.oidc.command.AbstractCallbackCommand.error = 通过 OpenID Connect 的连接失败。详细信息：{0} ({1})
 impl.auth.authenticate.oidc.command.AuthCallbackCommand.error     = 无法单点登录。
-impl.csv.CsvUploadService.alreadyDeleted                          = 目标数据已被删除。
 impl.csv.CsvUploadService.ctrlFlgInsertError                      = 因为控制标示位被设置成新建，无法更新。
 impl.csv.CsvUploadService.ctrlFlgUpdateError                      = 因为控制标示位被设置成更新，无法新建。
 impl.csv.CsvUploadService.denyDeleteError                         = 不允许删除。

--- a/iplass-web/src/main/resources/mtp-web-messages_zh_HK.properties
+++ b/iplass-web/src/main/resources/mtp-web-messages_zh_HK.properties
@@ -24,7 +24,6 @@ error.Error.retryMsg = 請在上一個頁面再次檢查您的輸入。
 impl.auth.authenticate.oidc.OIDCAuthenticationProvider.error      = 無法使用 OpenID Connect 進行單點登錄。詳細信息：{0} ({1})
 impl.auth.authenticate.oidc.command.AbstractCallbackCommand.error = 通過 OpenID Connect 的連接失敗。詳細信息：{0} ({1})
 impl.auth.authenticate.oidc.command.AuthCallbackCommand.error     = 無法單點登錄。
-impl.csv.CsvUploadService.alreadyDeleted                          = 目標數據已被刪除。
 impl.csv.CsvUploadService.ctrlFlgInsertError                      = 因為控制標示位被設置成新建，無法更新。
 impl.csv.CsvUploadService.ctrlFlgUpdateError                      = 因為控制標示位被設置成更新，無法新建。
 impl.csv.CsvUploadService.denyDeleteError                         = 不允許刪除。

--- a/iplass-web/src/main/resources/mtp-web-messages_zh_TW.properties
+++ b/iplass-web/src/main/resources/mtp-web-messages_zh_TW.properties
@@ -24,7 +24,6 @@ error.Error.retryMsg = 請在上一個頁面再次檢查您的輸入。
 impl.auth.authenticate.oidc.OIDCAuthenticationProvider.error      = 無法使用 OpenID Connect 進行單點登錄。詳細信息：{0} ({1})
 impl.auth.authenticate.oidc.command.AbstractCallbackCommand.error = 通過 OpenID Connect 的連接失敗。詳細信息：{0} ({1})
 impl.auth.authenticate.oidc.command.AuthCallbackCommand.error     = 無法單點登錄。
-impl.csv.CsvUploadService.alreadyDeleted                          = 目標數據已被刪除。
 impl.csv.CsvUploadService.ctrlFlgInsertError                      = 因為控制標示位被設置成新建，無法更新。
 impl.csv.CsvUploadService.ctrlFlgUpdateError                      = 因為控制標示位被設置成更新，無法新建。
 impl.csv.CsvUploadService.denyDeleteError                         = 不允許刪除。


### PR DESCRIPTION
## 対応内容
同じOIDに対して無効データのみのEntityデータに対して、CSVアップロードを利用して、「新しいバージョンとして更新」しようとしても「新規追加」として、別のOIDデータとして登録されてしまう。
登録済の状態を判定する際に、無効データも含めたチェックを行う。
fixes #1623

## 補足情報
バージョン管理Entityに対して、

1. CSVでバージョンが指定されている場合
　全バージョン含めて指定された oid 、version のデータが存在するか検索
1.1. 指定バージョンが存在する場合は対象バージョンを更新 (**`UPDATE_SPECIFIC`**)
1.2. 指定バージョンが存在しない場合は、oid で登録状態をチェック
　有効データに指定された oid のデータが存在するか検索
1.2.1. 有効データに oid データが存在する場合は、新しいバージョンとして追加 (**`UPDATE_NEW`**)
　新しいバージョンの元となるバージョンは有効データとする（version=nullで更新）
1.2.2. 有効データに oid データが存在しない場合は、全バージョン含めて oid の登録状態をチェック
　全バージョン含めて指定された oid のデータが存在するか検索
1.2.2.1. 全バージョンに oid データが存在する場合は、新しいバージョンとして追加 (**`UPDATE_NEW`**)
　新しいバージョンの元となるバージョンは登録済 version のMAX値データとする
1.2.2.2 全バージョンに oid データが存在しない場合は、追加する (**`INSERT`**)

2. CSVでバージョンが指定されていない場合
　有効データに指定された oid のデータが存在するか検索。1.2と同様のチェックを行う。