### PR TITLE
GEM: EntityViewのView名に予約文字が含まれないようにする

### DIFF
--- a/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/entity/layout/CreateViewDialog.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/entity/layout/CreateViewDialog.java
@@ -29,6 +29,7 @@ import org.iplass.adminconsole.client.base.ui.widget.MtpDialog;
 import org.iplass.adminconsole.client.base.ui.widget.form.MtpForm;
 import org.iplass.adminconsole.client.base.ui.widget.form.MtpTextItem;
 import org.iplass.adminconsole.client.base.util.SmartGWTUtil;
+import org.iplass.adminconsole.shared.metadata.dto.MetaDataConstants;
 import org.iplass.adminconsole.shared.metadata.rpc.MetaDataServiceAsync;
 import org.iplass.mtp.view.generic.EntityView;
 
@@ -37,6 +38,7 @@ import com.smartgwt.client.widgets.events.ClickEvent;
 import com.smartgwt.client.widgets.events.ClickHandler;
 import com.smartgwt.client.widgets.form.DynamicForm;
 import com.smartgwt.client.widgets.form.fields.TextItem;
+import com.smartgwt.client.widgets.form.validator.RegExpValidator;
 
 /**
  * View追加用ダイアログ
@@ -66,6 +68,12 @@ public class CreateViewDialog extends MtpDialog {
 
 		nameItem = new MtpTextItem("name", "View Name");
 		SmartGWTUtil.setRequired(nameItem);
+
+		//名前のPolicyをカスタマイズ
+		RegExpValidator nameRegExpValidator = new RegExpValidator();
+		nameRegExpValidator.setExpression(MetaDataConstants.NAME_REG_EXP_PATH_PERIOD);
+		nameRegExpValidator.setErrorMessage(AdminClientMessageUtil.getString("ui_metadata_entity_layout_CreateViewDialog_viewNameErr"));
+		nameItem.setValidators(nameRegExpValidator);
 
 		form = new MtpForm();
 		form.setAutoFocus(true);
@@ -138,4 +146,3 @@ public class CreateViewDialog extends MtpDialog {
 		this.okClickHandler = handler;
 	}
 }
-

--- a/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_en.js
+++ b/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_en.js
@@ -552,6 +552,7 @@ LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_viewName = "View Name";
 LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_failed = "Failed";
 LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_enterViewName = "Please enter the View name.";
 LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_failedReadScreenInfo = "Failed to read the screen information.";
+LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_viewNameErr = "The name can be used alphanumeric and hyphen and underscore and period.";
 LocaleInfo.ui_metadata_entity_layout_DetailDropLayout_propCheckThrought = "Property check was through";
 LocaleInfo.ui_metadata_entity_layout_DetailDropLayout_title = "Title";
 LocaleInfo.ui_metadata_entity_layout_DetailDropLayout_colNum = "Number of Columns";

--- a/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_ja.js
+++ b/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_ja.js
@@ -552,6 +552,7 @@ LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_viewName = "View名";
 LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_failed = "失敗";
 LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_enterViewName = "View名を入力してください。";
 LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_failedReadScreenInfo = "画面情報の読込に失敗しました。";
+LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_viewNameErr = "名前には英数字、ハイフン、アンダースコア、ピリオドのみ利用することができます。";
 LocaleInfo.ui_metadata_entity_layout_DetailDropLayout_propCheckThrought = "プロパティチェックスルーされた";
 LocaleInfo.ui_metadata_entity_layout_DetailDropLayout_title = "タイトル";
 LocaleInfo.ui_metadata_entity_layout_DetailDropLayout_colNum = "列数";

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/DefinitionNameCheckService.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/DefinitionNameCheckService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.tools.validator;
+
+import org.iplass.mtp.impl.metadata.RootMetaData;
+import org.iplass.mtp.spi.Service;
+
+/**
+ * メタデータ定義名チェック用Serviceインターフェース
+ */
+public interface DefinitionNameCheckService extends Service {
+
+	/**
+	 * メタデータ定義名チェックValidatorを返却
+	 * 
+	 * @param <T> メタデータの型
+	 * @param metaClass メタデータのクラス
+	 * @return メタデータ定義名チェックValidator
+	 */
+	<T extends RootMetaData> DefinitionNameCheckValidator<RootMetaData> getValidator(Class<T> metaClass);
+}

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/DefinitionNameCheckServiceImpl.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/DefinitionNameCheckServiceImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.tools.validator;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.iplass.mtp.impl.metadata.RootMetaData;
+import org.iplass.mtp.spi.Config;
+import org.iplass.mtp.spi.ServiceRegistry;
+
+/**
+ * メタデータ定義名チェック用Serviceクラス
+ */
+public class DefinitionNameCheckServiceImpl implements DefinitionNameCheckService {
+
+	public static DefinitionNameCheckService getInstance() {
+		return ServiceRegistry.getRegistry().getService(DefinitionNameCheckService.class);
+	}
+
+	private Map<String, DefinitionNameCheckValidator<RootMetaData>> validators;
+	private NoCheckValidator noCheckValidator;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void init(Config config) {
+		this.validators = config.getValue("validators", Map.class, new HashMap<>());
+		this.noCheckValidator = new NoCheckValidator();
+	}
+
+	@Override
+	public void destroy() {
+		// 何もしない
+	}
+
+	@Override
+	public <T extends RootMetaData> DefinitionNameCheckValidator<RootMetaData> getValidator(Class<T> metaClass) {
+		if (Objects.isNull(metaClass)) {
+			return this.noCheckValidator;
+		}
+
+		DefinitionNameCheckValidator<RootMetaData> validator = this.validators.get(metaClass.getName());
+		// Validatorの設定がなければチェックしない（チェックOK）
+		if (Objects.isNull(validator)) {
+			return this.noCheckValidator;
+		}
+
+		return validator;
+	}
+
+}

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/DefinitionNameCheckValidator.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/DefinitionNameCheckValidator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.tools.validator;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.iplass.mtp.impl.metadata.RootMetaData;
+import org.iplass.mtp.impl.tools.ToolsResourceBundleUtil;
+import org.iplass.mtp.util.StringUtil;
+
+/**
+ * メタデータ定義名チェックValidatorクラス
+ */
+public abstract class DefinitionNameCheckValidator<T extends RootMetaData> {
+
+	/**
+	 * エラーメッセージを返却
+	 * 
+	 * @param meta メタデータ
+	 * @return エラーメッセージ
+	 */
+	public abstract String getErrorMessage(T meta);
+
+	/**
+	 * 定義名に許可する正規表現を返却
+	 * 
+	 * @return 定義名に許可する正規表現
+	 */
+	public abstract String getRegularExpression();
+
+	/**
+	 * メタデータ定義名チェック
+	 * 
+	 * @param meta メタデータ
+	 * @return チェックOKの場合は空、チェックNGの場合はチェックエラーメッセージ
+	 */
+	public Optional<String> validate(T meta) {
+		// 必要な情報がなかったらチェックしない（チェックOKとする）
+		if (StringUtil.isEmpty(this.getErrorMessage(meta)) ||
+				StringUtil.isEmpty(this.getRegularExpression()) ||
+				Objects.isNull(meta)) {
+			return Optional.empty();
+		}
+
+		return this.check(meta.getName(), this.getRegularExpression()) ? Optional.empty() : Optional.of(this.getErrorMessage(meta));
+	}
+
+	protected boolean check(String definitionName, String regularExpression) {
+		Pattern p = Pattern.compile(regularExpression);
+		Matcher m = p.matcher(definitionName);
+		return m.find();
+	}
+
+	protected String getMessage(String key, Object... args) {
+		return ToolsResourceBundleUtil.resourceString(key, args);
+	}
+}

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/DefinitionNameValidatorConstants.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/DefinitionNameValidatorConstants.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.tools.validator;
+
+/**
+ * メタデータ定義名チェックValidator用定数定義クラス
+ */
+public interface DefinitionNameValidatorConstants {
+	/** 名前の正規表現(パスにスラッシュを利用) */
+	public static final String NAME_REG_EXP_PATH_SLASH = "^[0-9a-zA-Z_][0-9a-zA-Z_-]*(/[0-9a-zA-Z_-]+)*$";
+	/** 名前の正規表現(パスにスラッシュを利用、名前にピリオド含む) */
+	public static final String NAME_REG_EXP_PATH_SLASH_NAME_PERIOD = "^[0-9a-zA-Z_][0-9a-zA-Z_-]*(/[0-9a-zA-Z_-]+)*(\\.[0-9a-zA-Z_-]+)*$";
+	/** 名前の正規表現(パスにピリオドを利用) */
+	public static final String NAME_REG_EXP_PATH_PERIOD = "^[0-9a-zA-Z_][0-9a-zA-Z_-]*(\\.[0-9a-zA-Z_-]+)*$";
+
+	/** Entity名の正規表現(英数、アンダスコア、パスにピリオド、先頭の数字不可、マイナス不可) */
+	public static final String ENTITY_NAME_REG_EXP_PATH_PERIOD = "^[a-zA-Z_][0-9a-zA-Z_]*(\\.[a-zA-Z_][0-9a-zA-Z_]*)*$";
+	/** Entityプロパティ名の正規表現(英数、アンダスコア、先頭の数字不可、マイナス不可) */
+	public static final String ENTITY_PROPERTY_NAME_REG_EXP_PATH_PERIOD = "^[a-zA-Z_][0-9a-zA-Z_]*$";
+}

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/EntityValidator.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/EntityValidator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.tools.validator;
+
+import org.iplass.mtp.impl.metadata.RootMetaData;
+
+/**
+ * Entityメタデータ定義名をチェックするValidatorクラス
+ * 
+ * <p>
+ * 下記のようになってるかチェックする
+ * </p>
+ * <ul>
+ * <li>英数、アンダスコア、先頭の数字不可、マイナス不可</li>
+ * <li>パスにはピリオドを利用</li>
+ * </ul>
+ */
+public class EntityValidator<T extends RootMetaData> extends DefinitionNameCheckValidator<T> {
+
+	@Override
+	public String getErrorMessage(T meta) {
+		return this.getMessage("validator.regularExpression.entityName");
+	}
+
+	@Override
+	public String getRegularExpression() {
+		return DefinitionNameValidatorConstants.ENTITY_NAME_REG_EXP_PATH_PERIOD;
+	}
+}

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/EntityViewValidator.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/EntityViewValidator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.tools.validator;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.iplass.mtp.impl.view.generic.MetaEntityView;
+import org.iplass.mtp.impl.view.generic.MetaFormView;
+import org.iplass.mtp.util.StringUtil;
+
+/**
+ * EntityViewメタデータ定義名をチェックするValidatorクラス
+ * 
+ * <p>
+ * 下記のようになってるかチェックする
+ * </p>
+ * <ul>
+ * <li>英数、アンダスコア、先頭の数字不可、マイナス不可</li>
+ * <li>パスにはピリオドを利用</li>
+ * </ul>
+ * 
+ */
+public class EntityViewValidator extends EntityValidator<MetaEntityView> {
+
+	@Override
+	public Optional<String> validate(MetaEntityView meta) {
+		if (Objects.isNull(meta)) {
+			return Optional.empty();
+		}
+
+		// まずはEntity定義名のチェック
+		Optional<String> optResultEntityName = super.validate(meta);
+		if (optResultEntityName.isPresent()) {
+			return optResultEntityName;
+		}
+
+		// EntityView取得
+		List<MetaFormView> views = meta.getViews();
+		if (CollectionUtils.isEmpty(views)) {
+			return Optional.empty();
+		}
+
+		// EntityView名のチェック（1個でも許容されてないView名があったらチェックNG）
+		Optional<MetaFormView> optErrorView = views.stream().filter(view -> {
+			String viewName = view.getName();
+			if (StringUtil.isEmpty(viewName)) {
+				return false;
+			}
+
+			return !this.check(viewName, DefinitionNameValidatorConstants.NAME_REG_EXP_PATH_PERIOD);
+		}).findFirst();
+
+		return optErrorView.isEmpty() ? Optional.empty()
+				: Optional.of(this.getMessage("validator.regularExpression.viewName", optErrorView.get().getName()));
+	}
+}

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/NoCheckValidator.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/NoCheckValidator.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.tools.validator;
+
+import java.util.Optional;
+
+import org.iplass.mtp.impl.metadata.RootMetaData;
+
+/**
+ * メタデータ定義名チェックしないValidatorクラス
+ * 
+ * <p>
+ * メタデータ定義名チェックしない場合に利用
+ * </p>
+ * 
+ */
+public class NoCheckValidator extends DefinitionNameCheckValidator<RootMetaData> {
+
+	@Override
+	public String getErrorMessage(RootMetaData meta) {
+		return null;
+	}
+
+	@Override
+	public String getRegularExpression() {
+		return null;
+	}
+
+	@Override
+	public Optional<String> validate(RootMetaData meta) {
+		return Optional.empty();
+	}
+}

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/PathPeriodValidator.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/PathPeriodValidator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.tools.validator;
+
+import org.iplass.mtp.impl.metadata.RootMetaData;
+
+/**
+ * メタデータ定義名が下記になってるかチェックするValidatorクラス
+ * <ul>
+ * <li>英数字、ハイフン、アンダースコアのみ</li>
+ * <li>パスにはピリオドを利用</li>
+ * </ul>
+ */
+public class PathPeriodValidator<T extends RootMetaData> extends DefinitionNameCheckValidator<T> {
+
+	@Override
+	public String getErrorMessage(T meta) {
+		return this.getMessage("validator.regularExpression.pathPeriod");
+	}
+
+	@Override
+	public String getRegularExpression() {
+		return DefinitionNameValidatorConstants.NAME_REG_EXP_PATH_PERIOD;
+	}
+}

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/PathSlashNamePeriodValidator.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/PathSlashNamePeriodValidator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.tools.validator;
+
+import org.iplass.mtp.impl.metadata.RootMetaData;
+
+/**
+ * メタデータ定義名が下記になってるかチェックするValidatorクラス
+ * <ul>
+ * <li>英数字、ハイフン、アンダースコア、ピリオドのみ</li>
+ * <li>パスにはスラッシュを利用</li>
+ * </ul>
+ */
+public class PathSlashNamePeriodValidator<T extends RootMetaData> extends DefinitionNameCheckValidator<T> {
+
+	@Override
+	public String getErrorMessage(T meta) {
+		return this.getMessage("validator.regularExpression.pathSlashNamePeriod");
+	}
+
+	@Override
+	public String getRegularExpression() {
+		return DefinitionNameValidatorConstants.NAME_REG_EXP_PATH_SLASH_NAME_PERIOD;
+	}
+}

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/PathSlashValidator.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/validator/PathSlashValidator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.tools.validator;
+
+import org.iplass.mtp.impl.metadata.RootMetaData;
+
+/**
+ * メタデータ定義名が下記になってるかチェックするValidatorクラス
+ * <ul>
+ * <li>英数字、ハイフン、アンダースコアのみ</li>
+ * <li>パスにはスラッシュを利用</li>
+ * </ul>
+ */
+public class PathSlashValidator<T extends RootMetaData> extends DefinitionNameCheckValidator<T> {
+
+	@Override
+	public String getErrorMessage(T meta) {
+		return this.getMessage("validator.regularExpression.pathSlash");
+	}
+
+	@Override
+	public String getRegularExpression() {
+		return DefinitionNameValidatorConstants.NAME_REG_EXP_PATH_SLASH;
+	}
+}

--- a/iplass-tools/src/main/resources/mtp-tools-messages.properties
+++ b/iplass-tools/src/main/resources/mtp-tools-messages.properties
@@ -111,3 +111,9 @@ tenant.partition.createdPartitionMsg           = Created a Partition. : name = {
 tenant.partition.droppedPartitionMsg           = Dropped the Partition. : name = {0}
 tenant.partition.skipDropPartitionMsg          = Skip drop Partition because {0} does not exist.
 tenant.partition.skipPartitionMsg              = Skip the creation process, because it already has partition to {0} exists.: table = {1}
+
+validator.regularExpression.pathPeriod          = The definition name can be used alphanumeric and hyphen and underscore. The path will use the period.
+validator.regularExpression.pathSlash           = The definition name can be used alphanumeric and hyphen. The path will use the underscore.
+validator.regularExpression.pathSlashNamePeriod = The definition name can be used alphanumeric and hyphen and period. The path will use the underscore.
+validator.regularExpression.entityName          = The definition name can be used alphanumeric and underscore. The first character can be used alphabets only. The path will use the period.
+validator.regularExpression.viewName            = The view name can be used alphanumeric and hyphen and underscore and period. : name = {0}

--- a/iplass-tools/src/main/resources/mtp-tools-messages_en.properties
+++ b/iplass-tools/src/main/resources/mtp-tools-messages_en.properties
@@ -111,3 +111,9 @@ tenant.partition.createdPartitionMsg           = Created a Partition. : name = {
 tenant.partition.droppedPartitionMsg           = Dropped the Partition. : name = {0}
 tenant.partition.skipDropPartitionMsg          = Skip drop Partition because {0} does not exist.
 tenant.partition.skipPartitionMsg              = Skip the creation process, because it already has partition to {0} exists.: table = {1}
+
+validator.regularExpression.pathPeriod          = The definition name can be used alphanumeric and hyphen and underscore. The path will use the period.
+validator.regularExpression.pathSlash           = The definition name can be used alphanumeric and hyphen. The path will use the underscore.
+validator.regularExpression.pathSlashNamePeriod = The definition name can be used alphanumeric and hyphen and period. The path will use the underscore.
+validator.regularExpression.entityName          = The definition name can be used alphanumeric and underscore. The first character can be used alphabets only. The path will use the period.
+validator.regularExpression.viewName            = The view name can be used alphanumeric and hyphen and underscore and period. : name = {0}

--- a/iplass-tools/src/main/resources/mtp-tools-messages_ja.properties
+++ b/iplass-tools/src/main/resources/mtp-tools-messages_ja.properties
@@ -111,3 +111,9 @@ tenant.partition.createdPartitionMsg           = Partitionを作成しました�
 tenant.partition.droppedPartitionMsg           = Partitionを削除しました。 : name = {0}
 tenant.partition.skipDropPartitionMsg          = Partitionが存在しないため削除しませんでした。 : name = {0}
 tenant.partition.skipPartitionMsg              = 既に{0}までPartitionが存在しているため、作成処理をスキップします。: table = {1}
+
+validator.regularExpression.pathPeriod          = 定義名に利用できるのは英数字、ハイフン、アンダースコア、パスにピリオドのみです。
+validator.regularExpression.pathSlash           = 定義名に利用できるのは英数字、ハイフン、アンダースコア、パスにスラッシュのみです。
+validator.regularExpression.pathSlashNamePeriod = 定義名に利用できるのは英数字、ハイフン、アンダースコア、ピリオド、パスにスラッシュのみです。
+validator.regularExpression.entityName          = 定義名に利用できるのは英数字、アンダースコアのみで、先頭は英字のみ、パスにはピリオドのみです。
+validator.regularExpression.viewName            = View名に利用できるのは英数字、ハイフン、アンダースコア、ピリオドのみです。: name = {0}

--- a/iplass-tools/src/main/resources/mtp-tools-service-config.xml
+++ b/iplass-tools/src/main/resources/mtp-tools-service-config.xml
@@ -48,6 +48,7 @@
 		<depend>org.iplass.mtp.impl.core.TenantContextService</depend>
 		<depend>org.iplass.mtp.impl.entity.EntityService</depend>
 		<depend>org.iplass.mtp.impl.auth.AuthService</depend>
+		<depend>org.iplass.mtp.impl.tools.validator.DefinitionNameCheckService</depend>
 
 		<property name="importHandler" class="org.iplass.mtp.impl.tools.metaport.MetaDataImportHandlerImpl" />
 	</service>
@@ -91,6 +92,16 @@
 
 	<service>
 		<interface>org.iplass.mtp.impl.tools.clean.RecycleBinCleanService</interface>
+	</service>
+
+	<service>
+		<interface>org.iplass.mtp.impl.tools.validator.DefinitionNameCheckService</interface>
+		<class>org.iplass.mtp.impl.tools.validator.DefinitionNameCheckServiceImpl</class>
+		<property name="validators">
+			<property name="org.iplass.mtp.impl.web.actionmapping.MetaActionMapping" class="org.iplass.mtp.impl.tools.validator.PathSlashNamePeriodValidator"/>
+			<property name="org.iplass.mtp.impl.entity.MetaEntity" class="org.iplass.mtp.impl.tools.validator.EntityValidator"/>
+			<property name="org.iplass.mtp.impl.view.generic.MetaEntityView" class="org.iplass.mtp.impl.tools.validator.EntityViewValidator"/>
+		</property>
 	</service>
 
 </serviceDefinition>


### PR DESCRIPTION
<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->
- EntityView作成ダイアログにてOKボタン押下時にView名チェックをするように修正
- MetaDataExplorerにてメタデータインポート時に各メタデータの定義名に対してAdminConsole画面からメタデータ作成（変更）時と同じ入力チェックを実施するように修正
- Packagingにてメタデータインポート時に各メタデータの定義名に対してAdminConsole画面からメタデータ作成（変更）時と同じ入力チェックを実施するように修正
- バッチにてメタデータインポート時に各メタデータの定義名に対してAdminConsole画面からメタデータ作成（変更）時と同じ入力チェックを実施するように修正

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->
下記エビデンスを参照ください
[1699_エビデンス（無償版）.xlsx](https://github.com/user-attachments/files/19645756/1699_.xlsx)

## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->
- service-configにて、メタデータと定義名チェックValidatorをマッピングするようにしています。
https://github.com/dentsusoken/iPLAss/pull/1732/files#diff-1a854bf8d27aae5d8d34914adc7b088d3e40c16ba3a0180e9cd6d85edce38517R97

- 下記差分にはEclipseの自動フォーマットでの変更が含まれています
https://github.com/dentsusoken/iPLAss/pull/1732/files#diff-892d29cb5515895ee193259aaa2e78e81a336fabea2c6f0463444c88066aba33
本対応での修正箇所は下記（インポート部分などは除く）
https://github.com/dentsusoken/iPLAss/pull/1732/files#diff-892d29cb5515895ee193259aaa2e78e81a336fabea2c6f0463444c88066aba33R117
https://github.com/dentsusoken/iPLAss/pull/1732/files#diff-892d29cb5515895ee193259aaa2e78e81a336fabea2c6f0463444c88066aba33R305
https://github.com/dentsusoken/iPLAss/pull/1732/files#diff-892d29cb5515895ee193259aaa2e78e81a336fabea2c6f0463444c88066aba33R1043