### PR TITLE
GEM: TopViewの検索結果一覧パーツでcountクエリを実行しないようにする

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchListCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchListCommand.java
@@ -44,16 +44,16 @@ import org.iplass.mtp.webapi.definition.MethodType;
 import org.iplass.mtp.webapi.definition.RequestType;
 
 @WebApi(
-	name=SearchListCommand.WEBAPI_NAME,
-	displayName="Entity一覧検索(パーツ)",
-	accepts=RequestType.REST_JSON,
-	methods=MethodType.POST,
-	restJson=@RestJson(parameterName="param"),
-	results={SearchListCommand.RESULT_PARAM_COUNT, SearchListCommand.RESULT_PARAM_HTML_DATA},
-	checkXRequestedWithHeader=true
+		name = SearchListCommand.WEBAPI_NAME,
+		displayName = "Entity一覧検索(パーツ)",
+		accepts = RequestType.REST_JSON,
+		methods = MethodType.POST,
+		restJson = @RestJson(parameterName = "param"),
+		results = { SearchListCommand.RESULT_PARAM_HTML_DATA },
+		checkXRequestedWithHeader = true
 )
-@Template(name="gem/generic/search/list", displayName="検索結果パーツ", path="/jsp/gem/generic/search/list.jsp")
-@CommandClass(name="gem/generic/search/SearchListCommand", displayName="Entity一覧検索(パーツ)")
+@Template(name = "gem/generic/search/list", displayName = "検索結果パーツ", path = "/jsp/gem/generic/search/list.jsp")
+@CommandClass(name = "gem/generic/search/SearchListCommand", displayName = "Entity一覧検索(パーツ)")
 public final class SearchListCommand extends SearchListPartsCommandBase {
 
 	public static final String WEBAPI_NAME = "gem/generic/search/list";
@@ -81,12 +81,8 @@ public final class SearchListCommand extends SearchListPartsCommandBase {
 		context.setFilter(efm.get(context.getDefName()));
 
 		Query query = toQuery(context);
-
-		int count = count(context, query.copy());
-		request.setAttribute(RESULT_PARAM_COUNT, count);
-
 		query.setOrderBy(context.getOrderBy());
-		query.setLimit(context.getLimit());
+		query.setLimit(getLimitForPaging(context));
 
 		SearchResult<Entity> result = search(context, query);
 

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchNameListCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchNameListCommand.java
@@ -38,22 +38,21 @@ import org.iplass.mtp.webapi.definition.MethodType;
 import org.iplass.mtp.webapi.definition.RequestType;
 
 @WebApi(
-		name=SearchNameListCommand.WEBAPI_NAME,
-		displayName="Entity一覧検索(ウィジェット)",
-		accepts=RequestType.REST_JSON,
-		methods=MethodType.POST,
-		restJson=@RestJson(parameterName="param"),
-		results={SearchNameListCommand.RESULT_PARAM_LIST, SearchNameListCommand.RESULT_PARAM_COUNT},
-		checkXRequestedWithHeader=true
+		name = SearchNameListCommand.WEBAPI_NAME,
+		displayName = "Entity一覧検索(ウィジェット)",
+		accepts = RequestType.REST_JSON,
+		methods = MethodType.POST,
+		restJson = @RestJson(parameterName = "param"),
+		results = { SearchNameListCommand.RESULT_PARAM_LIST },
+		checkXRequestedWithHeader = true
 )
-@Template(name="gem/generic/search/listWidget", displayName="検索結果ウィジェット", path="/jsp/gem/generic/search/listWidget.jsp")
-@CommandClass(name="gem/generic/search/SearchNameListCommand", displayName="Entity一覧検索(ウィジェット)")
+@Template(name = "gem/generic/search/listWidget", displayName = "検索結果ウィジェット", path = "/jsp/gem/generic/search/listWidget.jsp")
+@CommandClass(name = "gem/generic/search/SearchNameListCommand", displayName = "Entity一覧検索(ウィジェット)")
 public final class SearchNameListCommand extends SearchListPartsCommandBase {
 
 	public static final String WEBAPI_NAME = "gem/generic/search/nameList";
 
 	public static final String RESULT_PARAM_LIST = "list";
-	public static final String RESULT_PARAM_COUNT = "count";
 
 	private EntityDefinitionManager edm;
 	private EntityViewManager evm;
@@ -75,14 +74,11 @@ public final class SearchNameListCommand extends SearchListPartsCommandBase {
 		context.setFilter(efm.get(context.getDefName()));
 
 		Query query = toQuery(context);
-
-		int count = count(context, query.copy());
-		request.setAttribute(RESULT_PARAM_COUNT, count);
-
 		query.setOrderBy(context.getOrderBy());
-		query.setLimit(context.getLimit());
+		query.setLimit(getLimitForPaging(context));
 
 		List<Entity> entity = search(context, query).getList();
+
 		request.setAttribute(RESULT_PARAM_LIST, entity);
 
 		return Constants.CMD_EXEC_SUCCESS;

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/search/list.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/search/list.jsp
@@ -393,6 +393,9 @@ colModel.push({name:"<%=propName%>", index:"<%=propName%>", classes:"<%=style%>"
 		nextFunc: function() {
 			offset += limit;
 			search();
+		},
+		hasNextFunc: function(offset, length, count, limit, notCount) {
+			return length > limit;
 		}
 	});
 
@@ -423,8 +426,12 @@ colModel.push({name:"<%=propName%>", index:"<%=propName%>", classes:"<%=style%>"
 
 		var sortKey = $table.attr("data-sortKey");
 		var sortType = $table.attr("data-sortType");
-		searchEntityList("<%=SearchListCommand.WEBAPI_NAME%>", "${m:escJs(entityListParts.defName)}", "${m:escJs(entityListParts.viewName)}", "${m:escJs(entityListParts.filterName)}", offset, sortKey, sortType, "<%=searchAsync%>", function(count, list) {
-			$pager.setPage(offset, list.length, count);
+		searchEntityList("<%=SearchListCommand.WEBAPI_NAME%>", "${m:escJs(entityListParts.defName)}", "${m:escJs(entityListParts.viewName)}", "${m:escJs(entityListParts.filterName)}", offset, sortKey, sortType, "<%=searchAsync%>", function(list) {
+			$pager.setPage(offset, list.length, null);
+			// listのサイズを表示件数設定に従い補正
+			if (list.length > limit) {
+				list = list.slice(0, limit);
+			}
 
 			if (searchAsync) {
 				// 検索後にボタン行を表示する

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/functions.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/functions.js
@@ -1690,6 +1690,16 @@ $.fn.allInputCheck = function(){
 				nextFunc: null,
 				searchFunc: null,
 				pagingInputErrorFunc: null,
+				hasPreviewFunc: function(offset, length, count, limit, notCount) {
+					return notCount
+						? offset > 0
+						: offset > 0 && count > 0
+				},
+				hasNextFunc: function(offset, length, count, limit, notCount) {
+					return notCount
+						? hasNext = limit <= length
+						: hasNext = limit < (count - offset)
+				},
 				previousLabel: scriptContext.gem.locale.pager.previous,
 				nextLabel: scriptContext.gem.locale.pager.next
 		};
@@ -1884,14 +1894,10 @@ $.fn.allInputCheck = function(){
 					var hasPreview;
 					var hasNext;
 					var notCount = typeof count === "undefined" || count == null;
-					if (notCount) {
-						hasPreview = offset > 0;
-						hasNext = limit == length;
-					} else {
-						hasPreview = offset > 0 && count > 0;
-						hasNext= limit < (count - offset);
-						if (tail > count) { tail = count; }
-					}
+
+					hasPreview = options.hasPreviewFunc(offset, length, count, limit, notCount);
+					hasNext = options.hasNextFunc(offset, length, count, limit, notCount);
+					if (!notCount && tail > count) { tail = count; }
 
 					if (!options.showNoPage && !hasPreview && !hasNext) {
 						$v.hide();
@@ -2109,6 +2115,9 @@ $.fn.allInputCheck = function(){
 					offset += limit;
 					search();
 				},
+				hasNextFunc: function(offset, length, count, limit, notCount) {
+					return length > limit;
+				},
 				previousLabel: prevLabel,
 				nextLabel: nextLabel
 			});
@@ -2129,8 +2138,12 @@ $.fn.allInputCheck = function(){
 			search();
 
 			function search() {
-				searchNameList(webapiName, defName, viewName, filterName, offset, function(count, list) {
-					$pager.setPage(offset, list.length, count);
+				searchNameList(webapiName, defName, viewName, filterName, offset, function(list) {
+					$pager.setPage(offset, list.length, null);
+					// listのサイズを表示件数設定に従い補正
+					if (list.length > limit) {
+						list = list.slice(0, limit);
+					}
 
 					//一覧にリンク再作成
 					$linkList.children().remove();

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/webapi.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/webapi.js
@@ -371,9 +371,8 @@ function searchEntityList(webapi, defName, viewName, filterName, offset, sortKey
 	params += "}";
 
 	postAsync(webapi, params, function(results){
-		var count = results.count;
 		var list = results.htmlData;
-		if (func && $.isFunction(func)) func.call(this, count, list);
+		if (func && $.isFunction(func)) func.call(this, list);
 	}, searchAsync == "true" ? true : false);
 }
 
@@ -385,9 +384,8 @@ function searchNameList(webapi, defName, viewName, filterName, offset, func) {
 	params += ",\"offset\":\"" + offset + "\"";
 	params += "}";
 	postAsync(webapi, params, function(results){
-		var count = results.count;
 		var list = results.list;
-		if (func && $.isFunction(func)) func.call(this, count, list);
+		if (func && $.isFunction(func)) func.call(this, list);
 	});
 }
 


### PR DESCRIPTION


<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->
closes #1618 

1. パーツ関連Commandでのcountクエリ実行処理を削除
2. パーツにおける次ページの存在判定処理を、countクエリの結果に依存せず同等の動作となるよう変更

### 対応内容2の変更点

Commandでは、 `[Admin Consoleでの表示件数の設定値] + 1` 行を検索させる。

画面側では、検索結果の行数が `[Admin Consoleでの表示件数の設定値]` より大きい場合に「次ページが存在する」と判定させる。
その後、検索結果の行数が  `[Admin Consoleでの表示件数の設定値]` と一致するように、検索結果リストをsliceさせる。

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->

- TopViewのMain AreaとWidget両方で確認
  - Admin Consoleで表示件数が **設定されている** 場合に、パーツのページング動作が変更前と同様であること
  - Admin Consoleで表示件数が **設定されていない** 場合に、パーツのページング動作が変更前と同様であること
- Entityの検索画面で確認
  - Admin Consoleで表示件数が **設定されている** 場合に、画面のページング動作が変更前と同様であること
  - Admin Consoleで表示件数が **設定されていない** 場合に、画面のページング動作が変更前と同様であること