### PR TITLE
GEM：ExpressionPropertyを利用している場合，ClassCastException発生します ＆ 部分検索条件にただしくない

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/NormalSearchContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/NormalSearchContext.java
@@ -392,6 +392,13 @@ public class NormalSearchContext extends SearchContextBase {
 			//文字とかそのまま検索できるプロパティは変換しない
 			ret = ((str[0] == null || str[0].trim().length() == 0) && (str[1] == null || str[1].trim().length() == 0)
 					&& (str[2] == null || str[2].trim().length() == 0)) ? null : str;
+		} else {
+			String value = getRequest().getParam(conditionPrefix + propName);
+			if (value == null || value.trim().length() == 0)
+				return null;
+
+			//Boolean、AutoNumberとかそのまま検索できるプロパティは変換しない
+			ret = value;
 		}
 		return ret;
 	}
@@ -473,6 +480,17 @@ public class NormalSearchContext extends SearchContextBase {
 			// 範囲検索
 			ret[1] = getRequest().getParam(propName + "From");
 			ret[2] = getRequest().getParam(propName + "To");
+			if (StringUtil.isBlank(ret[0]) && StringUtil.isBlank(ret[1]) && StringUtil.isBlank(ret[2])) {
+				return null;
+			}
+			return ret;
+		} else if (ep.getResultType() == PropertyDefinitionType.STRING) {
+			// 単一検索、範囲検索の判断ができないため3つ取得する
+			String[] ret = new String[3];
+			ret[0] = getRequest().getParam(propName);
+			ret[1] = getRequest().getParam(propName + "From");
+			ret[2] = getRequest().getParam(propName + "To");
+			//文字とかそのまま検索できるプロパティは変換しない
 			if (StringUtil.isBlank(ret[0]) && StringUtil.isBlank(ret[1]) && StringUtil.isBlank(ret[2])) {
 				return null;
 			}

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/ExpressionPropertySearchCondition.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/ExpressionPropertySearchCondition.java
@@ -111,7 +111,8 @@ public class ExpressionPropertySearchCondition extends PropertySearchCondition {
 	}
 
 	private PropertySearchCondition createSearchCondition(ExpressionSearchConditionType type, Object value) {
-		if (value == null) return null;
+		if (value == null)
+			return null;
 
 		PropertyEditor editor = ((ExpressionPropertyEditor) getEditor()).getEditor();
 		//SelectProperty以外DefinitionをcastしてないのでとりあえずExpressionを渡しても問題はないはず
@@ -147,8 +148,9 @@ public class ExpressionPropertySearchCondition extends PropertySearchCondition {
 		PropertyEditor editor = ((ExpressionPropertyEditor) getEditor()).getEditor();
 		if (type == ExpressionSearchConditionType.BOOLEAN) {
 			String value = (String) getValue();
-			if (value == null || value.trim().length() == 0) return null;
-			return Boolean.parseBoolean((String) getValue());
+			if (value == null || value.trim().length() == 0)
+				return null;
+			return value;
 		} else if (type == ExpressionSearchConditionType.DATE) {
 			String[] value = (String[]) getValue();
 			//2番目(From)、3番目(To)を利用
@@ -160,7 +162,7 @@ public class ExpressionPropertySearchCondition extends PropertySearchCondition {
 			if (value.length > 2 && value[2] != null) {
 				to = ConvertUtil.convertToDate(Date.class, value[2], TemplateUtil.getLocaleFormat().getServerDateFormat(), false);
 			}
-			return (from == null && to == null) ? null : new Date[]{from, to};
+			return (from == null && to == null) ? null : new Date[] { from, to };
 		} else if (type == ExpressionSearchConditionType.DATETIME) {
 			String[] value = (String[]) getValue();
 			//2番目(From)、3番目(To)を利用
@@ -172,7 +174,7 @@ public class ExpressionPropertySearchCondition extends PropertySearchCondition {
 			if (value.length > 2 && value[2] != null) {
 				to = ConvertUtil.convertToDate(Timestamp.class, value[2], TemplateUtil.getLocaleFormat().getServerDateTimeFormat(), false);
 			}
-			return (from == null && to == null) ? null : new Timestamp[]{from, to};
+			return (from == null && to == null) ? null : new Timestamp[] { from, to };
 		} else if (type == ExpressionSearchConditionType.DECIMAL) {
 			String[] value = (String[]) getValue();
 			DecimalPropertyEditor dpe = (DecimalPropertyEditor) editor;
@@ -183,7 +185,7 @@ public class ExpressionPropertySearchCondition extends PropertySearchCondition {
 				if (value.length > 0 && value[0] != null) {
 					single = ConvertUtil.convertFromString(BigDecimal.class, value[0]);
 				}
-				return single == null ? null : new BigDecimal[]{single};
+				return single == null ? null : new BigDecimal[] { single };
 			} else {
 				// 範囲検索
 				// 2番目(From)、3番目(To)を利用
@@ -196,7 +198,7 @@ public class ExpressionPropertySearchCondition extends PropertySearchCondition {
 					to = ConvertUtil.convertFromString(BigDecimal.class, value[2]);
 				}
 				// 長さ3の配列で返す
-				return (from == null && to == null) ? null : new BigDecimal[]{null, from, to};
+				return (from == null && to == null) ? null : new BigDecimal[] { null, from, to };
 			}
 		} else if (type == ExpressionSearchConditionType.FLOAT) {
 			String[] value = (String[]) getValue();
@@ -208,7 +210,7 @@ public class ExpressionPropertySearchCondition extends PropertySearchCondition {
 				if (value.length > 0 && value[0] != null) {
 					single = ConvertUtil.convertFromString(Double.class, value[0]);
 				}
-				return single == null ? null : new Double[]{single};
+				return single == null ? null : new Double[] { single };
 			} else {
 				// 範囲検索
 				// 2番目(From)、3番目(To)を利用
@@ -221,7 +223,7 @@ public class ExpressionPropertySearchCondition extends PropertySearchCondition {
 					to = ConvertUtil.convertFromString(Double.class, value[2]);
 				}
 				// 長さ3の配列で返す
-				return (from == null && to == null) ? null : new Double[]{null, from, to};
+				return (from == null && to == null) ? null : new Double[] { null, from, to };
 			}
 		} else if (type == ExpressionSearchConditionType.INTEGER) {
 			String[] value = (String[]) getValue();
@@ -233,7 +235,7 @@ public class ExpressionPropertySearchCondition extends PropertySearchCondition {
 				if (value.length > 0 && value[0] != null) {
 					single = ConvertUtil.convertFromString(Long.class, value[0]);
 				}
-				return single == null ? null : new Long[]{single};
+				return single == null ? null : new Long[] { single };
 			} else {
 				// 範囲検索
 				// 2番目(From)、3番目(To)を利用
@@ -246,11 +248,12 @@ public class ExpressionPropertySearchCondition extends PropertySearchCondition {
 					to = ConvertUtil.convertFromString(Long.class, value[2]);
 				}
 				// 長さ3の配列で返す
-				return (from == null && to == null) ? null : new Long[]{null, from, to};
+				return (from == null && to == null) ? null : new Long[] { null, from, to };
 			}
 		} else if (type == ExpressionSearchConditionType.SELECT) {
 			String[] value = (String[]) getValue();
-			if (value == null || value.length == 0) return null;
+			if (value == null || value.length == 0)
+				return null;
 			SelectPropertyEditor se = (SelectPropertyEditor) editor;
 			if (se.getDisplayType() == SelectDisplayType.CHECKBOX
 					|| se.getDisplayType() == SelectDisplayType.HIDDEN) {
@@ -267,9 +270,32 @@ public class ExpressionPropertySearchCondition extends PropertySearchCondition {
 				}
 			}
 		} else if (type == ExpressionSearchConditionType.STRING) {
-			String value = (String) getValue();
-			if (value == null || value.trim().length() == 0) return null;
-			return value;
+			String[] value = (String[]) getValue();
+			StringPropertyEditor spe = (StringPropertyEditor) editor;
+			if (!spe.isSearchInRange()) {
+				// 単一検索
+				// 1番目を利用
+				String single = null;
+				if (value.length > 0 && value[0] != null) {
+					single = value[0];
+				}
+				return (single == null || single.trim().length() == 0) ? null : new String[] { single };
+			} else {
+				// 範囲検索
+				// 2番目(From)、3番目(To)を利用
+				String from = null;
+				String to = null;
+				if (value.length > 1 && value[1] != null) {
+					from = value[1];
+				}
+				if (value.length > 2 && value[2] != null) {
+					to = value[2];
+				}
+				// 長さ3の配列で返す
+				return ((from == null || from.trim().length() == 0) && (to == null || to.trim().length() == 0)) ? null
+						: new String[] { null, from, to };
+			}
+
 		} else if (type == ExpressionSearchConditionType.TIME) {
 			String[] value = (String[]) getValue();
 			//2番目(From)、3番目(To)を利用
@@ -281,22 +307,13 @@ public class ExpressionPropertySearchCondition extends PropertySearchCondition {
 			if (value.length > 2 && value[2] != null) {
 				to = ConvertUtil.convertToDate(Time.class, value[2], TemplateUtil.getLocaleFormat().getServerTimeFormat(), false);
 			}
-			return (from == null && to == null) ? null : new Time[]{from, to};
+			return (from == null && to == null) ? null : new Time[] { from, to };
 		}
 		return null;
 	}
 
-	enum ExpressionSearchConditionType{
-		BOOLEAN,
-		DATE,
-		DATETIME,
-		DECIMAL,
-		EXPRESSION,
-		FLOAT,
-		INTEGER,
-		SELECT,
-		STRING,
-		TIME;
+	enum ExpressionSearchConditionType {
+		BOOLEAN, DATE, DATETIME, DECIMAL, EXPRESSION, FLOAT, INTEGER, SELECT, STRING, TIME;
 
 		public static ExpressionSearchConditionType createSearchCondition(
 				ExpressionProperty ep, PropertyEditor editor) {

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/StringPropertySearchCondition.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/StringPropertySearchCondition.java
@@ -61,48 +61,48 @@ public class StringPropertySearchCondition extends PropertySearchCondition {
 	public List<Condition> convertNormalCondition() {
 		List<Condition> conditions = new ArrayList<>();
 		PropertyEditor editor = getEditor();
-		//like検索
 		if (editor instanceof StringPropertyEditor) {
 			StringPropertyEditor sp = (StringPropertyEditor) editor;
-			if ((sp.getDisplayType() != null && sp.getDisplayType() == StringDisplayType.SELECT)
-					|| sp.isSearchExactMatchCondition()) {
-				// 「値なし」を検索条件の選択肢に追加するか
-				if (sp.isIsNullSearchEnabled() && Constants.ISNULL_VALUE.equals(getValue())) {
-					conditions.add(new IsNull(getPropertyName()));
-				} else {
-					//選択時または完全一致有無にチェック時はEquals
-					conditions.add(new Equals(getPropertyName(), getValue()));
+			String[] values = (String[]) getValue();
+			if (sp.isSearchInRange()) {
+				//範囲検索
+				// From-To検索
+				// 2番目、3番目を利用
+				String from = null;
+				String to = null;
+				if (values.length > 1 && values[1] != null) {
+					from = values[1];
+				}
+				if (values.length > 2 && values[2] != null) {
+					to = values[2];
+				}
+				if (StringUtil.isNotEmpty(from) && StringUtil.isNotEmpty(to)) {
+					conditions.add(new Between(getPropertyName(), from, to));
+				} else if (StringUtil.isNotEmpty(from) && StringUtil.isEmpty(to)) {
+					conditions.add(new GreaterEqual(getPropertyName(), from));
+				} else if (StringUtil.isEmpty(from) && StringUtil.isNotEmpty(to)) {
+					conditions.add(new LesserEqual(getPropertyName(), to));
 				}
 			} else {
-				String[] values = (String[]) getValue();
-				if (sp.isSearchInRange()) {
-					//範囲検索
-					// From-To検索
-					// 2番目、3番目を利用
-					String from = null;
-					String to = null;
-					if (values.length > 1 && values[1] != null) {
-						from = values[1];
-					}
-					if (values.length > 2 && values[2] != null) {
-						to = values[2];
-					}
-					if (StringUtil.isNotEmpty(from) && StringUtil.isNotEmpty(to)) {
-						conditions.add(new Between(getPropertyName(), from, to));
-					} else if (StringUtil.isNotEmpty(from) && StringUtil.isEmpty(to)) {
-						conditions.add(new GreaterEqual(getPropertyName(), from));
-					} else if (StringUtil.isEmpty(from) && StringUtil.isNotEmpty(to)) {
-						conditions.add(new LesserEqual(getPropertyName(), to));
-					}
-				} else {
-					// like検索
-					// 1番目を利用
-					//conditions.add(new Like(getPropertyName(), "%" + StringUtil.escapeEqlForLike(getValue().toString()) + "%"));
-					if (values.length > 0 && values[0] != null) {
-						String strValue = values[0];
+				if (values.length > 0 && values[0] != null) {
+					String strValue = values[0];
+					if ((sp.getDisplayType() != null && sp.getDisplayType() == StringDisplayType.SELECT)
+							|| sp.isSearchExactMatchCondition()) {
+						// 「値なし」を検索条件の選択肢に追加するか
+						if (sp.isIsNullSearchEnabled() && Constants.ISNULL_VALUE.equals(strValue)) {
+							conditions.add(new IsNull(getPropertyName()));
+						} else {
+							//選択時または完全一致有無にチェック時はEquals
+							conditions.add(new Equals(getPropertyName(), strValue));
+						}
+					} else {
+						// like検索
+						// 1番目を利用
+						//conditions.add(new Like(getPropertyName(), "%" + StringUtil.escapeEqlForLike(getValue().toString()) + "%"));
 						//複数の場合は部分一致
-						conditions.add(new Like(getPropertyName(), strValue.toString(), Like.MatchPattern.PARTIAL));
+						conditions.add(new Like(getPropertyName(), strValue, Like.MatchPattern.PARTIAL));
 					}
+
 				}
 			}
 		} else if (editor instanceof UserPropertyEditor) {


### PR DESCRIPTION
<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->

1. NormalSearchContextにelse分岐を追加し、Boolean型およびAutoNumber型の検索条件の処理を正常に動くできます。
2. String型の検索条件ParamsはすべてString[]として統一し、1番目は単独の検索値、2番目と3番目は範囲検索のfromとtoを表します。
3. Expression型では、String型の検索条件がString[]として処理されるロジックを追加しました。
4. Expression型では、Boolean型の検索条件をString型に変換する処理を修正し、BooleanPropertySearchConditionによる処理を容易にしました。

fixes [#1731](https://github.com/dentsusoken/iPLAss/issues/1731)

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->

■String型

- [x] 単独形式のString検索条件が正しく検索できる
- [x] 範囲型のString検索条件が正しく検索できる

■Boolean型

- [x] Boolean検索条件が正しく検索できる

■AutoNumber型

- [x] AutoNumber検索条件が正しく検索できる

■Expression型

- [x] ResultTypeが単独形式のString検索条件が正しく検索できる
- [x] ResultTypeが範囲型のString検索条件が正しく検索できる
- [x] ResultTypeがBooleanの検索条件が正しく検索できる

■Reference型

- [x] Referenceフィールドが単独形式のString検索条件が正しく検索できる
- [x] Referenceフィールドが範囲型のString検索条件が正しく検索できる
- [x] ReferenceフィールドがBooleanの検索条件が正しく検索できる

## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->