### PR TITLE
TopView用お知らせパーツ: 多言語対応データを検索可能にする

### DIFF
--- a/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/top/item/InformationItem.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/top/item/InformationItem.java
@@ -101,6 +101,7 @@ public class InformationItem extends PartsItem {
 
 		private SelectItem dispRangeField;
 		private IntegerItem numberOfDisplayField;
+		private CheckboxItem chkEnableDataLocalization;
 		private CheckboxItem chkEnableHtmlTag;
 		private CheckboxItem chkUseRichtextEditor;
 		private SelectItem richTextLibraryField;
@@ -154,6 +155,9 @@ public class InformationItem extends PartsItem {
 			numberOfDisplayField.setWidth("100%");
 			SmartGWTUtil.addHoverToFormItem(numberOfDisplayField, AdminClientMessageUtil.getString("ui_metadata_top_item_InformationItem_numberOfDisplay"));
 
+			chkEnableDataLocalization = new CheckboxItem();
+			chkEnableDataLocalization.setTitle("Enable Data Localization");
+
 			chkEnableHtmlTag = new CheckboxItem();
 			chkEnableHtmlTag.setTitle("Enable Html Tag");
 			chkUseRichtextEditor = new CheckboxItem();
@@ -202,7 +206,7 @@ public class InformationItem extends PartsItem {
 			txaDetailCustomStyle.setHeight(100);
 			SmartGWTUtil.setReadOnlyTextArea(txaDetailCustomStyle);
 
-			infoListForm.setItems(dispRangeField, numberOfDisplayField, chkEnableHtmlTag,
+			infoListForm.setItems(dispRangeField, numberOfDisplayField, chkEnableDataLocalization, chkEnableHtmlTag,
 					chkUseRichtextEditor, richTextLibraryField, txaRichtextEditorOption, chkAllowRichTextEditorLinkAction,
 					btnEditEetailCustomStyle, txaDetailCustomStyle);
 
@@ -275,6 +279,7 @@ public class InformationItem extends PartsItem {
 							parts.setPasswordWarnMarkStyleClass(SmartGWTUtil.getStringValue(passwordWarnMarkStyleField));
 						}
 						parts.setNumberOfDisplay(SmartGWTUtil.getIntegerValue(numberOfDisplayField));
+						parts.setEnableDataLocalization(SmartGWTUtil.getBooleanValue(chkEnableDataLocalization));
 						parts.setEnableHtmlTag(SmartGWTUtil.getBooleanValue(chkEnableHtmlTag));
 						parts.setUseRichtextEditor(SmartGWTUtil.getBooleanValue(chkUseRichtextEditor));
 						if (richTextLibraryField.getValue() != null && !richTextLibraryField.getValueAsString().isEmpty()) {
@@ -355,6 +360,7 @@ public class InformationItem extends PartsItem {
 				dispRangeField.setValue("");
 			}
 
+			chkEnableDataLocalization.setValue(parts.isEnableDataLocalization());
 			chkEnableHtmlTag.setValue(parts.isEnableHtmlTag());
 			chkUseRichtextEditor.setValue(parts.isUseRichtextEditor());
 			if (parts.getRichTextLibrary() != null) {

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/top/item/InformationItem.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/top/item/InformationItem.java
@@ -157,6 +157,7 @@ public class InformationItem extends PartsItem {
 
 			chkEnableDataLocalization = new CheckboxItem();
 			chkEnableDataLocalization.setTitle("Enable Data Localization");
+			SmartGWTUtil.addHoverToFormItem(chkEnableDataLocalization, AdminClientMessageUtil.getString("ui_metadata_top_item_InformationItem_dataLocalization"));
 
 			chkEnableHtmlTag = new CheckboxItem();
 			chkEnableHtmlTag.setTitle("Enable Html Tag");

--- a/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_en.js
+++ b/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_en.js
@@ -1112,6 +1112,7 @@ LocaleInfo.ui_metadata_top_item_InformationItem_iconTagComment = "Can set tags f
 LocaleInfo.ui_metadata_top_item_InformationItem_partsTimeDispRange = "Specify the display range of parts time on the list.";
 LocaleInfo.ui_metadata_top_item_InformationItem_numberOfDisplay = "Specify the number to become a scrolling display.<br/>Not a scroll display in the case of unspecified.";
 LocaleInfo.ui_metadata_top_item_InformationItem_richTextLibrary = "Specify the library to be used as a rich text editor, if a rich text editor is used.";
+LocaleInfo.ui_metadata_top_item_InformationItem_dataLocalization = "Specify whether to display the localized data in the list. <br/>This setting is only valid if data localization of the Information Notice Entity is enabled.";
 LocaleInfo.ui_metadata_top_item_InformationItem_showPasswordWarn = "Show warning message of the password expiration date.";
 LocaleInfo.ui_metadata_top_item_InformationItem_specifyPasswordWarnremainDay = "Specify warning target  password expiration date remaining days.";
 LocaleInfo.ui_metadata_top_item_InformationItem_specifyCustomWarnMessage = "Specify if want to customize the warning message.";

--- a/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_ja.js
+++ b/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_ja.js
@@ -1111,6 +1111,7 @@ LocaleInfo.ui_metadata_top_item_InformationItem_titleEachLang = "言語毎のタ
 LocaleInfo.ui_metadata_top_item_InformationItem_iconTagComment = "Fontawsomeによるアイコン用のタグを設定できます。";
 LocaleInfo.ui_metadata_top_item_InformationItem_partsTimeDispRange = "一覧上の時間部分の表示範囲を指定します。";
 LocaleInfo.ui_metadata_top_item_InformationItem_numberOfDisplay = "スクロール表示になる件数を指定します。<br/>未指定の場合はスクロール表示になりません。";
+LocaleInfo.ui_metadata_top_item_InformationItem_dataLocalization = "お知らせ情報を検索する際に、多言語化されたデータを取得するかを指定します。<br/>この設定は、お知らせ情報Entityのデータが多言語化されている場合のみ有効です。";
 LocaleInfo.ui_metadata_top_item_InformationItem_richTextLibrary = "リッチテキストエディタを利用する場合に、リッチテキストエディタとして利用するライブラリを指定します。";
 LocaleInfo.ui_metadata_top_item_InformationItem_showPasswordWarn = "パスワード有効期間に対する警告メッセージを表示します。";
 LocaleInfo.ui_metadata_top_item_InformationItem_specifyPasswordWarnremainDay = "警告対象とするパスワード有効期間残日数を指定します。";

--- a/iplass-gem/src/main/java/org/iplass/gem/command/information/InformationViewCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/information/InformationViewCommand.java
@@ -80,18 +80,20 @@ public final class InformationViewCommand implements Command {
 		String oid = request.getParam(Constants.OID);
 		Long version = request.getParamAsLong(Constants.VERSION);
 
+		//パーツ
+		InformationParts infoParts = tvdm.getRequestTopViewParts(InformationParts.class);
+
 		//検索
 		Entity entity = null;
 		if (oid != null) {
-			entity = em.load(oid, version ,InformationListCommand.INFORMATION_ENTITY, new LoadOption(false, false));
+			entity = em.load(oid, version ,InformationListCommand.INFORMATION_ENTITY, getLoadOption(infoParts));
 		}
+
 		if (entity == null) {
 			request.setAttribute(Constants.MESSAGE, GemResourceBundleUtil.resourceString("information.view.noPermission"));
 			return Constants.CMD_EXEC_ERROR_NODATA;
 		}
 
-		//パーツ
-		InformationParts infoParts = tvdm.getRequestTopViewParts(InformationParts.class);
 		if (infoParts == null) {
 			request.setAttribute(Constants.MESSAGE, GemResourceBundleUtil.resourceString("information.view.viewErr"));
 			return Constants.CMD_EXEC_ERROR_VIEW;
@@ -110,6 +112,14 @@ public final class InformationViewCommand implements Command {
 		request.setAttribute(Constants.INFO_DETAIL_CUSTOM_STYLE, customStyle);
 
 		return Constants.CMD_EXEC_SUCCESS;
+	}
+
+	private LoadOption getLoadOption(InformationParts infoParts) {
+		LoadOption option = new LoadOption(false, false);
+
+		return infoParts != null && infoParts.isEnableDataLocalization()
+				? option.localized()
+				: option;
 	}
 
 }

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/top/parts/MetaInformationParts.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/top/parts/MetaInformationParts.java
@@ -98,6 +98,9 @@ public class MetaInformationParts extends MetaActionParts {
 	/** パスワード警告マークスタイルクラス */
 	private String passwordWarnMarkStyleClass;
 
+	/** データの多言語化有無 */
+	private boolean enableDataLocalization;
+
 	/** HTML出力可否 */
 	private boolean availableHtmlTag = false;
 
@@ -156,7 +159,7 @@ public class MetaInformationParts extends MetaActionParts {
 	 * @return アイコンタグ
 	 */
 	public String getIconTag() {
-	    return iconTag;
+		return iconTag;
 	}
 
 	/**
@@ -164,7 +167,7 @@ public class MetaInformationParts extends MetaActionParts {
 	 * @param iconTag アイコンタグ
 	 */
 	public void setIconTag(String iconTag) {
-	    this.iconTag = iconTag;
+		this.iconTag = iconTag;
 	}
 
 	/**
@@ -280,6 +283,22 @@ public class MetaInformationParts extends MetaActionParts {
 	}
 
 	/**
+	 * データの多言語化有無を取得します。
+	 * @return データの多言語化有無
+	 */
+	public boolean isEnableDataLocalization() {
+		return enableDataLocalization;
+	}
+
+	/**
+	 * データの多言語化有無を設定します。
+	 * @param enableDataLocalization データの多言語化有無
+	*/
+	public void setEnableDataLocalization(boolean enableDataLocalization) {
+		this.enableDataLocalization = enableDataLocalization;
+	}
+
+	/**
 	 * HTML出力可否を取得します。
 	 * @return HTML出力可否
 	 */
@@ -300,7 +319,7 @@ public class MetaInformationParts extends MetaActionParts {
 	 * @return 一覧の表示件数
 	 */
 	public Integer getNumberOfDisplay() {
-	    return numberOfDisplay;
+		return numberOfDisplay;
 	}
 
 	/**
@@ -308,7 +327,7 @@ public class MetaInformationParts extends MetaActionParts {
 	 * @param numberOfDisplay 一覧の表示件数
 	 */
 	public void setNumberOfDisplay(Integer numberOfDisplay) {
-	    this.numberOfDisplay = numberOfDisplay;
+		this.numberOfDisplay = numberOfDisplay;
 	}
 
 	/**
@@ -413,6 +432,7 @@ public class MetaInformationParts extends MetaActionParts {
 		localizedPasswordWarningMessageList = I18nUtil.toMeta(definition.getLocalizedPasswordWarningMessageList());
 		passwordWarnAreaStyleClass = definition.getPasswordWarnAreaStyleClass();
 		passwordWarnMarkStyleClass = definition.getPasswordWarnMarkStyleClass();
+		enableDataLocalization = definition.isEnableDataLocalization();
 		availableHtmlTag = definition.isEnableHtmlTag();
 		useRichtextEditor = definition.isUseRichtextEditor();
 		richTextLibrary = definition.getRichTextLibrary();
@@ -437,6 +457,7 @@ public class MetaInformationParts extends MetaActionParts {
 		parts.setLocalizedPasswordWarningMessageList(I18nUtil.toDef(localizedPasswordWarningMessageList));
 		parts.setPasswordWarnAreaStyleClass(passwordWarnAreaStyleClass);
 		parts.setPasswordWarnMarkStyleClass(passwordWarnMarkStyleClass);
+		parts.setEnableDataLocalization(enableDataLocalization);
 		parts.setEnableHtmlTag(availableHtmlTag);
 		parts.setUseRichtextEditor(useRichtextEditor);
 		parts.setRichTextLibrary(richTextLibrary);

--- a/iplass-gem/src/main/java/org/iplass/mtp/view/top/parts/InformationParts.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/view/top/parts/InformationParts.java
@@ -62,6 +62,9 @@ public class InformationParts extends ActionParts {
 	/** パスワード警告マークスタイルクラス */
 	private String passwordWarnMarkStyleClass;
 
+	/** データの多言語化有無 */
+	private boolean enableDataLocalization;
+
 	/** HTML出力可否 */
 	private boolean enableHtmlTag;
 
@@ -133,7 +136,7 @@ public class InformationParts extends ActionParts {
 	 * @return アイコンタグ
 	 */
 	public String getIconTag() {
-	    return iconTag;
+		return iconTag;
 	}
 
 	/**
@@ -141,7 +144,7 @@ public class InformationParts extends ActionParts {
 	 * @param iconTag アイコンタグ
 	 */
 	public void setIconTag(String iconTag) {
-	    this.iconTag = iconTag;
+		this.iconTag = iconTag;
 	}
 
 	/**
@@ -275,6 +278,22 @@ public class InformationParts extends ActionParts {
 	}
 
 	/**
+	 * データの多言語化有無を取得します。
+	 * @return データの多言語化有無
+	 */
+	public boolean isEnableDataLocalization() {
+		return enableDataLocalization;
+	}
+
+	/**
+	 * データの多言語化有無を設定します。
+	 * @param enableDataLocalization データの多言語化有無
+	*/
+	public void setEnableDataLocalization(boolean enableDataLocalization) {
+		this.enableDataLocalization = enableDataLocalization;
+	}
+
+	/**
 	 * HTML出力可否を取得します。
 	 * @return HTML出力可否
 	 */
@@ -379,7 +398,7 @@ public class InformationParts extends ActionParts {
 	 * @return 一覧の表示件数
 	 */
 	public Integer getNumberOfDisplay() {
-	    return numberOfDisplay;
+		return numberOfDisplay;
 	}
 
 	/**
@@ -387,7 +406,7 @@ public class InformationParts extends ActionParts {
 	 * @param numberOfDisplay 一覧の表示件数
 	 */
 	public void setNumberOfDisplay(Integer numberOfDisplay) {
-	    this.numberOfDisplay = numberOfDisplay;
+		this.numberOfDisplay = numberOfDisplay;
 	}
 
 }


### PR DESCRIPTION
<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->

- TopView用お知らせパーツに多言語対応フラグを追加
- お知らせ関連Commandの検索処理に多言語データの考慮オプションを設定

closes #1616 

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->

以下を確認した。

- 変更前のバージョンにおけるTopViewのメタデータを、変更後のバージョンの環境で読み込めること

多言語対応フラグがOFFの場合：
- Entitiyの多言語対応状態にかかわらず、多言語を考慮しないデータが検索される

多言語対応フラグがONの場合：
- Entityが多言語対応されていれば、多言語を考慮したデータが検索される
- Entityが多言語対応されていなければ、多言語を考慮しないデータが検索される
