### PR TITLE
GEM: 一括更新Commandにおける対象の取得時に、対象のソート順が維持されるよう修正

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/bulk/BulkCommandContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/bulk/BulkCommandContext.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -491,8 +492,10 @@ public class BulkCommandContext extends RegistrationCommandContext {
 		};
 	}
 
-	public Set<String> getOids() {
-		return bulkCommandParams.stream().map(p -> p.getOid()).collect(Collectors.toSet());
+	public LinkedHashSet<String> getOids() {
+		return bulkCommandParams.stream()
+				.map(p -> p.getOid())
+				.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
 	/**


### PR DESCRIPTION
<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->

一括更新系のCommandがリクエスト情報から更新対象を取得する際に、リクエストにおける更新対象の順序が維持されるよう修正する。

fixes: #1706 

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->

動作確認用に、 `BulkOperationInterrupter` を実装するクラスを作成し、 `beforeOperation()` で `BulkOperationContext` 内の更新対象Entityリストをソートするよう実装した。
上記クラスをEntityのSearchViewに設定し、以下を確認した。

- 「検索条件を元に全て一括更新」により一括更新した際に、 `BulkUpdateListCommand` で取得された更新対象が  `BulkUpdateAllCommand` でのInterrupterによるソート順通りになっていること
- 「選択された行を一括更新」による一括更新をこれまで通り実行できること