### PR TITLE
Entity更新時の参照先のロード処理のパフォーマンス改善

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/GemConfigService.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/GemConfigService.java
@@ -43,7 +43,10 @@ import org.iplass.mtp.view.generic.element.section.SearchConditionSection.FileSu
  */
 public class GemConfigService implements Service {
 
-	/** リクエストのパラメータを基に参照データをロードする際、参照プロパティも合わせてロードするか */
+	/** リクエストのパラメータをもとに参照データを更新する際に、参照データをロードしなおすか。*/
+	private boolean mustLoadWithReference;
+
+	/** リクエストのパラメータを基に参照データを更新する際に、参照エンティティの参照プロパティも合わせてロードするか */
 	private boolean loadWithReference;
 
 	/** 詳細表示画面で数値プロパティの値をカンマでフォーマットするか */
@@ -176,8 +179,9 @@ public class GemConfigService implements Service {
 				: null;
 
 		imageColors = config.getValues("imageColors", ImageColorSetting.class);
-		loadWithReference = Boolean.valueOf(config.getValue("loadWithReference"));
-		formatNumberWithComma = Boolean.valueOf(config.getValue("formatNumberWithComma"));
+		mustLoadWithReference = config.getValue("mustLoadWithReference", Boolean.class, true);
+		loadWithReference = config.getValue("loadWithReference", Boolean.class, false);
+		formatNumberWithComma = config.getValue("formatNumberWithComma", Boolean.class, false);
 
 		fileSupportType = config.getValue("fileSupportType", FileSupportType.class, FileSupportType.CSV);
 		csvDownloadMaxCount = config.getValue("csvDownloadMaxCount", Integer.class, 65535);
@@ -263,8 +267,7 @@ public class GemConfigService implements Service {
 						Entity.CREATE_DATE,
 						Entity.UPDATE_BY,
 						Entity.UPDATE_DATE,
-						Entity.LOCKED_BY
-						));
+						Entity.LOCKED_BY));
 				String systemPropertiesStr = config.getValue("autoGenerateSystemProperties");
 				String[] inputArray = systemPropertiesStr.split(",");
 				String[] validArray = Arrays.stream(inputArray)
@@ -290,8 +293,16 @@ public class GemConfigService implements Service {
 	}
 
 	/**
-	 * リクエストのパラメータを基に参照データをロードする際、参照プロパティも合わせてロードするかを取得します。
-	 * @return リクエストのパラメータを基に参照データをロードする際、参照プロパティも合わせてロードするか
+	 * リクエストのパラメータをもとに参照データを更新する際に、参照データをロードしなおすかを取得します。
+	 * @return リクエストのパラメータをもとに参照データを更新する際に、参照データをロードしなおすか
+	 */
+	public boolean isMustLoadWithReference() {
+		return mustLoadWithReference;
+	}
+
+	/**
+	 * リクエストのパラメータを基に参照データを更新する際に、参照エンティティの参照プロパティも合わせてロードするかを取得します。
+	 * @return リクエストのパラメータを基に参照データを更新する際に、参照エンティティの参照プロパティも合わせてロードするか
 	 */
 	public boolean isLoadWithReference() {
 		return loadWithReference;

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/bulk/BulkCommandContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/bulk/BulkCommandContext.java
@@ -43,6 +43,7 @@ import org.iplass.gem.command.generic.detail.RegistrationPropertyBaseHandler;
 import org.iplass.mtp.ApplicationException;
 import org.iplass.mtp.command.RequestContext;
 import org.iplass.mtp.entity.Entity;
+import org.iplass.mtp.entity.EntityKey;
 import org.iplass.mtp.entity.EntityManager;
 import org.iplass.mtp.entity.LoadOption;
 import org.iplass.mtp.entity.ValidateError;
@@ -264,26 +265,24 @@ public class BulkCommandContext extends RegistrationCommandContext {
 		//→件数取れないため通常の参照扱いで処理が終わる
 		Long count = getLongValue(prefix + p.getName() + "_count");
 		if (p.getMultiplicity() == 1) {
-			Entity entity = null;
+			List<Entity> list = null;
 			if (count == null) {
 				String key = getParam(prefix + p.getName());
-				entity = getRefEntity(rp.getObjectDefinitionName(), key);
+				list = getRefEntities(rp.getObjectDefinitionName(), new String[] { key });
 			} else {
-				List<Entity> list = getRefTableValues(rp, defName, count, prefix);
-				if (list.size() > 0) {
-					entity = list.get(0);
-				}
+				list = getRefTableValues(rp, defName, count, prefix);
 			}
-			return entity;
+			if (list.size() > 0) {
+				return list.get(0);
+			} else {
+				return null;
+			}
 		} else {
 			List<Entity> list = null;
 			if (count == null) {
 				String[] params = getParams(prefix + p.getName());
 				if (params != null) {
-					list = Arrays.stream(params)
-							.map(key -> getRefEntity(rp.getObjectDefinitionName(), key))
-							.filter(value -> value != null)
-							.collect(Collectors.toList());
+					list = getRefEntities(rp.getObjectDefinitionName(), params);
 				}
 			} else {
 				//参照型で参照先のデータを作成・編集するケース
@@ -306,38 +305,61 @@ public class BulkCommandContext extends RegistrationCommandContext {
 		}
 	}
 
-	private Entity getRefEntity(String definitionName, String key) {
-		Entity entity = null;
-		String oid = null;
-		Long version = null;
-		if (key != null) {
-			int lastIndex = key.lastIndexOf("_");
+	/**
+	 * NestTable以外の参照先編集データを返します。
+	 *
+	 * @param definitionName 参照先Entity定義名
+	 * @param keyParameters oidとversionのパラメータ情報
+	 * @return 編集データ
+	 */
+	private List<Entity> getRefEntities(String definitionName, String[] keyParameters) {
 
-			if (lastIndex < 0) {
-				oid = key;
-			} else {
-				oid = key.substring(0, lastIndex);
-				version = CommandUtil.getLong(key.substring(lastIndex + 1));
-			}
-		}
-		if (StringUtil.isNotBlank(oid)) {
-			//バリデーションエラー時に消えないようにデータ読み込み
-			//gemの設定により、参照を合わせて読み込むか切り替える
+		List<EntityKey> keys = Arrays.stream(keyParameters)
+				.map(key -> {
+					int lastIndex = key.lastIndexOf("_");
+					String oid = null;
+					Long version = null;
+					if (lastIndex < 0) {
+						oid = key;
+					} else {
+						oid = key.substring(0, lastIndex);
+						version = CommandUtil.getLong(key.substring(lastIndex + 1));
+					}
+					return new EntityKey(oid, version);
+				})
+				.collect(Collectors.toList());
+
+		List<Entity> entities = null;
+		if (gemConfig.isMustLoadWithReference()) {
+			// 参照Entityをロードし直す
 			if (gemConfig.isLoadWithReference()) {
-				entity = entityManager.load(oid, version, definitionName);
+				entities = entityManager.batchLoad(keys, definitionName);
 			} else {
-				entity = entityManager.load(oid, version, definitionName, new LoadOption(false, false));
+				entities = entityManager.batchLoad(keys, definitionName, new LoadOption(false, false));
 			}
+		} else {
+			// 参照Entityをロードし直さない
+			final EntityDefinition referenceEntityDefinition = definitionManager.get(definitionName);
+			entities = keys.stream()
+					.map(key -> {
+						Entity entity = newEntity(referenceEntityDefinition);
+						entity.setOid(key.getOid());
+						entity.setVersion(key.getVersion());
+						return entity;
+					})
+					.collect(Collectors.toList());
 		}
-		return entity;
+		return entities;
 	}
 
 	/**
-	 * リクエストパラメータからテーブルの参照型データの値を取得します。
-	 * @param p プロパティ定義
-	 * @param defName 参照型のEntity定義名
-	 * @param count 参照データの最大件数
-	 * @return 参照データのリスト
+	 * NestTableの編集データを返します。
+	 *
+	 * @param p 対象ReferenceProperty定義
+	 * @param defName 参照先Entity定義名
+	 * @param count 件数
+	 * @param prefix 参照型のプロパティのリクエストパラメータに設定されているプレフィックス
+	 * @return NestTableの編集データ
 	 */
 	private List<Entity> getRefTableValues(ReferenceProperty p, String defName, Long count, String prefix) {
 		final List<Entity> list = new ArrayList<>();

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/bulk/BulkCommandContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/bulk/BulkCommandContext.java
@@ -199,7 +199,7 @@ public class BulkCommandContext extends RegistrationCommandContext {
 		}
 		String targetRow = rowParam.substring(0, rowParam.indexOf("_"));
 		String targetParam = rowParam.substring(rowParam.indexOf("_") + 1);
-		String[] params = new String[] { targetRow, targetParam };
+		String[] params = { targetRow, targetParam };
 		return params;
 	}
 
@@ -219,7 +219,7 @@ public class BulkCommandContext extends RegistrationCommandContext {
 	private boolean hasDifferentPropertyValue(String propName) {
 		Set<String> oids = getOids();
 		for (String oid : oids) {
-			for (Long version: getVersions(oid)) {
+			for (Long version : getVersions(oid)) {
 				List<Object> propValues = bulkCommandParams.stream()
 						.filter(p -> p.getOid().equals(oid) && p.getVersion().equals(version))
 						.map(p -> p.getValue(propName))
@@ -270,7 +270,9 @@ public class BulkCommandContext extends RegistrationCommandContext {
 				entity = getRefEntity(rp.getObjectDefinitionName(), key);
 			} else {
 				List<Entity> list = getRefTableValues(rp, defName, count, prefix);
-				if (list.size() > 0) entity = list.get(0);
+				if (list.size() > 0) {
+					entity = list.get(0);
+				}
 			}
 			return entity;
 		} else {
@@ -388,7 +390,9 @@ public class BulkCommandContext extends RegistrationCommandContext {
 
 	private void addNestTableRegistHandler(ReferenceProperty p, List<Entity> list, EntityDefinition red, PropertyColumn property) {
 		// ネストテーブルはプロパティ単位で登録可否決定
-		if (!NestTableReferenceRegistHandler.canRegist(property, getRegistrationPropertyBaseHandler())) return;
+		if (!NestTableReferenceRegistHandler.canRegist(property, getRegistrationPropertyBaseHandler())) {
+			return;
+		}
 
 		ReferencePropertyEditor editor = (ReferencePropertyEditor) property.getBulkUpdateEditor();
 
@@ -404,7 +408,8 @@ public class BulkCommandContext extends RegistrationCommandContext {
 			target = list;
 		}
 
-		ReferenceRegistHandler handler = NestTableReferenceRegistHandler.get(this, list, red, p, property, editor.getNestProperties(), getRegistrationPropertyBaseHandler());
+		ReferenceRegistHandler handler = NestTableReferenceRegistHandler.get(this, list, red, p, property, editor.getNestProperties(),
+				getRegistrationPropertyBaseHandler());
 		if (handler != null) {
 			handler.setForceUpdate(editor.isForceUpadte());
 			getReferenceRegistHandlers().add(handler);
@@ -420,9 +425,13 @@ public class BulkCommandContext extends RegistrationCommandContext {
 		for (PropertyDefinition pd : getPropertyList()) {
 			if (pd.getMultiplicity() != 1) {
 				Object[] obj = entity.getValue(pd.getName());
-				if (obj != null && obj.length > 0) return false;
+				if (obj != null && obj.length > 0) {
+					return false;
+				}
 			} else {
-				if (entity.getValue(pd.getName()) != null) return false;
+				if (entity.getValue(pd.getName()) != null) {
+					return false;
+				}
 			}
 		}
 		return true;
@@ -526,7 +535,9 @@ public class BulkCommandContext extends RegistrationCommandContext {
 			PropertyDefinition pd = getProperty(property.getPropertyName());
 			if (pd instanceof ReferenceProperty) {
 				String mappedBy = ((ReferenceProperty) pd).getMappedBy();
-				if (StringUtil.isBlank(mappedBy)) continue;
+				if (StringUtil.isBlank(mappedBy)) {
+					continue;
+				}
 
 				if (property.getBulkUpdateEditor() instanceof ReferencePropertyEditor) {
 					ReferencePropertyEditor editor = (ReferencePropertyEditor) property.getBulkUpdateEditor();
@@ -614,14 +625,14 @@ public class BulkCommandContext extends RegistrationCommandContext {
 	}
 
 	public Entity createEntity(String oid, Long version, Timestamp updateDate) {
-		Entity entity = createEntityInternal("" , null);
+		Entity entity = createEntityInternal("", null);
 		entity.setOid(oid);
 		entity.setUpdateDate(updateDate);
-//		if (isVersioned()) {
+		//		if (isVersioned()) {
 		// バージョン管理にかかわらず、セットする問題ないかな..
 		entity.setVersion(version);
-//		}
-//		setVirtualPropertyValue(entity);
+		//		}
+		//		setVirtualPropertyValue(entity);
 		getRegistrationInterrupterHandler().dataMapping(entity);
 		validate(entity);
 		return entity;
@@ -631,7 +642,9 @@ public class BulkCommandContext extends RegistrationCommandContext {
 		Entity entity = newEntity();
 		for (PropertyColumn pc : getProperty()) {
 			PropertyDefinition p = getProperty(pc.getPropertyName());
-			if (p == null || skipProps.contains(p.getName())) continue;
+			if (p == null || skipProps.contains(p.getName())) {
+				continue;
+			}
 			Object value = getPropValue(p, paramPrefix);
 			entity.setValue(p.getName(), value);
 			if (errorPrefix != null) {
@@ -639,8 +652,8 @@ public class BulkCommandContext extends RegistrationCommandContext {
 				// Entity生成時にエラーが発生していないかチェックして置き換え
 				String errorName = errorPrefix + p.getName();
 				getErrors().stream()
-					.filter(error -> error.getPropertyName().equals(name))
-					.forEach(error -> error.setPropertyName(errorName));
+						.filter(error -> error.getPropertyName().equals(name))
+						.forEach(error -> error.setPropertyName(errorName));
 			}
 		}
 		return entity;
@@ -667,7 +680,7 @@ public class BulkCommandContext extends RegistrationCommandContext {
 				Entity[] ary = null;
 				if (val != null) {
 					if (val instanceof Entity) {
-						ary = new Entity[] {(Entity) val};
+						ary = new Entity[] { (Entity) val };
 					} else if (val instanceof Entity[]) {
 						ary = (Entity[]) val;
 					}
@@ -795,7 +808,7 @@ public class BulkCommandContext extends RegistrationCommandContext {
 	 */
 	private void setValidateErrorMessage(RangePropertyEditor editor, String fromName, String errorPrefix, String resourceStringKey) {
 		String errorMessage = TemplateUtil.getMultilingualString(editor.getErrorMessage(), editor.getLocalizedErrorMessageList());
-		if (StringUtil.isBlank(errorMessage )) {
+		if (StringUtil.isBlank(errorMessage)) {
 			errorMessage = resourceString(resourceStringKey);
 		}
 		ValidateError e = new ValidateError();
@@ -812,7 +825,7 @@ public class BulkCommandContext extends RegistrationCommandContext {
 	@SuppressWarnings("unchecked")
 	@Override
 	public List<PropertyColumn> getProperty() {
-//		String execType = getExecType();
+		//		String execType = getExecType();
 		List<PropertyColumn> propList = new ArrayList<>();
 		String updatePropName = getBulkUpdatePropName();
 		if (StringUtil.isEmpty(updatePropName)) {
@@ -843,7 +856,7 @@ public class BulkCommandContext extends RegistrationCommandContext {
 					dummy.setPropertyName(de.getToPropertyName());
 					dummy.setBulkUpdateEditor(de.getEditor());
 					propList.add(dummy);
-				//組み合わせで使うプロパティを通常のプロパティ扱いに
+					//組み合わせで使うプロパティを通常のプロパティ扱いに
 				} else if (pc.getBulkUpdateEditor() instanceof JoinPropertyEditor) {
 					JoinPropertyEditor je = (JoinPropertyEditor) pc.getBulkUpdateEditor();
 					for (NestProperty nest : je.getProperties()) {
@@ -853,7 +866,7 @@ public class BulkCommandContext extends RegistrationCommandContext {
 						dummy.setBulkUpdateEditor(nest.getEditor());
 						propList.add(dummy);
 					}
-				//組み合わせで使うプロパティを通常のプロパティ扱いに
+					//組み合わせで使うプロパティを通常のプロパティ扱いに
 				} else if (pc.getBulkUpdateEditor() instanceof NumericRangePropertyEditor) {
 					NumericRangePropertyEditor de = (NumericRangePropertyEditor) pc.getBulkUpdateEditor();
 					PropertyColumn dummy = new PropertyColumn();
@@ -989,7 +1002,8 @@ public class BulkCommandContext extends RegistrationCommandContext {
 		if (interrupter == null) {
 			// 何もしないデフォルトInterrupter生成
 			getLogger().debug("set default bulk update operation interrupter.");
-			interrupter = new BulkOperationInterrupter() {};
+			interrupter = new BulkOperationInterrupter() {
+			};
 		}
 		return interrupter;
 	}

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/bulk/MultiBulkCommandContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/bulk/MultiBulkCommandContext.java
@@ -177,7 +177,7 @@ public class MultiBulkCommandContext extends RegistrationCommandContext {
 		}
 		String targetRow = rowParam.substring(0, rowParam.indexOf("_"));
 		String targetParam = rowParam.substring(rowParam.indexOf("_") + 1);
-		String[] params = new String[] { targetRow, targetParam };
+		String[] params = { targetRow, targetParam };
 		return params;
 	}
 
@@ -197,7 +197,7 @@ public class MultiBulkCommandContext extends RegistrationCommandContext {
 	private boolean hasDifferentPropertyValue(String propName) {
 		Set<String> oids = getOids();
 		for (String oid : oids) {
-			for (Long version: getVersions(oid)) {
+			for (Long version : getVersions(oid)) {
 				List<Object> propValues = bulkCommandParams.stream()
 						.filter(p -> p.getOid().equals(oid) && p.getVersion().equals(version))
 						.map(p -> p.getValue(propName))
@@ -235,7 +235,9 @@ public class MultiBulkCommandContext extends RegistrationCommandContext {
 				entity = getRefEntity(rp.getObjectDefinitionName(), key);
 			} else {
 				List<Entity> list = getRefTableValues(rp, defName, count, prefix);
-				if (list.size() > 0) entity = list.get(0);
+				if (list.size() > 0) {
+					entity = list.get(0);
+				}
 			}
 			return entity;
 		} else {
@@ -353,7 +355,9 @@ public class MultiBulkCommandContext extends RegistrationCommandContext {
 
 	private void addNestTableRegistHandler(ReferenceProperty p, List<Entity> list, EntityDefinition red, PropertyItem property) {
 		// ネストテーブルはプロパティ単位で登録可否決定
-		if (!NestTableReferenceRegistHandler.canRegist(property, getRegistrationPropertyBaseHandler())) return;
+		if (!NestTableReferenceRegistHandler.canRegist(property, getRegistrationPropertyBaseHandler())) {
+			return;
+		}
 
 		// カスタム登録処理によるNestTableの更新制御
 		ReferenceRegistOption option = getRegistrationInterrupterHandler().getNestTableRegistOption(red, p.getName());
@@ -378,7 +382,8 @@ public class MultiBulkCommandContext extends RegistrationCommandContext {
 			target = list;
 		}
 
-		ReferenceRegistHandler handler = NestTableReferenceRegistHandler.get(this, list, red, p, property, editor.getNestProperties(), getRegistrationPropertyBaseHandler(), option);
+		ReferenceRegistHandler handler = NestTableReferenceRegistHandler.get(this, list, red, p, property, editor.getNestProperties(),
+				getRegistrationPropertyBaseHandler(), option);
 		if (handler != null) {
 			handler.setForceUpdate(editor.isForceUpadte());
 			getReferenceRegistHandlers().add(handler);
@@ -394,9 +399,13 @@ public class MultiBulkCommandContext extends RegistrationCommandContext {
 		for (PropertyDefinition pd : getPropertyList()) {
 			if (pd.getMultiplicity() != 1) {
 				Object[] obj = entity.getValue(pd.getName());
-				if (obj != null && obj.length > 0) return false;
+				if (obj != null && obj.length > 0) {
+					return false;
+				}
 			} else {
-				if (entity.getValue(pd.getName()) != null) return false;
+				if (entity.getValue(pd.getName()) != null) {
+					return false;
+				}
 			}
 		}
 		return true;
@@ -500,7 +509,9 @@ public class MultiBulkCommandContext extends RegistrationCommandContext {
 			PropertyDefinition pd = getProperty(property.getPropertyName());
 			if (pd instanceof ReferenceProperty) {
 				String mappedBy = ((ReferenceProperty) pd).getMappedBy();
-				if (StringUtil.isBlank(mappedBy)) continue;
+				if (StringUtil.isBlank(mappedBy)) {
+					continue;
+				}
 
 				if (property.getEditor() instanceof ReferencePropertyEditor) {
 					ReferencePropertyEditor editor = (ReferencePropertyEditor) property.getEditor();
@@ -578,14 +589,14 @@ public class MultiBulkCommandContext extends RegistrationCommandContext {
 	 * @return 空のプロパティは更新しないので、更新するプロパティが1件もない場合、nullを返します。
 	 */
 	public Entity createEntity(String oid, Long version, Timestamp updateDate) {
-		Entity entity = createEntityInternal("" , null);
+		Entity entity = createEntityInternal("", null);
 		entity.setOid(oid);
 		entity.setUpdateDate(updateDate);
-//		if (isVersioned()) {
+		//		if (isVersioned()) {
 		// バージョン管理にかかわらず、セットする問題ないかな..
 		entity.setVersion(version);
-//		}
-//		setVirtualPropertyValue(entity);
+		//		}
+		//		setVirtualPropertyValue(entity);
 		getRegistrationInterrupterHandler().dataMapping(entity);
 		validate(entity);
 
@@ -604,7 +615,9 @@ public class MultiBulkCommandContext extends RegistrationCommandContext {
 	private Entity createEntityInternal(String paramPrefix, String errorPrefix) {
 		Entity entity = newEntity();
 		for (PropertyDefinition p : getPropertyList()) {
-			if (skipProps.contains(p.getName())) continue;
+			if (skipProps.contains(p.getName())) {
+				continue;
+			}
 			Object value = getPropValue(p, paramPrefix);
 			entity.setValue(p.getName(), value);
 			if (errorPrefix != null) {
@@ -612,8 +625,8 @@ public class MultiBulkCommandContext extends RegistrationCommandContext {
 				// Entity生成時にエラーが発生していないかチェックして置き換え
 				String errorName = errorPrefix + p.getName();
 				getErrors().stream()
-					.filter(error -> error.getPropertyName().equals(name))
-					.forEach(error -> error.setPropertyName(errorName));
+						.filter(error -> error.getPropertyName().equals(name))
+						.forEach(error -> error.setPropertyName(errorName));
 			}
 		}
 		return entity;
@@ -641,7 +654,7 @@ public class MultiBulkCommandContext extends RegistrationCommandContext {
 				Entity[] ary = null;
 				if (val != null) {
 					if (val instanceof Entity) {
-						ary = new Entity[] {(Entity) val};
+						ary = new Entity[] { (Entity) val };
 					} else if (val instanceof Entity[]) {
 						ary = (Entity[]) val;
 					}
@@ -769,7 +782,7 @@ public class MultiBulkCommandContext extends RegistrationCommandContext {
 	 */
 	private void setValidateErrorMessage(RangePropertyEditor editor, String fromName, String errorPrefix, String resourceStringKey) {
 		String errorMessage = TemplateUtil.getMultilingualString(editor.getErrorMessage(), editor.getLocalizedErrorMessageList());
-		if (StringUtil.isBlank(errorMessage )) {
+		if (StringUtil.isBlank(errorMessage)) {
 			errorMessage = resourceString(resourceStringKey);
 		}
 		ValidateError e = new ValidateError();
@@ -777,7 +790,6 @@ public class MultiBulkCommandContext extends RegistrationCommandContext {
 		e.addErrorMessage(errorMessage);
 		getErrors().add(e);
 	}
-
 
 	/**
 	 * ブランクの項目は未入力と見なし、更新しないので、一括更新可能なプロパティリストから外す。
@@ -792,8 +804,8 @@ public class MultiBulkCommandContext extends RegistrationCommandContext {
 	 * @param entity
 	 */
 	private List<PropertyItem> createBlankPropList(Entity entity) {
-			return (getProperty().stream().filter(pi -> entity.getValue(pi.getPropertyName()) == null)
-					.collect(Collectors.toList()));
+		return (getProperty().stream().filter(pi -> entity.getValue(pi.getPropertyName()) == null)
+				.collect(Collectors.toList()));
 	}
 
 	/**
@@ -974,7 +986,8 @@ public class MultiBulkCommandContext extends RegistrationCommandContext {
 		if (interrupter == null) {
 			// 何もしないデフォルトInterrupter生成
 			getLogger().debug("set default bulk operation interrupter.");
-			interrupter = new BulkOperationInterrupter() { };
+			interrupter = new BulkOperationInterrupter() {
+			};
 		}
 		return interrupter;
 	}

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/DetailCommandContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/DetailCommandContext.java
@@ -179,7 +179,6 @@ public class DetailCommandContext extends RegistrationCommandContext
 		return editedEntity != null ? editedEntity : currentEntity;
 	}
 
-
 	/**
 	 * 更新対象ロードエンティティを設定します。
 	 * @param currentEntity 対象エンティティ
@@ -213,7 +212,8 @@ public class DetailCommandContext extends RegistrationCommandContext
 			@Override
 			public boolean isDispProperty(PropertyItem property) {
 				//詳細編集で非表示なら更新対象外
-				return EntityViewUtil.isDisplayElement(entityDefinition.getName(), property.getElementRuntimeId(), OutputType.EDIT, getDispControlBindEntity())
+				return EntityViewUtil.isDisplayElement(entityDefinition.getName(), property.getElementRuntimeId(), OutputType.EDIT,
+						getDispControlBindEntity())
 						&& !property.isHideDetail();
 			}
 
@@ -238,7 +238,7 @@ public class DetailCommandContext extends RegistrationCommandContext
 			if (section instanceof DefaultSection) {
 				if (EntityViewUtil.isDisplayElement(getDefinitionName(), section.getElementRuntimeId(), OutputType.EDIT, getDispControlBindEntity())
 						&& !((DefaultSection) section).isHideDetail() && ViewUtil.dispElement(execType, section)) {
-					propList.addAll(getProperty((DefaultSection)section));
+					propList.addAll(getProperty((DefaultSection) section));
 				}
 			} else if (section instanceof ReferenceSection) {
 				// 参照セクションは同一名の定義が複数の場合があるのでまとめる
@@ -246,9 +246,9 @@ public class DetailCommandContext extends RegistrationCommandContext
 				if (EntityViewUtil.isDisplayElement(getDefinitionName(), section.getElementRuntimeId(), OutputType.EDIT, getDispControlBindEntity())
 						&& !rs.isHideDetail() && ViewUtil.dispElement(execType, rs)) {
 					Optional<ReferenceSectionPropertyItem> ret = propList.stream().filter(p -> p instanceof ReferenceSectionPropertyItem)
-						.map(p -> (ReferenceSectionPropertyItem) p)
-						.filter(p -> p.getPropertyName().equals(rs.getPropertyName()))
-						.findFirst();
+							.map(p -> (ReferenceSectionPropertyItem) p)
+							.filter(p -> p.getPropertyName().equals(rs.getPropertyName()))
+							.findFirst();
 
 					if (ret.isPresent()) {
 						ret.get().getSections().add(rs);
@@ -272,9 +272,9 @@ public class DetailCommandContext extends RegistrationCommandContext
 		List<PropertyItem> propList = getProperty();
 
 		//EditorのLabel形式のチェック
-		List<PropertyItem> updateList = propList.stream().filter(property->{
+		List<PropertyItem> updateList = propList.stream().filter(property -> {
 			if (property.getEditor() instanceof LabelablePropertyEditor) {
-				LabelablePropertyEditor editor = (LabelablePropertyEditor)property.getEditor();
+				LabelablePropertyEditor editor = (LabelablePropertyEditor) property.getEditor();
 				if (editor.isLabel() && !editor.isUpdateWithLabelValue()) {
 					return false;
 				}
@@ -330,9 +330,9 @@ public class DetailCommandContext extends RegistrationCommandContext
 				if (EntityViewUtil.isDisplayElement(getDefinitionName(), elem.getElementRuntimeId(), OutputType.EDIT, getDispControlBindEntity())
 						&& !rs.isHideDetail() && ViewUtil.dispElement(execType, rs)) {
 					Optional<ReferenceSectionPropertyItem> ret = propList.stream().filter(p -> p instanceof ReferenceSectionPropertyItem)
-						.map(p -> (ReferenceSectionPropertyItem) p)
-						.filter(p -> p.getPropertyName().equals(rs.getPropertyName()))
-						.findFirst();
+							.map(p -> (ReferenceSectionPropertyItem) p)
+							.filter(p -> p.getPropertyName().equals(rs.getPropertyName()))
+							.findFirst();
 
 					if (ret.isPresent()) {
 						ret.get().getSections().add(rs);
@@ -353,7 +353,7 @@ public class DetailCommandContext extends RegistrationCommandContext
 	private ReferenceSectionPropertyItem createReferenceSectionPropertyItem(ReferenceSection section) {
 		ReferenceSectionPropertyItem property = new ReferenceSectionPropertyItem();
 		property.setPropertyName(section.getPropertyName());
-//		property.setDispFlag(section.getDispFlag());
+		//		property.setDispFlag(section.getDispFlag());
 		property.getSections().add(section);
 		return property;
 	}
@@ -367,7 +367,7 @@ public class DetailCommandContext extends RegistrationCommandContext
 		Set<String> loadReferences = new HashSet<>();
 		for (Section section : getView().getSections()) {
 			if (section instanceof DefaultSection) {
-				getReferencePropertyName((DefaultSection)section, loadReferences);
+				getReferencePropertyName((DefaultSection) section, loadReferences);
 			} else if (section instanceof ReferenceSection) {
 				ReferenceSection rs = (ReferenceSection) section;
 				loadReferences.add(rs.getPropertyName());
@@ -441,7 +441,9 @@ public class DetailCommandContext extends RegistrationCommandContext
 		public boolean isHideDetail() {
 			// hideDetailがfalseのものがあればfalse扱い
 			for (ReferenceSection section : sections) {
-				if (!section.isHideDetail()) return false;
+				if (!section.isHideDetail()) {
+					return false;
+				}
 			}
 			return true;
 		}
@@ -558,7 +560,9 @@ public class DetailCommandContext extends RegistrationCommandContext
 			PropertyDefinition pd = getProperty(property.getPropertyName());
 			if (pd instanceof ReferenceProperty) {
 				String mappedBy = ((ReferenceProperty) pd).getMappedBy();
-				if (StringUtil.isBlank(mappedBy)) continue;
+				if (StringUtil.isBlank(mappedBy)) {
+					continue;
+				}
 
 				if (property instanceof ReferenceSectionPropertyItem) {
 					return true;
@@ -647,10 +651,10 @@ public class DetailCommandContext extends RegistrationCommandContext
 			if (errorPrefix != null) {
 				String name = paramPrefix + p.getName();
 				//Entity生成時にエラーが発生していないかチェックして置き換え
-				String errorName = errorPrefix +  p.getName();
+				String errorName = errorPrefix + p.getName();
 				getErrors().stream()
-					.filter(error -> error.getPropertyName().equals(name))
-					.forEach(error -> error.setPropertyName(errorName));
+						.filter(error -> error.getPropertyName().equals(name))
+						.forEach(error -> error.setPropertyName(errorName));
 			}
 		}
 		return entity;
@@ -659,7 +663,9 @@ public class DetailCommandContext extends RegistrationCommandContext
 	private Timestamp getTimestamp() {
 		Timestamp ts = null;
 		Long l = getLongValue(Constants.TIMESTAMP);
-		if (l != null) ts = new Timestamp(l);
+		if (l != null) {
+			ts = new Timestamp(l);
+		}
 		return ts;
 	}
 
@@ -691,7 +697,9 @@ public class DetailCommandContext extends RegistrationCommandContext
 				} else {
 					list = getRefTableValues(rp, defName, count, prefix);
 				}
-				if (list.size() > 0) entity = list.get(0);
+				if (list.size() > 0) {
+					entity = list.get(0);
+				}
 			}
 			return entity;
 		} else {
@@ -813,7 +821,9 @@ public class DetailCommandContext extends RegistrationCommandContext
 
 	private void addNestTableRegistHandler(ReferenceProperty p, List<Entity> list, EntityDefinition red, PropertyItem property) {
 		// ネストテーブルはプロパティ単位で登録可否決定
-		if (!NestTableReferenceRegistHandler.canRegist(property, getRegistrationPropertyBaseHandler())) return;
+		if (!NestTableReferenceRegistHandler.canRegist(property, getRegistrationPropertyBaseHandler())) {
+			return;
+		}
 
 		// カスタム登録処理によるNestTableの更新制御
 		ReferenceRegistOption option = null;
@@ -842,13 +852,13 @@ public class DetailCommandContext extends RegistrationCommandContext
 			target = list;
 		}
 
-		ReferenceRegistHandler handler = NestTableReferenceRegistHandler.get(this, list, red, p, property, editor.getNestProperties(), getRegistrationPropertyBaseHandler(), option);
+		ReferenceRegistHandler handler = NestTableReferenceRegistHandler.get(this, list, red, p, property, editor.getNestProperties(),
+				getRegistrationPropertyBaseHandler(), option);
 		if (handler != null) {
 			handler.setForceUpdate(editor.isForceUpadte());
 			getReferenceRegistHandlers().add(handler);
 		}
 	}
-
 
 	private List<Entity> getRefSectionValues(ReferenceProperty p, String defName, Long count, String prefix) {
 		List<Entity> list = new ArrayList<>();
@@ -928,9 +938,12 @@ public class DetailCommandContext extends RegistrationCommandContext
 		return list;
 	}
 
-	private void addReferenceSectionRegistHandler(final ReferenceProperty p, final List<ReferenceSectionValue> list, EntityDefinition red, ReferenceSectionPropertyItem property) {
+	private void addReferenceSectionRegistHandler(final ReferenceProperty p, final List<ReferenceSectionValue> list, EntityDefinition red,
+			ReferenceSectionPropertyItem property) {
 		// 参照セクションはプロパティ単位で登録可否決定
-		if (!ReferenceSectionReferenceRegistHandler.canRegist(property)) return;
+		if (!ReferenceSectionReferenceRegistHandler.canRegist(property)) {
+			return;
+		}
 
 		// カスタム登録処理による参照セクションの更新制御
 		ReferenceRegistOption option = null;
@@ -956,15 +969,19 @@ public class DetailCommandContext extends RegistrationCommandContext
 		private Integer index;
 		private Entity entity;
 		private ReferenceSection section;
+
 		public Integer getIndex() {
 			return index;
 		}
+
 		public Entity getEntity() {
 			return entity;
 		}
+
 		public void setEntity(Entity entity) {
 			this.entity = entity;
 		}
+
 		public ReferenceSection getSection() {
 			return section;
 		}
@@ -979,9 +996,13 @@ public class DetailCommandContext extends RegistrationCommandContext
 		for (PropertyDefinition pd : getPropertyList()) {
 			if (pd.getMultiplicity() != 1) {
 				Object[] obj = entity.getValue(pd.getName());
-				if (obj != null && obj.length > 0) return false;
+				if (obj != null && obj.length > 0) {
+					return false;
+				}
 			} else {
-				if (entity.getValue(pd.getName()) != null) return false;
+				if (entity.getValue(pd.getName()) != null) {
+					return false;
+				}
 			}
 		}
 		return true;
@@ -1106,7 +1127,7 @@ public class DetailCommandContext extends RegistrationCommandContext
 		List<PropertyElement> excludeList = new ArrayList<>();
 		for (Section section : getView().getSections()) {
 			if (section instanceof DefaultSection) {
-				excludeList.addAll(getExcludeLabelableProperty((DefaultSection)section));
+				excludeList.addAll(getExcludeLabelableProperty((DefaultSection) section));
 			}
 		}
 		this.excludeLabelableProperties = excludeList;
@@ -1128,14 +1149,15 @@ public class DetailCommandContext extends RegistrationCommandContext
 			boolean isInsert = (currentEntity == null);
 			for (Element element : section.getElements()) {
 				if (element instanceof DefaultSection) {
-					excludeList.addAll(getExcludeLabelableProperty((DefaultSection)element));
+					excludeList.addAll(getExcludeLabelableProperty((DefaultSection) element));
 				} else if (element instanceof PropertyItem) {
-					PropertyItem prop = (PropertyItem)element;
+					PropertyItem prop = (PropertyItem) element;
 					if (prop.getEditor() instanceof LabelablePropertyEditor) {
-						LabelablePropertyEditor editor = (LabelablePropertyEditor)prop.getEditor();
+						LabelablePropertyEditor editor = (LabelablePropertyEditor) prop.getEditor();
 						//更新時は値セットは除外しないため追加時のみチェック
 						if (isInsert && editor.isLabel()) {
-							if (EntityViewUtil.isDisplayElement(getDefinitionName(), prop.getElementRuntimeId(), OutputType.EDIT, getDispControlBindEntity())
+							if (EntityViewUtil.isDisplayElement(getDefinitionName(), prop.getElementRuntimeId(), OutputType.EDIT,
+									getDispControlBindEntity())
 									&& !prop.isHideDetail() && ViewUtil.dispElement(execType, prop)) {
 								if (!editor.isInsertWithLabelValue()) {
 									excludeList.add(prop);
@@ -1146,10 +1168,11 @@ public class DetailCommandContext extends RegistrationCommandContext
 				} else if (element instanceof VirtualPropertyItem) {
 					VirtualPropertyItem prop = (VirtualPropertyItem) element;
 					if (prop.getEditor() instanceof LabelablePropertyEditor) {
-						LabelablePropertyEditor editor = (LabelablePropertyEditor)prop.getEditor();
+						LabelablePropertyEditor editor = (LabelablePropertyEditor) prop.getEditor();
 						//更新時は値セットは除外しないため追加時のみチェック
 						if (isInsert && editor.isLabel()) {
-							if (EntityViewUtil.isDisplayElement(getDefinitionName(), prop.getElementRuntimeId(), OutputType.EDIT, getDispControlBindEntity())
+							if (EntityViewUtil.isDisplayElement(getDefinitionName(), prop.getElementRuntimeId(), OutputType.EDIT,
+									getDispControlBindEntity())
 									&& !prop.isHideDetail() && ViewUtil.dispElement(execType, prop)) {
 								if (!editor.isInsertWithLabelValue()) {
 									excludeList.add(prop);
@@ -1254,7 +1277,7 @@ public class DetailCommandContext extends RegistrationCommandContext
 				Entity[] ary = null;
 				if (val != null) {
 					if (val instanceof Entity) {
-						ary = new Entity[] {(Entity) val};
+						ary = new Entity[] { (Entity) val };
 					} else if (val instanceof Entity[]) {
 						ary = (Entity[]) val;
 					}
@@ -1477,7 +1500,7 @@ public class DetailCommandContext extends RegistrationCommandContext
 	 */
 	private void setValidateErrorMessage(RangePropertyEditor editor, String fromName, String errorPrefix, String resourceStringKey) {
 		String errorMessage = TemplateUtil.getMultilingualString(editor.getErrorMessage(), editor.getLocalizedErrorMessageList());
-		if (StringUtil.isBlank(errorMessage )) {
+		if (StringUtil.isBlank(errorMessage)) {
 			errorMessage = resourceString(resourceStringKey);
 		}
 		ValidateError e = new ValidateError();
@@ -1573,7 +1596,8 @@ public class DetailCommandContext extends RegistrationCommandContext
 
 		PropertyItem property = new PropertyItem();
 		property.setPropertyName(section.getPropertyName());
-		property.setDispFlag(EntityViewUtil.isDisplayElement(getDefinitionName(), section.getElementRuntimeId(), outputType, getDispControlBindEntity()));
+		property.setDispFlag(
+				EntityViewUtil.isDisplayElement(getDefinitionName(), section.getElementRuntimeId(), outputType, getDispControlBindEntity()));
 
 		ReferencePropertyEditor editor = new ReferencePropertyEditor();
 		editor.setDisplayType(ReferenceDisplayType.NESTTABLE);

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/DetailCommandContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/DetailCommandContext.java
@@ -43,6 +43,7 @@ import org.iplass.gem.command.generic.detail.handler.ShowEditViewEventHandler;
 import org.iplass.mtp.command.RequestContext;
 import org.iplass.mtp.entity.BinaryReference;
 import org.iplass.mtp.entity.Entity;
+import org.iplass.mtp.entity.EntityKey;
 import org.iplass.mtp.entity.EntityManager;
 import org.iplass.mtp.entity.EntityRuntimeException;
 import org.iplass.mtp.entity.LoadOption;
@@ -684,37 +685,34 @@ public class DetailCommandContext extends RegistrationCommandContext
 		//prefixが付くケース=NestTable内の多重参照なのであり得ない
 		//→件数取れないため通常の参照扱いで処理が終わる
 		Long count = getLongValue(prefix + p.getName() + "_count");
-		String isRs = getParam("isReferenceSection_" + prefix + p.getName());
+		String isReferenceSection = getParam("isReferenceSection_" + prefix + p.getName());
 		if (p.getMultiplicity() == 1) {
-			Entity entity = null;
+			List<Entity> list = null;
 			if (count == null) {
 				String key = getParam(prefix + p.getName());
-				entity = getRefEntity(rp.getObjectDefinitionName(), key);
+				list = getRefEntities(rp.getObjectDefinitionName(), new String[] { key });
 			} else {
-				List<Entity> list = null;
-				if (isRs != null && "true".equals(isRs)) {
+				if (isReferenceSection != null && "true".equals(isReferenceSection)) {
 					list = getRefSectionValues(rp, defName, count, prefix);
 				} else {
 					list = getRefTableValues(rp, defName, count, prefix);
 				}
-				if (list.size() > 0) {
-					entity = list.get(0);
-				}
 			}
-			return entity;
+			if (list.size() > 0) {
+				return list.get(0);
+			} else {
+				return null;
+			}
 		} else {
 			List<Entity> list = null;
 			if (count == null) {
 				String[] params = getParams(prefix + p.getName());
 				if (params != null) {
-					list = Arrays.stream(params)
-							.map(key -> getRefEntity(rp.getObjectDefinitionName(), key))
-							.filter(value -> value != null)
-							.collect(Collectors.toList());
+					list = getRefEntities(rp.getObjectDefinitionName(), params);
 				}
 			} else {
 				//参照型で参照先のデータを作成・編集するケース
-				if (isRs != null && "true".equals(isRs)) {
+				if (isReferenceSection != null && "true".equals(isReferenceSection)) {
 					list = getRefSectionValues(rp, defName, count, prefix);
 				} else {
 					list = getRefTableValues(rp, defName, count, prefix);
@@ -737,38 +735,61 @@ public class DetailCommandContext extends RegistrationCommandContext
 		}
 	}
 
-	private Entity getRefEntity(String definitionName, String key) {
-		Entity entity = null;
-		String oid = null;
-		Long version = null;
-		if (key != null) {
-			int lastIndex = key.lastIndexOf("_");
+	/**
+	 * NestTable、ReferenceSection以外の参照先編集データを返します。
+	 *
+	 * @param definitionName 参照先Entity定義名
+	 * @param keyParameters oidとversionのパラメータ情報
+	 * @return 編集データ
+	 */
+	private List<Entity> getRefEntities(String definitionName, String[] keyParameters) {
 
-			if (lastIndex < 0) {
-				oid = key;
-			} else {
-				oid = key.substring(0, lastIndex);
-				version = CommandUtil.getLong(key.substring(lastIndex + 1));
-			}
-		}
-		if (StringUtil.isNotBlank(oid)) {
-			//バリデーションエラー時に消えないようにデータ読み込み
-			//gemの設定により、参照を合わせて読み込むか切り替える
+		List<EntityKey> keys = Arrays.stream(keyParameters)
+				.map(key -> {
+					int lastIndex = key.lastIndexOf("_");
+					String oid = null;
+					Long version = null;
+					if (lastIndex < 0) {
+						oid = key;
+					} else {
+						oid = key.substring(0, lastIndex);
+						version = CommandUtil.getLong(key.substring(lastIndex + 1));
+					}
+					return new EntityKey(oid, version);
+				})
+				.collect(Collectors.toList());
+
+		List<Entity> entities = null;
+		if (gemConfig.isMustLoadWithReference()) {
+			// 参照Entityをロードし直す
 			if (gemConfig.isLoadWithReference()) {
-				entity = entityManager.load(oid, version, definitionName);
+				entities = entityManager.batchLoad(keys, definitionName);
 			} else {
-				entity = entityManager.load(oid, version, definitionName, new LoadOption(false, false));
+				entities = entityManager.batchLoad(keys, definitionName, new LoadOption(false, false));
 			}
+		} else {
+			// 参照Entityをロードし直さない
+			final EntityDefinition referenceEntityDefinition = definitionManager.get(definitionName);
+			entities = keys.stream()
+					.map(key -> {
+						Entity entity = newEntity(referenceEntityDefinition);
+						entity.setOid(key.getOid());
+						entity.setVersion(key.getVersion());
+						return entity;
+					})
+					.collect(Collectors.toList());
 		}
-		return entity;
+		return entities;
 	}
 
 	/**
-	 * リクエストパラメータからテーブルの参照型データの値を取得します。
-	 * @param p プロパティ定義
-	 * @param defName 参照型のEntity定義名
-	 * @param count 参照データの最大件数
-	 * @return 参照データのリスト
+	 * NestTableの編集データを返します。
+	 *
+	 * @param p 対象ReferenceProperty定義
+	 * @param defName 参照先Entity定義名
+	 * @param count 件数
+	 * @param prefix 参照型のプロパティのリクエストパラメータに設定されているプレフィックス
+	 * @return NestTableの編集データ
 	 */
 	private List<Entity> getRefTableValues(ReferenceProperty p, String defName, Long count, String prefix) {
 		final List<Entity> list = new ArrayList<>();
@@ -860,6 +881,15 @@ public class DetailCommandContext extends RegistrationCommandContext
 		}
 	}
 
+	/**
+	 * ReferenceSectionの編集データを返します。
+	 *
+	 * @param p 対象ReferenceProperty定義
+	 * @param defName 参照先Entity定義名
+	 * @param count 件数
+	 * @param prefix 参照型のプロパティのリクエストパラメータに設定されているプレフィックス
+	 * @return ReferenceSectionの編集データ
+	 */
 	private List<Entity> getRefSectionValues(ReferenceProperty p, String defName, Long count, String prefix) {
 		List<Entity> list = new ArrayList<>();
 		EntityDefinition ed = getEntityDefinition();

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/RegistrationCommandContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/RegistrationCommandContext.java
@@ -79,8 +79,8 @@ public abstract class RegistrationCommandContext extends GenericCommandContext {
 
 	/** Load時に最新データを強制的に取得するか（下位互換対応） */
 	@Deprecated
-	private final boolean loadLatestVersionedEntity
-		= Boolean.parseBoolean(System.getProperty("mtp.entity.update.targetSpecific.loadLatestVersionedEntity"));
+	private final boolean loadLatestVersionedEntity = Boolean
+			.parseBoolean(System.getProperty("mtp.entity.update.targetSpecific.loadLatestVersionedEntity"));
 
 	/** 変換時に発生したエラー情報 */
 	private List<ValidateError> errors;
@@ -146,7 +146,7 @@ public abstract class RegistrationCommandContext extends GenericCommandContext {
 	protected Object getPropValue(PropertyDefinition p, String paramPrefix) {
 		Object value = null;
 		boolean isMultiple = p.getMultiplicity() != 1;
-		String name = paramPrefix +  p.getName();
+		String name = paramPrefix + p.getName();
 		if (p instanceof BinaryProperty) {
 			value = isMultiple ? getBinaryReferenceValues(name) : getBinaryReferenceValue(name);
 		} else if (p instanceof BooleanProperty) {
@@ -262,10 +262,13 @@ public abstract class RegistrationCommandContext extends GenericCommandContext {
 			ret = param != null ? Boolean.parseBoolean(param) : null;
 
 			//チェックボックス未チェック時はNullになるがfalseに置き換える
-			if (ret == null && type == BooleanDisplayType.CHECKBOX) ret = false;
+			if (ret == null && type == BooleanDisplayType.CHECKBOX) {
+				ret = false;
+			}
 		}
 		return ret;
 	}
+
 	protected Boolean[] getBooleanValues(String name, int multiplicity) {
 		String _type = getParam(name + "Type");
 		BooleanDisplayType type = StringUtil.isNotEmpty(_type) ? BooleanDisplayType.valueOf(_type) : null;
@@ -290,13 +293,15 @@ public abstract class RegistrationCommandContext extends GenericCommandContext {
 			for (int i = 0; i < multiplicity; i++) {
 				String param = getParam(name + i);
 				Boolean b = param != null ? Boolean.parseBoolean(param) : null;
-				if (b == null && type == BooleanDisplayType.CHECKBOX) b = false;
+				if (b == null && type == BooleanDisplayType.CHECKBOX) {
+					b = false;
+				}
 				list.add(b);
 			}
 			//データが１つでも存在する場合のみ配列化
 			boolean hasValue = list.stream().anyMatch(value -> value != null);
 			if (hasValue) {
-				ret = list.toArray(new Boolean[]{});
+				ret = list.toArray(new Boolean[] {});
 			}
 		}
 		return ret != null && ret.length > 0 ? ret : null;
@@ -314,13 +319,13 @@ public abstract class RegistrationCommandContext extends GenericCommandContext {
 		String param = getParam(name);
 		String lang = I18nUtil.getLanguageIfUseMultilingual();
 		if (StringUtil.isNotBlank(param)) {
-			if(selectProperty == null) {
+			if (selectProperty == null) {
 				return new SelectValue(param);
 			}
 			SelectValue selectValue = selectProperty.getLocalizedSelectValue(param, lang);
 			return selectValue == null
-				? new SelectValue(param)
-				: selectValue;
+					? new SelectValue(param)
+					: selectValue;
 		}
 
 		return null;
@@ -336,14 +341,14 @@ public abstract class RegistrationCommandContext extends GenericCommandContext {
 							return null;
 						}
 
-						if(selectProperty == null) {
+						if (selectProperty == null) {
 							return new SelectValue(param);
 						}
 
 						SelectValue selectValue = selectProperty.getLocalizedSelectValue(param, lang);
 						return selectValue == null
-							? new SelectValue(param)
-							: selectValue;
+								? new SelectValue(param)
+								: selectValue;
 					})
 					.toArray(SelectValue[]::new);
 			return ret.length > 0 ? ret : null;
@@ -400,7 +405,8 @@ public abstract class RegistrationCommandContext extends GenericCommandContext {
 		if (interrupter == null) {
 			//何もしないデフォルトInterrupter生成
 			getLogger().debug("set defaul registration interrupter.");
-			interrupter = new RegistrationInterrupter(){};
+			interrupter = new RegistrationInterrupter() {
+			};
 		}
 		return interrupter;
 	}
@@ -433,7 +439,8 @@ public abstract class RegistrationCommandContext extends GenericCommandContext {
 		if (interrupter == null) {
 			//何もしないデフォルトInterrupter生成
 			getLogger().debug("set defaul load entity interrupter.");
-			interrupter = new LoadEntityInterrupter() {};
+			interrupter = new LoadEntityInterrupter() {
+			};
 		}
 		return interrupter;
 	}
@@ -508,7 +515,9 @@ public abstract class RegistrationCommandContext extends GenericCommandContext {
 
 	@Override
 	public List<ValidateError> getErrors() {
-		if (errors == null) errors = new ArrayList<>();
+		if (errors == null) {
+			errors = new ArrayList<>();
+		}
 		return errors;
 	}
 

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/RegistrationCommandContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/RegistrationCommandContext.java
@@ -20,6 +20,7 @@
 
 package org.iplass.gem.command.generic.detail;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -36,6 +37,7 @@ import org.iplass.mtp.entity.EntityRuntimeException;
 import org.iplass.mtp.entity.GenericEntity;
 import org.iplass.mtp.entity.SelectValue;
 import org.iplass.mtp.entity.ValidateError;
+import org.iplass.mtp.entity.definition.EntityDefinition;
 import org.iplass.mtp.entity.definition.EntityDefinitionManager;
 import org.iplass.mtp.entity.definition.PropertyDefinition;
 import org.iplass.mtp.entity.definition.PropertyDefinitionType;
@@ -124,23 +126,35 @@ public abstract class RegistrationCommandContext extends GenericCommandContext {
 		return loadLatestVersionedEntity;
 	}
 
+	/**
+	 * MappingClassを考慮したEntityインスタンスを返します。
+	 *
+	 * @return Entityインスタンス
+	 */
 	protected Entity newEntity() {
-		Entity res = null;
+		return newEntity(entityDefinition);
+	}
+
+	/**
+	 * MappingClassを考慮したEntityインスタンスを返します。
+	 *
+	 * @param entityDefinition Entity定義
+	 * @return Entityインスタンス
+	 */
+	protected Entity newEntity(EntityDefinition entityDefinition) {
+		Entity entity = null;
 		if (entityDefinition.getMapping() != null && entityDefinition.getMapping().getMappingModelClass() != null) {
 			try {
-				res = (Entity) Class.forName(entityDefinition.getMapping().getMappingModelClass()).newInstance();
-			} catch (InstantiationException e) {
-				throw new EntityRuntimeException(e);
-			} catch (IllegalAccessException e) {
-				throw new EntityRuntimeException(e);
-			} catch (ClassNotFoundException e) {
+				entity = (Entity) Class.forName(entityDefinition.getMapping().getMappingModelClass()).getDeclaredConstructor().newInstance();
+			} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException
+					| ClassNotFoundException e) {
 				throw new EntityRuntimeException(e);
 			}
 		} else {
-			res = new GenericEntity();
+			entity = new GenericEntity();
 		}
-		res.setDefinitionName(entityDefinition.getName());
-		return res;
+		entity.setDefinitionName(entityDefinition.getName());
+		return entity;
 	}
 
 	protected Object getPropValue(PropertyDefinition p, String paramPrefix) {

--- a/iplass-gem/src/main/resources/gem-service-config.xml
+++ b/iplass-gem/src/main/resources/gem-service-config.xml
@@ -78,7 +78,13 @@
 	<service>
 		<interface>org.iplass.gem.GemConfigService</interface>
 		<class>org.iplass.gem.GemConfigService</class>
+
+		<!-- リクエストのパラメータをもとに参照データを更新する際に、参照データをロードしなおすか -->
+		<property name="mustLoadWithReference" value="true" />
+
+		<!-- リクエストのパラメータを基に参照データを更新する際に、参照エンティティの参照プロパティも合わせてロードするか -->
 		<property name="loadWithReference" value="false" />
+
 		<property name="formatNumberWithComma" value="true" />
 
 		<!-- Entityデータのサポートファイルタイプ。CSV, EXCEL, SPECIFY -->


### PR DESCRIPTION
## 対応内容
- GemConfigServiceに `mustLoadWithReference` を追加
　falseの場合、更新時に参照先の再Loadを行わない。保持するプロパティ値は oid と version のみ。
　デフォルトは既存処理に合わせ true とする。

- 上記がtrueの場合は、既存の処理同様、GemConfigServiceの `loadWithReference` の設定により、LoadOptionを制御する
　ただしこの際も、 `EntityManager#batchLoad` により、一括でLoadする。

closes #1700

## 動作確認・スクリーンショット
- Validationエラーなどで編集画面が再表示される際に、表示プロパティが指定されていても、oid version で再検索して表示しているため、正しく表示されている

## レビュー観点・補足情報
- 既存の処理に合わせて、デフォルト値は true とする。本来であれば、 false のほうがパフォーマンスはいい。
