### PR TITLE
編集画面のCKEditorオプション制御の変更

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/string/richtext/ckeditor/CKEditor_Add.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/string/richtext/ckeditor/CKEditor_Add.jsp
@@ -30,11 +30,13 @@
 %>
 <script type="text/javascript">
 function addRichtextItem_<%=StringUtil.escapeJavaScript(targetName)%>(targetId) {
+	const defaults = { allowedContent:<%=allowedContent%> };
 <%	if (StringUtil.isNotBlank(editorOption)) {%>
-	var opt = <%=editorOption%>;
+	const custom = <%=editorOption%>;
 <%	} else {%>
-	var opt = { allowedContent:<%=allowedContent%> };
+	const custom = {};
 <%	}%>
-	$("#" + targetId).ckeditor(function() {}, opt);
+	const option = $.extend(true, {}, defaults, custom);
+	$("#" + targetId).ckeditor(function() {}, option);
 }
 </script>

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/string/richtext/ckeditor/CKEditor_Edit.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/string/richtext/ckeditor/CKEditor_Edit.jsp
@@ -30,13 +30,15 @@
 %>
 <script type="text/javascript">
 $(function() {
-<%	if (StringUtil.isNotBlank(editorOption)) { %>
-	var opt = <%=editorOption%>;
-<%	} else { %>
-	var opt = { allowedContent:<%=allowedContent%> };
-<%	} %>
+	const defaults = { allowedContent:<%=allowedContent%> };
+<%	if (StringUtil.isNotBlank(editorOption)) {%>
+	const custom = <%=editorOption%>;
+<%	} else {%>
+	const custom = {};
+<%	}%>
+	const option = $.extend(true, {}, defaults, custom);
 	$("textarea[name='<%=StringUtil.escapeJavaScript(targetName)%>']").ckeditor(
-		function() {}, opt
+		function() {}, option
 	);
 });
 </script>

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/string/richtext/ckeditor/CKEditor_NestTable.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/string/richtext/ckeditor/CKEditor_NestTable.jsp
@@ -38,12 +38,14 @@ addNestRow_ColumnCallback("<%=StringUtil.escapeJavaScript(nestPropName) %>", "<%
 			const $textArea = $td.children("textarea");
 			const editorId = $textArea.attr("id");
 
+			const defaults = { allowedContent:<%=allowedContent%> };
 <%	if (StringUtil.isNotBlank(editorOption)) {%>
-			const opt = <%=editorOption%>;
+			const custom = <%=editorOption%>;
 <%	} else {%>
-			const opt = { allowedContent:<%=allowedContent%> };
+			const custom = {};
 <%	}%>
-			$("#" + editorId).ckeditor(function() {}, opt);
+			const option = $.extend(true, {}, defaults, custom);
+			$("#" + editorId).ckeditor(function() {}, option);
 		}
 );
 </script>


### PR DESCRIPTION
## 対応内容
`RickText Editor Option` が指定された場合も、 オプションとしては `allowedContent` を指定した上で、`RickText Editor Option` で上書きすることを可能にする。

closes #1643