### PR TITLE
ログファイルのフィルター機能実装

### DIFF
--- a/iplass-admin/src/main/java/org/iplass/adminconsole/server/base/service/AdminConsoleService.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/server/base/service/AdminConsoleService.java
@@ -21,6 +21,7 @@
 package org.iplass.adminconsole.server.base.service;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -143,7 +144,7 @@ public class AdminConsoleService implements Service {
 	public List<String> getTenantLogFileFilters() {
 		List<String> filters = getLogDownloadConfig().getFileFilter();
 		if (filters == null || filters.isEmpty()) {
-			return null;
+			return Collections.emptyList();
 		}
 
 		return filters.stream().map(filter -> {

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/shared/tools/dto/logexplorer/LogFileCondition.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/shared/tools/dto/logexplorer/LogFileCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 DENTSU SOKEN INC. All Rights Reserved.
+ * Copyright (C) 2024 DENTSU SOKEN INC. All Rights Reserved.
  *
  * Unless you have purchased a commercial license,
  * the following license terms apply:
@@ -17,99 +17,57 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.iplass.adminconsole.shared.tools.dto.logexplorer;
 
 import java.io.Serializable;
 
 /**
- * ログファイル情報
+ * ログファイル情報検索条件
  */
-public class LogFile implements Serializable {
+public class LogFileCondition implements Serializable {
 
-	private static final long serialVersionUID = -7013254428082272889L;
+	private static final long serialVersionUID = 2459207754956721755L;
 
-	/** パス */
-	private String path;
-
-	/** ログファイル名(表示用) */
+	/** ログファイル名(表示用)条件（正規表現） */
 	private String fileName;
 
-	/** 最終更新日時(フォーマット済み) */
+	/** 最終更新日時条件（正規表現） */
 	private String lastModified;
 
-	/** ファイルサイズ */
-	private long size;
-
 	/**
-	 * パスを返します。
+	 * ログファイル名(表示用)条件（正規表現）を返します。
 	 *
-	 * @return パス
-	 */
-	public String getPath() {
-		return path;
-	}
-
-	/**
-	 * パスを設定します。
-	 * @param path パス
-	 */
-	public void setPath(String path) {
-		this.path = path;
-	}
-
-	/**
-	 * ファイル名を返します。
-	 *
-	 * @return ファイル名
+	 * @return ログファイル名(表示用)条件（正規表現）
 	 */
 	public String getFileName() {
 		return fileName;
 	}
 
 	/**
-	 * ファイル名を設定します。
+	 * ログファイル名(表示用)条件（正規表現）を設定します。
 	 *
-	 * @param fileName ファイル名
+	 * @param fileName ログファイル名(表示用)条件（正規表現）
 	 */
 	public void setFileName(String fileName) {
 		this.fileName = fileName;
 	}
 
 	/**
-	 * 最終更新日時を返します。
+	 * 最終更新日時条件（正規表現）を返します。
 	 *
-	 * @return 最終更新日時
+	 * @return 最終更新日時条件（正規表現）
 	 */
 	public String getLastModified() {
 		return lastModified;
 	}
 
 	/**
-	 * 最終更新日時を設定します。
+	 * 最終更新日時条件（正規表現）を設定します。
 	 *
-	 * @param lastModified 最終更新日時
+	 * @param lastModified 最終更新日時条件（正規表現）
 	 */
 	public void setLastModified(String lastModified) {
 		this.lastModified = lastModified;
-	}
-
-	/**
-	 * ファイルサイズを返します。
-	 *
-	 * @return ファイルサイズ
-	 */
-	public long getSize() {
-		return size;
-	}
-
-	/**
-	 * ファイルサイズを設定します。
-	 *
-	 * @param size ファイルサイズ
-	 */
-	public void setSize(long size) {
-		this.size = size;
 	}
 
 }

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/shared/tools/rpc/logexplorer/LogExplorerService.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/shared/tools/rpc/logexplorer/LogExplorerService.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.iplass.adminconsole.shared.tools.dto.logexplorer.LogConditionInfo;
 import org.iplass.adminconsole.shared.tools.dto.logexplorer.LogFile;
+import org.iplass.adminconsole.shared.tools.dto.logexplorer.LogFileCondition;
 
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 import com.google.gwt.user.client.rpc.XsrfProtectedService;
@@ -34,9 +35,10 @@ import com.google.gwt.user.client.rpc.XsrfProtectedService;
 @RemoteServiceRelativePath("service/logexplorer")
 public interface LogExplorerService extends XsrfProtectedService {
 
-	public List<LogFile> getLogfileNames(final int tenantId);
+	public List<LogFile> getLogfileNames(final int tenantId, LogFileCondition logFileCondition);
 
 	public List<LogConditionInfo> getLogConditions(final int tenantId);
 
 	public String applyLogConditions(final int tenantId, final List<LogConditionInfo> logConditions);
+
 }

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/shared/tools/rpc/logexplorer/LogExplorerServiceAsync.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/shared/tools/rpc/logexplorer/LogExplorerServiceAsync.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.iplass.adminconsole.shared.tools.dto.logexplorer.LogConditionInfo;
 import org.iplass.adminconsole.shared.tools.dto.logexplorer.LogFile;
+import org.iplass.adminconsole.shared.tools.dto.logexplorer.LogFileCondition;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
@@ -32,7 +33,7 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
  */
 public interface LogExplorerServiceAsync {
 
-	void getLogfileNames(final int tenantId, AsyncCallback<List<LogFile>> callback);
+	void getLogfileNames(final int tenantId, LogFileCondition logFileCondition, AsyncCallback<List<LogFile>> callback);
 
 	void getLogConditions(final int tenantId, AsyncCallback<List<LogConditionInfo>> callback);
 


### PR DESCRIPTION
## 対応内容
AdminConsoleのLogExplorerにて、対象のログファイルのPathを正規表現で絞り込めるようにする。

- PathとLast Modified列の上部にFilter入力欄を表示。
- 正規表現にてファイルを絞り込む（Matcher#find()）。

closes #1662