### PR TITLE
文字列をJSON用にエスケープ・アンエスケープする機能を追加

### DIFF
--- a/iplass-core/src/main/java/org/iplass/mtp/util/StringUtil.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/util/StringUtil.java
@@ -54,13 +54,11 @@ public class StringUtil {
 		APOS_ESCAPE = Collections.unmodifiableMap(initMap);
 	}
 
-	private static final CharSequenceTranslator ESCAPE_HTML4_SP =
-			new AggregateTranslator(
-				new LookupTranslator(EntityArrays.BASIC_ESCAPE),
-				new LookupTranslator(APOS_ESCAPE),
-				new LookupTranslator(EntityArrays.ISO8859_1_ESCAPE),
-				new LookupTranslator(EntityArrays.HTML40_EXTENDED_ESCAPE)
-			);
+	private static final CharSequenceTranslator ESCAPE_HTML4_SP = new AggregateTranslator(
+			new LookupTranslator(EntityArrays.BASIC_ESCAPE),
+			new LookupTranslator(APOS_ESCAPE),
+			new LookupTranslator(EntityArrays.ISO8859_1_ESCAPE),
+			new LookupTranslator(EntityArrays.HTML40_EXTENDED_ESCAPE));
 
 	/**
 	 * 文字列中に、'があった場合、''とエスケープする。
@@ -93,9 +91,9 @@ public class StringUtil {
 		char current = 0;
 		for (int i = 0; i < str.length(); i++) {
 			current = str.charAt(i);
-		
+
 			switch (current) {
-		//	case '\'':
+			//	case '\'':
 			case '%':
 			case '_':
 			case '\\':
@@ -160,6 +158,7 @@ public class StringUtil {
 		}
 		return StringEscapeUtils.escapeXml10(str);
 	}
+
 	/**
 	 * XML1.1仕様に基づくエスケープ処理をする。
 	 *
@@ -183,9 +182,11 @@ public class StringUtil {
 		}
 		return StringEscapeUtils.escapeXml11(str);
 	}
+
 	public static String unescapeXml(String str) {
 		return StringEscapeUtils.unescapeXml(str);
 	}
+
 	/**
 	 * HTML4.0レベルで定義されるエンティティ、および'を&#039;に変換するエスケープ処理をする。
 	 *
@@ -195,6 +196,7 @@ public class StringUtil {
 	public static String escapeHtml(String str) {
 		return ESCAPE_HTML4_SP.translate(str);
 	}
+
 	/**
 	 * HTML4.0レベルで定義されるエンティティ、および'を&#039;に変換するエスケープ処理をする。
 	 *
@@ -208,8 +210,28 @@ public class StringUtil {
 		}
 		return ESCAPE_HTML4_SP.translate(str);
 	}
+
 	public static String unescapeHtml(String str) {
 		return StringEscapeUtils.unescapeHtml4(str);
+	}
+
+	/**
+	 * JSON仕様（RFC4627）に基づくエスケープ処理をする。
+	 * 
+	 * @param str
+	 * @param emptyIfNull strがnullの場合、空文字で返却するか否か
+	 * @return エスケープされた文字列
+	 */
+	public static String escapeJson(String str, boolean emptyIfNull) {
+		if (emptyIfNull && str == null) {
+			return "";
+		}
+
+		return StringEscapeUtils.escapeJson(str);
+	}
+
+	public static String unescapeJson(String str) {
+		return StringEscapeUtils.unescapeJson(str);
 	}
 
 	/**
@@ -226,15 +248,19 @@ public class StringUtil {
 	public static boolean isEmpty(String str) {
 		return StringUtils.isEmpty(str);
 	}
+
 	public static boolean isNotEmpty(String str) {
 		return StringUtils.isNotEmpty(str);
 	}
+
 	public static boolean isBlank(String str) {
 		return StringUtils.isBlank(str);
 	}
+
 	public static boolean isNotBlank(String str) {
 		return StringUtils.isNotBlank(str);
 	}
+
 	public static String deleteWhitespace(String str) {
 		return StringUtils.deleteWhitespace(str);
 	}


### PR DESCRIPTION
<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->

iplass-coreの `StringUtil` に、文字列をJSON用にエスケープ・アンエスケープする機能を追加する。

closes #1689 

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->

以下を含む文字列をエスケープできることを確認した。

- `\"`
- `\\`
- `/`
- `\b`
- `\f`
- `\n`
- `\r`
- `\t`
