### PR TITLE
LogExplorerのLimit対応

### DIFF
--- a/iplass-admin/src/main/java/org/iplass/adminconsole/client/tools/data/logexplorer/LogFileDS.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/client/tools/data/logexplorer/LogFileDS.java
@@ -49,6 +49,8 @@ public class LogFileDS extends AbstractAdminDataSource {
 		PATH, LAST_MODIFIED, SIZE, FULL_PATH, VALUE_OBJECT
 	}
 
+	public static final String LIMIT = "limit";
+
 	public static LogFileDS getInstance() {
 		return new LogFileDS();
 	}
@@ -69,14 +71,16 @@ public class LogFileDS extends AbstractAdminDataSource {
 
 		// 画面入力条件の取得
 		LogFileCondition logFileCondition = new LogFileCondition();
-		Criteria filter = request.getCriteria();
-		if (filter != null) {
-			Map<?, ?> criteriaMap = filter.getValues();
+		Criteria criteria = request.getCriteria();
+		if (criteria != null) {
+			Map<?, ?> criteriaMap = criteria.getValues();
 			for (Object key : criteriaMap.keySet()) {
 				if (key.equals(FIELD_NAME.PATH.name())) {
 					logFileCondition.setFileName((String) criteriaMap.get(key));
 				} else if (key.equals(FIELD_NAME.LAST_MODIFIED.name())) {
 					logFileCondition.setLastModified((String) criteriaMap.get(key));
+				} else if (key.equals(LIMIT)) {
+					logFileCondition.setLimit((Integer) criteriaMap.get(key));
 				}
 			}
 		}

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/client/tools/ui/logexplorer/LogExplorerFileListPane.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/client/tools/ui/logexplorer/LogExplorerFileListPane.java
@@ -20,6 +20,7 @@
 
 package org.iplass.adminconsole.client.tools.ui.logexplorer;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.iplass.adminconsole.client.base.i18n.AdminClientMessageUtil;
@@ -42,6 +43,7 @@ import com.smartgwt.client.widgets.Canvas;
 import com.smartgwt.client.widgets.Label;
 import com.smartgwt.client.widgets.events.ClickEvent;
 import com.smartgwt.client.widgets.events.ClickHandler;
+import com.smartgwt.client.widgets.form.fields.ComboBoxItem;
 import com.smartgwt.client.widgets.grid.CellFormatter;
 import com.smartgwt.client.widgets.grid.ListGrid;
 import com.smartgwt.client.widgets.grid.ListGridField;
@@ -58,6 +60,19 @@ public class LogExplorerFileListPane extends VLayout {
 
 	private static final String REFRESH_ICON = "[SKIN]/actions/refresh.png";
 	private static final String EXPORT_ICON = "[SKINIMG]/actions/download.png";
+
+	/** Limit選択用Map */
+	private static LinkedHashMap<Integer, String> limitValueMap;
+	static {
+		limitValueMap = new LinkedHashMap<Integer, String>();
+		limitValueMap.put(-1, "-1");
+		limitValueMap.put(50, "50");
+		limitValueMap.put(100, "100");
+		limitValueMap.put(200, "200");
+		limitValueMap.put(500, "500");
+	}
+
+	private ComboBoxItem limitItem;
 
 	private ListGrid grid;
 
@@ -83,6 +98,13 @@ public class LogExplorerFileListPane extends VLayout {
 		toolStrip.addMember(lblTitle);
 
 		toolStrip.addFill();
+
+		limitItem = new ComboBoxItem();
+		limitItem.setTitle("Limit");
+		limitItem.setValueMap(limitValueMap);
+		// limitItem.setValidators(new IsIntegerValidator());
+		limitItem.setValue(100);
+		toolStrip.addFormItem(limitItem);
 
 		final ToolStripButton refreshButton = new ToolStripButton();
 		refreshButton.setIcon(REFRESH_ICON);
@@ -176,6 +198,13 @@ public class LogExplorerFileListPane extends VLayout {
 		// サーバーにリクエストが飛ぶように一意の条件を付与
 		Criteria condition = new Criteria("dummy", String.valueOf(System.currentTimeMillis()));
 
+		// Limit指定。未指定または文字列など変換不可の場合は-1
+		if (limitItem.getValueAsInteger() == null) {
+			limitItem.setValue(-1);
+		}
+		condition.addCriteria(LogFileDS.LIMIT, limitItem.getValueAsInteger());
+
+		// 画面上でのフィルタ条件
 		if (filter != null) {
 			Map<?, ?> criteriaMap = filter.getValues();
 			for (Object key : criteriaMap.keySet()) {

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/server/tools/rpc/logexplorer/LogExplorerServiceImpl.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/server/tools/rpc/logexplorer/LogExplorerServiceImpl.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
@@ -111,46 +110,42 @@ public class LogExplorerServiceImpl extends XsrfProtectedServiceServlet implemen
 		List<String> filters = acs.getTenantLogFileFilters();
 		List<Pattern> filterPatterns = filters.stream().map(Pattern::compile).collect(Collectors.toList());
 
+		// 画面上の入力Filter条件を取得
+		Pattern fileNamePattern = null;
+		Pattern lastModifiedPattern = null;
+		try {
+			fileNamePattern = StringUtil.isNotEmpty(logFileCondition.getFileName())
+					? Pattern.compile(logFileCondition.getFileName())
+					: null;
+			lastModifiedPattern = StringUtil.isNotEmpty(logFileCondition.getLastModified())
+					? Pattern.compile(logFileCondition.getLastModified())
+					: null;
+		} catch (PatternSyntaxException e) {
+			logger.warn("log file filter pattern is invalid. LogFileCondition=" + logFileCondition.getFileName() + ",LastModifiedCondition="
+					+ logFileCondition.getLastModified());
+			return Collections.emptyList();
+		}
+
 		List<LogFile> logFiles = new ArrayList<>();
 
 		DateFormat dateFormat = DateUtil.getSimpleDateFormat(TemplateUtil.getLocaleFormat().getOutputDatetimeSecFormat(), true);
 		for (String logHome : logHomes) {
-			logFiles.addAll(searchLogFile(logHome, filterPatterns, dateFormat, logHomes.size() > 1));
+			logFiles.addAll(searchLogFile(logHome, filterPatterns, fileNamePattern, lastModifiedPattern,
+					logFiles.size(), logFileCondition.getLimit(), dateFormat, logHomes.size() > 1));
+
+			// checkLimit
+			if (logFileCondition.getLimit() > 0 && logFiles.size() >= logFileCondition.getLimit()) {
+				break;
+			}
 		}
 
 		if (logFiles.isEmpty()) {
 			logger.debug("log file is not found. log home="
 					+ ToStringBuilder.reflectionToString(logHomes.toArray(new String[] {}), ToStringStyle.SIMPLE_STYLE));
 		} else {
-			// 画面上のFilter条件を適用
-			try {
-				final Pattern fileNamePattern = StringUtil.isNotEmpty(logFileCondition.getFileName())
-						? Pattern.compile(logFileCondition.getFileName())
-						: null;
-				final Pattern lastModifiedPattern = StringUtil.isNotEmpty(logFileCondition.getLastModified())
-						? Pattern.compile(logFileCondition.getLastModified())
-						: null;
-
-				logFiles = logFiles.stream()
-						.filter(logFile -> {
-							if (fileNamePattern != null) {
-								Matcher matcher = fileNamePattern.matcher(logFile.getFileName());
-								return matcher.find();
-							}
-							return true;
-						}).filter(logFile -> {
-							if (lastModifiedPattern != null) {
-								Matcher matcher = lastModifiedPattern.matcher(logFile.getLastModified());
-								return matcher.find();
-							}
-							return true;
-						}).sorted(Comparator.comparing((LogFile logFile) -> logFile.getFileName()))
-						.collect(Collectors.toList());
-			} catch (PatternSyntaxException e) {
-				logger.warn("log file filter pattern is invalid. LogFileCondition=" + logFileCondition.getFileName() + ",LastModifiedCondition="
-						+ logFileCondition.getLastModified());
-				return Collections.emptyList();
-			}
+			logFiles = logFiles.stream()
+					.sorted(Comparator.comparing((LogFile logFile) -> logFile.getFileName()))
+					.collect(Collectors.toList());
 		}
 		return logFiles;
 	}
@@ -159,12 +154,17 @@ public class LogExplorerServiceImpl extends XsrfProtectedServiceServlet implemen
 	 * <p>ファイル検索</p>
 	 *
 	 * @param home RootとなるHOMEパス
-	 * @param filterPatterns ファイルに対するFilter
+	 * @param filterPatterns ファイル名に対するconfig定義のFilter
+	 * @param fileNamePattern ファイル名に対するFilter
+	 * @param lastModifiedPattern 最終更新日時に対するFilter
+	 * @param count 現在の対象ファイル数
+	 * @param limit 取得上限数
 	 * @param dateFormat 最終更新日時変換用Format
 	 * @param multiHomes Logホームが複数設定されているか
-	 * @return
+	 * @return ログファイル情報
 	 */
-	private List<LogFile> searchLogFile(String home, List<Pattern> filterPatterns, DateFormat dateFormat, boolean multiHomes) {
+	private List<LogFile> searchLogFile(String home, List<Pattern> filterPatterns,
+			Pattern fileNamePattern, Pattern lastModifiedPattern, int count, int limit, DateFormat dateFormat, boolean multiHomes) {
 
 		if (home.contains("/*/")) {
 			//*を含む場合は、パスを分解。固定部分の抽出
@@ -181,10 +181,11 @@ public class LogExplorerServiceImpl extends XsrfProtectedServiceServlet implemen
 				}
 				rootPath += path + "/";
 			}
-			return searchDynamicLogFile(rootPath, homePaths, index, rootPath, filterPatterns, dateFormat, multiHomes);
+			return searchDynamicLogFile(rootPath, homePaths, index, rootPath, filterPatterns,
+					fileNamePattern, lastModifiedPattern, count, limit, dateFormat, multiHomes);
 		} else {
-			//*が含まれない場合は単純に検索(こっちのほうが無駄な処理はない)
-			return searchStaticLogFile(home, home, filterPatterns, dateFormat, multiHomes);
+			// *が含まれない場合は単純に検索(こっちのほうが無駄な処理はない)
+			return searchStaticLogFile(home, home, filterPatterns, fileNamePattern, lastModifiedPattern, count, limit, dateFormat, multiHomes);
 		}
 	}
 
@@ -193,12 +194,17 @@ public class LogExplorerServiceImpl extends XsrfProtectedServiceServlet implemen
 	 *
 	 * @param home RootとなるHOMEパス
 	 * @param path 検索対象パス
-	 * @param filterPatterns ファイル名に対するFilter
+	 * @param filterPatterns ファイル名に対するconfig定義のFilter
+	 * @param fileNamePattern ファイル名に対するFilter
+	 * @param lastModifiedPattern 最終更新日時に対するFilter
+	 * @param count 現在の対象ファイル数
+	 * @param limit 取得上限数
 	 * @param dateFormat 最終更新日時変換用Format
 	 * @param multiHomes Logホームが複数設定されているか
-	 * @return
+	 * @return ログファイル情報
 	 */
-	private List<LogFile> searchStaticLogFile(String home, String path, List<Pattern> filterPatterns, DateFormat dateFormat, boolean multiHomes) {
+	private List<LogFile> searchStaticLogFile(String home, String path, List<Pattern> filterPatterns,
+			Pattern fileNamePattern, Pattern lastModifiedPattern, int count, int limit, DateFormat dateFormat, boolean multiHomes) {
 
 		List<LogFile> dirList = new ArrayList<>();
 		List<LogFile> fileList = new ArrayList<>();
@@ -206,39 +212,34 @@ public class LogExplorerServiceImpl extends XsrfProtectedServiceServlet implemen
 		File logsDir = new File(path);
 		if (logsDir.exists() && logsDir.isDirectory()) {
 			File[] logs = logsDir.listFiles();
-			for (File f : logs) {
-				if (f.isDirectory()) {
-					dirList.addAll(searchStaticLogFile(home, f.getPath(), filterPatterns, dateFormat, multiHomes));
+			for (File file : logs) {
+				if (file.isDirectory()) {
+					dirList.addAll(searchStaticLogFile(home, file.getPath(), filterPatterns,
+							fileNamePattern, lastModifiedPattern, count + dirList.size() + fileList.size(), limit, dateFormat, multiHomes));
 				} else {
-					String checkName = getFileName(home, f, multiHomes);
-					if (!filterPatterns.isEmpty()) {
-						// Filterチェック
-						for (Pattern filter : filterPatterns) {
-							if (filter.matcher(checkName).matches()) {
-								LogFile info = new LogFile();
-								info.setPath(f.getPath());
-								info.setFileName(checkName);
-								info.setLastModified(dateFormat.format(new Timestamp(f.lastModified())));
-								info.setSize(f.length());
-								fileList.add(info);
-								break;
-							}
-						}
-					} else {
+					String checkName = getFileName(home, file, multiHomes);
+
+					boolean isMatch = isMatchFile(file, checkName, filterPatterns, fileNamePattern, lastModifiedPattern, dateFormat);
+					if (isMatch) {
 						LogFile info = new LogFile();
-						info.setPath(f.getPath());
+						info.setPath(file.getPath());
 						info.setFileName(checkName);
-						info.setLastModified(dateFormat.format(new Timestamp(f.lastModified())));
-						info.setSize(f.length());
+						info.setLastModified(dateFormat.format(new Timestamp(file.lastModified())));
+						info.setSize(file.length());
 						fileList.add(info);
 					}
+				}
+
+				// checkLimit
+				if (limit > 0 && count + dirList.size() + fileList.size() >= limit) {
+					break;
 				}
 			}
 		} else {
 			logger.debug("either logsDir doesn't exist or is not a folder. path=" + path);
 		}
 
-		// directy->fileの順番で
+		// サブdirectory配下->fileの順番で
 		List<LogFile> list = new ArrayList<>(dirList.size() + fileList.size());
 		list.addAll(dirList);
 		list.addAll(fileList);
@@ -253,13 +254,17 @@ public class LogExplorerServiceImpl extends XsrfProtectedServiceServlet implemen
 	 * @param homePaths HOMEを/で区切ったパス
 	 * @param index     現在のindex
 	 * @param path      検索対象パス
-	 * @param filterPatterns ファイル名に対するFilter
+	 * @param filterPatterns ファイル名に対するconfig定義のFilter
+	 * @param fileNamePattern ファイル名に対するFilter
+	 * @param lastModifiedPattern 最終更新日時に対するFilter
+	 * @param count 現在の対象ファイル数
+	 * @param limit 取得上限数
 	 * @param dateFormat 最終更新日時変換用Format
 	 * @param multiHomes Logホームが複数設定されているか
-	 * @return
+	 * @return ログファイル情報
 	 */
 	private List<LogFile> searchDynamicLogFile(String fixedPath, String[] homePaths, int index, String path, List<Pattern> filterPatterns,
-			DateFormat dateFormat, boolean multiHomes) {
+			Pattern fileNamePattern, Pattern lastModifiedPattern, int count, int limit, DateFormat dateFormat, boolean multiHomes) {
 
 		List<LogFile> dirList = new ArrayList<>();
 		List<LogFile> fileList = new ArrayList<>();
@@ -267,52 +272,48 @@ public class LogExplorerServiceImpl extends XsrfProtectedServiceServlet implemen
 		File logsDir = new File(path);
 		if (logsDir.exists() && logsDir.isDirectory()) {
 			File[] logs = logsDir.listFiles();
-			for (File f : logs) {
-				if (f.isDirectory()) {
+			for (File file : logs) {
+				if (file.isDirectory()) {
 					if (index < homePaths.length) {
 						//フォルダ名チェック
 						if (!homePaths[index].equals("*")) {
-							if (!f.getName().equals(homePaths[index])) {
+							if (!file.getName().equals(homePaths[index])) {
 								//対象外
 								continue;
 							}
 						}
 					}
-					dirList.addAll(searchDynamicLogFile(fixedPath, homePaths, index + 1, f.getPath(), filterPatterns, dateFormat, multiHomes));
+					dirList.addAll(searchDynamicLogFile(fixedPath, homePaths, index + 1, file.getPath(), filterPatterns,
+							fileNamePattern, lastModifiedPattern, count + dirList.size() + fileList.size(), limit, dateFormat, multiHomes));
 				} else {
 					if (index < homePaths.length) {
 						//階層として、対象外
 						continue;
 					}
-					if (!filterPatterns.isEmpty()) {
-						// Filterチェック
-						for (Pattern filter : filterPatterns) {
-							if (filter.matcher(f.getName()).matches()) {
-								LogFile info = new LogFile();
-								info.setPath(f.getPath());
-								//info.setFileName(f.getName());
-								info.setFileName(getFileName(fixedPath, f, multiHomes));
-								info.setLastModified(dateFormat.format(new Timestamp(f.lastModified())));
-								info.setSize(f.length());
-								fileList.add(info);
-								break;
-							}
-						}
-					} else {
+
+					String checkName = getFileName(fixedPath, file, multiHomes);
+
+					boolean isMatch = isMatchFile(file, checkName, filterPatterns, fileNamePattern, lastModifiedPattern, dateFormat);
+					if (isMatch) {
 						LogFile info = new LogFile();
-						info.setPath(f.getPath());
-						info.setFileName(getFileName(fixedPath, f, multiHomes));
-						info.setLastModified(dateFormat.format(new Timestamp(f.lastModified())));
-						info.setSize(f.length());
+						info.setPath(file.getPath());
+						info.setFileName(checkName);
+						info.setLastModified(dateFormat.format(new Timestamp(file.lastModified())));
+						info.setSize(file.length());
 						fileList.add(info);
 					}
+				}
+
+				// checkLimit
+				if (limit > 0 && count + dirList.size() + fileList.size() >= limit) {
+					break;
 				}
 			}
 		} else {
 			logger.debug("either logsDir doesn't exist or is not a folder. path=" + path);
 		}
 
-		// directy->fileの順番で
+		// サブdirectory配下->fileの順番で
 		List<LogFile> list = new ArrayList<>(dirList.size() + fileList.size());
 		list.addAll(dirList);
 		list.addAll(fileList);
@@ -337,6 +338,47 @@ public class LogExplorerServiceImpl extends XsrfProtectedServiceServlet implemen
 			return path.substring(hidePrefixPath.length());
 		}
 		return path;
+	}
+
+	/**
+	 * <p>ファイルのFilterチェック</p>
+	 *
+	 * @param file ファイル
+	 * @param fileName ファイル名(チェック用)
+	 * @param filterPatterns ファイル名に対するconfig定義のFilter
+	 * @param fileNamePattern ファイル名に対するFilter
+	 * @param lastModifiedPattern 最終更新日時に対するFilter
+	 * @param dateFormat 最終更新日時変換用Format
+	 * @return チェック結果
+	 */
+	private boolean isMatchFile(File file, String fileName, List<Pattern> filterPatterns,
+			Pattern fileNamePattern, Pattern lastModifiedPattern, DateFormat dateFormat) {
+
+		boolean isMatch = false;
+
+		// Filterチェック
+		if (!filterPatterns.isEmpty()) {
+			for (Pattern filter : filterPatterns) {
+				if (filter.matcher(fileName).matches()) {
+					isMatch = true;
+					break;
+				}
+			}
+		} else {
+			isMatch = true;
+		}
+
+		// ファイル名チェック
+		if (isMatch && fileNamePattern != null) {
+			isMatch = fileNamePattern.matcher(fileName).find();
+		}
+
+		// 最終更新日時チェック
+		if (isMatch && lastModifiedPattern != null) {
+			isMatch = lastModifiedPattern.matcher(dateFormat.format(new Timestamp(file.lastModified()))).find();
+		}
+
+		return isMatch;
 	}
 
 	@Override

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/shared/tools/dto/logexplorer/LogFileCondition.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/shared/tools/dto/logexplorer/LogFileCondition.java
@@ -28,11 +28,32 @@ public class LogFileCondition implements Serializable {
 
 	private static final long serialVersionUID = 2459207754956721755L;
 
+	/** Limit件数 */
+	private int limit;
+
 	/** ログファイル名(表示用)条件（正規表現） */
 	private String fileName;
 
 	/** 最終更新日時条件（正規表現） */
 	private String lastModified;
+
+	/**
+	 * Limit件数を返します。
+	 *
+	 * @return Limit件数
+	 */
+	public int getLimit() {
+		return limit;
+	}
+
+	/**
+	 * Limit件数を設定します。
+	 *
+	 * @param limit Limit件数
+	 */
+	public void setLimit(int limit) {
+		this.limit = limit;
+	}
 
 	/**
 	 * ログファイル名(表示用)条件（正規表現）を返します。


### PR DESCRIPTION
## 対応内容
LogExplorerにて、画面上でログファイルの表示件数のLimitを指定可能にする。
デフォルトは100とする。

closes #1673

## 補足情報
Limitについて、 service-config で `logHome` として指定されたフォルダを、複数ある場合は先頭から順番に検索し、
各フォルダに対して、 `File#listFiles()` により取得される順番でLimitまでファイルを取得する。

画面上でのファイル名などでのソート指定（降順など）は、Limitまで取得されたデータに適用される。
フォルダをソートした状態に対して、Limitをチェックするわけではない。
