### PR TITLE
GEM: EntityViewのView名に予約文字が含まれないようにする

### DIFF
--- a/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/entity/layout/CreateViewDialog.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/entity/layout/CreateViewDialog.java
@@ -29,6 +29,7 @@ import org.iplass.adminconsole.client.base.ui.widget.MtpDialog;
 import org.iplass.adminconsole.client.base.ui.widget.form.MtpForm;
 import org.iplass.adminconsole.client.base.ui.widget.form.MtpTextItem;
 import org.iplass.adminconsole.client.base.util.SmartGWTUtil;
+import org.iplass.adminconsole.shared.metadata.dto.MetaDataConstants;
 import org.iplass.adminconsole.shared.metadata.rpc.MetaDataServiceAsync;
 import org.iplass.mtp.view.generic.EntityView;
 
@@ -37,6 +38,7 @@ import com.smartgwt.client.widgets.events.ClickEvent;
 import com.smartgwt.client.widgets.events.ClickHandler;
 import com.smartgwt.client.widgets.form.DynamicForm;
 import com.smartgwt.client.widgets.form.fields.TextItem;
+import com.smartgwt.client.widgets.form.validator.RegExpValidator;
 
 /**
  * View追加用ダイアログ
@@ -70,6 +72,12 @@ public class CreateViewDialog extends MtpDialog {
 		form = new MtpForm();
 		form.setAutoFocus(true);
 		form.setItems(nameItem);
+
+		//名前のPolicyをカスタマイズ
+		RegExpValidator nameRegExpValidator = new RegExpValidator();
+		nameRegExpValidator.setExpression(MetaDataConstants.NAME_REG_EXP_PATH_PERIOD);
+		nameRegExpValidator.setErrorMessage(AdminClientMessageUtil.getString("ui_metadata_entity_layout_CreateViewDialog_nameErr"));
+		nameItem.setValidators(nameRegExpValidator);
 
 		container.addMember(form);
 
@@ -138,4 +146,3 @@ public class CreateViewDialog extends MtpDialog {
 		this.okClickHandler = handler;
 	}
 }
-

--- a/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_en.js
+++ b/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_en.js
@@ -554,6 +554,7 @@ LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_viewName = "View Name";
 LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_failed = "Failed";
 LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_enterViewName = "Please enter the View name.";
 LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_failedReadScreenInfo = "Failed to read the screen information.";
+LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_nameErr = "The name can be used alphanumeric and hyphen and underscore and period.";
 LocaleInfo.ui_metadata_entity_layout_DetailDropLayout_propCheckThrought = "Property check was through";
 LocaleInfo.ui_metadata_entity_layout_DetailDropLayout_title = "Title";
 LocaleInfo.ui_metadata_entity_layout_DetailDropLayout_colNum = "Number of Columns";

--- a/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_ja.js
+++ b/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_ja.js
@@ -554,6 +554,7 @@ LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_viewName = "View名";
 LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_failed = "失敗";
 LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_enterViewName = "View名を入力してください。";
 LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_failedReadScreenInfo = "画面情報の読込に失敗しました。";
+LocaleInfo.ui_metadata_entity_layout_CreateViewDialog_nameErr = "名前には英数字、ハイフン、アンダースコア、ピリオドのみ利用することができます。";
 LocaleInfo.ui_metadata_entity_layout_DetailDropLayout_propCheckThrought = "プロパティチェックスルーされた";
 LocaleInfo.ui_metadata_entity_layout_DetailDropLayout_title = "タイトル";
 LocaleInfo.ui_metadata_entity_layout_DetailDropLayout_colNum = "列数";

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/entity/MetaEntity.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/entity/MetaEntity.java
@@ -44,6 +44,8 @@ import org.iplass.mtp.impl.entity.property.MetaReferenceProperty;
 import org.iplass.mtp.impl.i18n.I18nUtil;
 import org.iplass.mtp.impl.metadata.BaseRootMetaData;
 import org.iplass.mtp.impl.metadata.MetaDataConfig;
+import org.iplass.mtp.impl.metadata.validation.DefinitionNameCheckValidator;
+import org.iplass.mtp.impl.metadata.validation.EntityDeinitionNameCheckValidator;
 import org.iplass.mtp.impl.properties.basic.BasicType;
 import org.iplass.mtp.impl.properties.extend.AutoNumberType;
 import org.iplass.mtp.impl.properties.extend.SelectType;
@@ -51,7 +53,6 @@ import org.iplass.mtp.impl.util.KeyGenerator;
 import org.iplass.mtp.impl.util.ObjectUtil;
 import org.iplass.mtp.impl.validation.MetaValidation;
 import org.iplass.mtp.impl.validation.MetaValidationNotNull;
-
 
 public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<EntityDefinition> {
 	private static final long serialVersionUID = 6349144477923315083L;
@@ -61,7 +62,6 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 	//TODO Resourceのバージョンアップの場合、patchツールにて、全テナントを更新。ただし、共有テナントがある場合、共有テナントで当該MetaDataをカスタマイズしていた場合、共有テナントのみ更新
 	//TODO 共有テナントのMetaDataのローカルへの反映は、各テナントの判断（でよいか？運用が手間かも。。。やっぱり自動かな。。。結局、各テナントに反映しなかったら、共通ロジックで落ちるかもだから。）
 	//TODO 現行のものはカスタマイズ前のMetaData持ってないので、その場合の考慮もする
-
 
 	/** oidとして使用するPropertyの定義名。未指定の場合は、自動生成されるIDが使用される */
 	private List<String> oidPropertyId;
@@ -182,7 +182,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 			return null;
 		}
 
-		for (MetaProperty p: declaredPropertyList) {
+		for (MetaProperty p : declaredPropertyList) {
 			if (propName.equals(p.getName())) {
 				return p;
 			}
@@ -196,7 +196,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 			return null;
 		}
 
-		for (MetaProperty p: declaredPropertyList) {
+		for (MetaProperty p : declaredPropertyList) {
 			if (propId.equals(p.getId())) {
 				return p;
 			}
@@ -220,7 +220,6 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 		this.mapping = mapping;
 	}
 
-
 	public MetaEntityStore getEntityStoreDefinition() {
 		return entityStoreDefinition;
 	}
@@ -237,13 +236,13 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 		this.storeMapping = storeMapping;
 	}
 
-//	public String getDataStoreType() {
-//		return dataStoreType;
-//	}
-//
-//	public void setDataStoreType(String dataStoreType) {
-//		this.dataStoreType = dataStoreType;
-//	}
+	//	public String getDataStoreType() {
+	//		return dataStoreType;
+	//	}
+	//
+	//	public void setDataStoreType(String dataStoreType) {
+	//		this.dataStoreType = dataStoreType;
+	//	}
 
 	public void applyConfig(EntityDefinition definition, EntityContext context, KeyGenerator keyGene) {
 
@@ -278,7 +277,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 
 		List<MetaProperty> newDeclaredPropertyList = new ArrayList<MetaProperty>();
 		if (definition.getPropertyList() != null) {
-			for (PropertyDefinition pDef: definition.getPropertyList()) {
+			for (PropertyDefinition pDef : definition.getPropertyList()) {
 				if (!pDef.isInherited()) {
 					MetaProperty pMeta = getDeclaredProperty(pDef.getName());
 
@@ -299,7 +298,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 
 		if (definition.getEventListenerList() != null) {
 			eventListenerList = new ArrayList<MetaEventListener>();
-			for (EventListenerDefinition ed: definition.getEventListenerList()) {
+			for (EventListenerDefinition ed : definition.getEventListenerList()) {
 				//TODO instanceofの判断してしまっている
 				if (ed instanceof ScriptingEventListenerDefinition) {
 					MetaScriptingEventListener ms = new MetaScriptingEventListener();
@@ -326,7 +325,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 		List<MetaProperty> superPropertyList = null;
 		if (!EntityHandler.ROOT_ENTITY_ID.equals(getId())) {
 			EntityHandler thisHandler = context.getHandlerById(getId());
-			if (thisHandler != null) {	//Create時はnullの可能性あり
+			if (thisHandler != null) { //Create時はnullの可能性あり
 				EntityHandler superEntityHandler = thisHandler.getSuperDataModelHandler(context);
 				if (superEntityHandler != null) {
 					MetaEntity superEntity = superEntityHandler.getMetaData();
@@ -334,7 +333,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 				}
 			} else {
 				EntityHandler superEntityHandler;
-					superEntityHandler = context.getHandlerById(inheritedEntityMetaDataId);
+				superEntityHandler = context.getHandlerById(inheritedEntityMetaDataId);
 				if (superEntityHandler != null) {
 					MetaEntity superEntity = superEntityHandler.getMetaData();
 					superPropertyList = superEntity.declaredPropertyList;
@@ -348,7 +347,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 				throw new EntityRuntimeException("oidProperty not found:" + definition.getOidPropertyName());
 			}
 			oidPropertyId = new ArrayList<String>();
-			for (String oidPropName: definition.getOidPropertyName()) {
+			for (String oidPropName : definition.getOidPropertyName()) {
 				boolean match = false;
 				match = validateOidProperty(declaredPropertyList, oidPropName);
 				if (!match && superPropertyList != null) {
@@ -384,7 +383,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 				throw new EntityRuntimeException("crawlProperty not found:" + definition.getCrawlPropertyName());
 			}
 			crawlPropertyId = new ArrayList<String>();
-			for (String crawlPropName: definition.getCrawlPropertyName()) {
+			for (String crawlPropName : definition.getCrawlPropertyName()) {
 				boolean match = false;
 				match = validateCrawlProperty(declaredPropertyList, crawlPropName);
 				if (!match && superPropertyList != null) {
@@ -421,7 +420,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 	private boolean validateOidProperty(List<MetaProperty> properties, String oidPropName) {
 		boolean match = false;
 		if (properties != null) {
-			for (MetaProperty p: properties) {
+			for (MetaProperty p : properties) {
 				if (p.getName().equals(oidPropName)) {
 					if (p instanceof MetaPrimitiveProperty) {
 						MetaPrimitiveProperty pp = (MetaPrimitiveProperty) p;
@@ -452,7 +451,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 	private boolean validateNameProperty(List<MetaProperty> properties, String namePropName) {
 		boolean match = false;
 		if (properties != null) {
-			for (MetaProperty p: properties) {
+			for (MetaProperty p : properties) {
 				if (p.getName().equals(namePropName)) {
 					if (p instanceof MetaPrimitiveProperty) {
 						MetaPrimitiveProperty pp = (MetaPrimitiveProperty) p;
@@ -480,7 +479,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 	private boolean validateCrawlProperty(List<MetaProperty> properties, String crawlPropName) {
 		boolean match = false;
 		if (properties != null) {
-			for (MetaProperty p: properties) {
+			for (MetaProperty p : properties) {
 				if (p.getName().equals(crawlPropName)) {
 					crawlPropertyId.add(p.getId());
 					match = true;
@@ -500,7 +499,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 			return false;
 		}
 		boolean isNotNullDef = false;
-		for (MetaValidation mv: pp.getValidations()) {
+		for (MetaValidation mv : pp.getValidations()) {
 			if (mv instanceof MetaValidationNotNull) {
 				isNotNullDef = true;
 				break;
@@ -535,20 +534,20 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 			}
 			superEntity = superEntityHandler.getMetaData().currentConfig(context);
 			superPropertyList = superEntityHandler.getMetaData().declaredPropertyList;
-//			if (!superEntity.getName().equals(EntityDefinition.SYSTEM_DEFAULT_DEFINITION_NAME)) {
-				def.setInheritedDefinition(superEntity.getName());
-//			}
+			//			if (!superEntity.getName().equals(EntityDefinition.SYSTEM_DEFAULT_DEFINITION_NAME)) {
+			def.setInheritedDefinition(superEntity.getName());
+			//			}
 		}
 
 		List<PropertyDefinition> propertyDefList = new ArrayList<PropertyDefinition>();
 		if (superEntity != null) {
-			for (PropertyDefinition pd: superEntity.getPropertyList()) {
+			for (PropertyDefinition pd : superEntity.getPropertyList()) {
 				pd.setInherited(true);
 				propertyDefList.add(pd);
 			}
 		}
 		if (declaredPropertyList != null) {
-			for (MetaProperty pMeta: declaredPropertyList) {
+			for (MetaProperty pMeta : declaredPropertyList) {
 				PropertyDefinition pDef = pMeta.currentConfig(context);
 				if (pDef != null) {
 					propertyDefList.add(pDef);
@@ -558,7 +557,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 		def.setPropertyList(propertyDefList);
 
 		if (eventListenerList != null) {
-			for (MetaEventListener me: eventListenerList) {
+			for (MetaEventListener me : eventListenerList) {
 				def.addEventListener(me.currentConfig());
 			}
 		}
@@ -567,10 +566,10 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 
 		if (oidPropertyId != null) {
 			ArrayList<String> oidNames = new ArrayList<String>();
-			for (String oidPropId: oidPropertyId) {
+			for (String oidPropId : oidPropertyId) {
 				boolean match = false;
 				if (declaredPropertyList != null) {
-					for (MetaProperty pMeta: declaredPropertyList) {
+					for (MetaProperty pMeta : declaredPropertyList) {
 						if (pMeta.getId().equals(oidPropId)) {
 							oidNames.add(pMeta.getName());
 							match = true;
@@ -579,7 +578,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 					}
 				}
 				if (!match && superPropertyList != null) {
-					for (MetaProperty pMeta: superPropertyList) {
+					for (MetaProperty pMeta : superPropertyList) {
 						if (pMeta.getId().equals(oidPropId)) {
 							oidNames.add(pMeta.getName());
 							match = true;
@@ -595,7 +594,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 		if (namePropertyId != null) {
 			boolean match = false;
 			if (declaredPropertyList != null) {
-				for (MetaProperty pMeta: declaredPropertyList) {
+				for (MetaProperty pMeta : declaredPropertyList) {
 					if (pMeta.getId().equals(namePropertyId)) {
 						def.setNamePropertyName(pMeta.getName());
 						match = true;
@@ -604,7 +603,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 				}
 			}
 			if (!match && superPropertyList != null) {
-				for (MetaProperty pMeta: superPropertyList) {
+				for (MetaProperty pMeta : superPropertyList) {
 					if (pMeta.getId().equals(namePropertyId)) {
 						def.setNamePropertyName(pMeta.getName());
 						match = true;
@@ -616,10 +615,10 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 
 		if (crawlPropertyId != null) {
 			ArrayList<String> crawlNames = new ArrayList<String>();
-			for (String crawlPropId: crawlPropertyId) {
+			for (String crawlPropId : crawlPropertyId) {
 				boolean match = false;
 				if (declaredPropertyList != null) {
-					for (MetaProperty pMeta: declaredPropertyList) {
+					for (MetaProperty pMeta : declaredPropertyList) {
 						if (pMeta.getId().equals(crawlPropId)) {
 							crawlNames.add(pMeta.getName());
 							match = true;
@@ -628,7 +627,7 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 					}
 				}
 				if (!match && superPropertyList != null) {
-					for (MetaProperty pMeta: superPropertyList) {
+					for (MetaProperty pMeta : superPropertyList) {
 						if (pMeta.getId().equals(crawlPropId)) {
 							crawlNames.add(pMeta.getName());
 							match = true;
@@ -681,16 +680,19 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 						: dataLocalizationStrategy.hashCode());
 		result = prime
 				* result
-				+ ((declaredPropertyList == null) ? 0 : declaredPropertyList
-						.hashCode());
+				+ ((declaredPropertyList == null) ? 0
+						: declaredPropertyList
+								.hashCode());
 		result = prime
 				* result
-				+ ((entityStoreDefinition == null) ? 0 : entityStoreDefinition
-						.hashCode());
+				+ ((entityStoreDefinition == null) ? 0
+						: entityStoreDefinition
+								.hashCode());
 		result = prime
 				* result
-				+ ((eventListenerList == null) ? 0 : eventListenerList
-						.hashCode());
+				+ ((eventListenerList == null) ? 0
+						: eventListenerList
+								.hashCode());
 		result = prime
 				* result
 				+ ((inheritedEntityMetaDataId == null) ? 0
@@ -705,8 +707,9 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 				+ ((storeMapping == null) ? 0 : storeMapping.hashCode());
 		result = prime
 				* result
-				+ ((versionControlType == null) ? 0 : versionControlType
-						.hashCode());
+				+ ((versionControlType == null) ? 0
+						: versionControlType
+								.hashCode());
 		return result;
 	}
 
@@ -806,5 +809,15 @@ public class MetaEntity extends BaseRootMetaData implements DefinableMetaData<En
 	public EntityDefinition currentConfig() {
 		EntityContext ec = EntityContext.getCurrentContext();
 		return currentConfig(ec);
+	}
+
+	@Override
+	public String pathPrefix() {
+		return EntityService.ENTITY_META_PATH;
+	}
+
+	@Override
+	public Class<? extends DefinitionNameCheckValidator> definitionNameCheckValidatorClass() {
+		return EntityDeinitionNameCheckValidator.class;
 	}
 }

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/metadata/RootMetaData.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/metadata/RootMetaData.java
@@ -23,6 +23,8 @@ package org.iplass.mtp.impl.metadata;
 import java.util.List;
 
 import org.iplass.mtp.impl.i18n.MetaLocalizedString;
+import org.iplass.mtp.impl.metadata.validation.DefinitionNameCheckValidator;
+import org.iplass.mtp.impl.metadata.validation.NoCheckValidator;
 
 /**
  * メタデータをあらわすインタフェース。
@@ -109,4 +111,23 @@ public interface RootMetaData extends MetaData {
 
 	public RootMetaData copy();
 
+	/**
+	 * メタデータパスプレフィックスを返す。
+	 * TODO コンパイルエラー回避のため一旦default
+	 * 
+	 * @return メタデータパスプレフィックス
+	 */
+	public default String pathPrefix() {
+		return null;
+	}
+
+	/**
+	 * メタデータ定義名チェックValidatorクラスを返す。
+	 * TODO コンパイルエラー回避のため一旦default
+	 * 
+	 * @return メタデータ定義名チェックValidatorクラス
+	 */
+	public default Class<? extends DefinitionNameCheckValidator> definitionNameCheckValidatorClass() {
+		return NoCheckValidator.class;
+	}
 }

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/metadata/validation/DefinitionNameCheckValidator.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/metadata/validation/DefinitionNameCheckValidator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.metadata.validation;
+
+import java.util.Optional;
+
+import org.iplass.mtp.impl.util.CoreResourceBundleUtil;
+import org.iplass.mtp.util.StringUtil;
+
+/**
+ * メタデータ定義名チェックValidatorクラス
+ */
+public abstract class DefinitionNameCheckValidator {
+
+	/**
+	 * エラーメッセージを返却
+	 * 
+	 * @param definitionName メタデータ定義名
+	 * @return エラーメッセージ
+	 */
+	public abstract String getErrorMessage(String definitionName);
+
+	/**
+	 * 定義名に許可する正規表現を返却
+	 * 
+	 * @return 定義名に許可する正規表現
+	 */
+	public abstract String getRegularExpression();
+
+	/**
+	 * メタデータ定義名チェック
+	 * 
+	 * @param definitionName メタデータ定義名
+	 * @return チェックOKの場合は空、チェックNGの場合はチェックエラーメッセージ
+	 */
+	public Optional<String> validate(String definitionName) {
+		// 必要な情報がなかったらチェックしない（チェックOKとする）
+		String errorMessage = this.getErrorMessage(definitionName);
+		String regularExpression = this.getRegularExpression();
+		if (StringUtil.isEmpty(errorMessage) ||
+				StringUtil.isEmpty(regularExpression) ||
+				StringUtil.isEmpty(definitionName)) {
+			return Optional.empty();
+		}
+
+		return this.check(definitionName, regularExpression) ? Optional.empty() : Optional.of(errorMessage);
+	}
+
+	protected boolean check(String definitionName, String regularExpression) {
+		// メタデータ定義名未指定ならチェックしない
+		if (StringUtil.isEmpty(definitionName)) {
+			return true;
+		}
+
+		return definitionName.matches(regularExpression);
+	}
+
+	protected String getMessage(String key, Object... args) {
+		return CoreResourceBundleUtil.resourceString(key, args);
+	}
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/metadata/validation/DefinitionNameValidatorConstants.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/metadata/validation/DefinitionNameValidatorConstants.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.metadata.validation;
+
+/**
+ * メタデータ定義名チェックValidator用定数定義クラス
+ */
+public interface DefinitionNameValidatorConstants {
+	/** 名前の正規表現(パスにスラッシュを利用) */
+	public static final String NAME_REG_EXP_PATH_SLASH = "^[0-9a-zA-Z_][0-9a-zA-Z_-]*(/[0-9a-zA-Z_-]+)*$";
+	/** 名前の正規表現(パスにスラッシュを利用、名前にピリオド含む) */
+	public static final String NAME_REG_EXP_PATH_SLASH_NAME_PERIOD = "^[0-9a-zA-Z_][0-9a-zA-Z_-]*(/[0-9a-zA-Z_-]+)*(\\.[0-9a-zA-Z_-]+)*$";
+	/** 名前の正規表現(パスにピリオドを利用) */
+	public static final String NAME_REG_EXP_PATH_PERIOD = "^[0-9a-zA-Z_][0-9a-zA-Z_-]*(\\.[0-9a-zA-Z_-]+)*$";
+
+	/** Entity名の正規表現(英数、アンダスコア、パスにピリオド、先頭の数字不可、マイナス不可) */
+	public static final String ENTITY_NAME_REG_EXP_PATH_PERIOD = "^[a-zA-Z_][0-9a-zA-Z_]*(\\.[a-zA-Z_][0-9a-zA-Z_]*)*$";
+	/** Entityプロパティ名の正規表現(英数、アンダスコア、先頭の数字不可、マイナス不可) */
+	public static final String ENTITY_PROPERTY_NAME_REG_EXP_PATH_PERIOD = "^[a-zA-Z_][0-9a-zA-Z_]*$";
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/metadata/validation/EntityDeinitionNameCheckValidator.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/metadata/validation/EntityDeinitionNameCheckValidator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.metadata.validation;
+
+/**
+ * Entityメタデータ定義名をチェックするValidatorクラス
+ * 
+ * <p>
+ * 下記のようになってるかチェックする
+ * </p>
+ * <ul>
+ * <li>英数、アンダスコア、先頭の数字不可、マイナス不可</li>
+ * <li>パスにはピリオドを利用</li>
+ * </ul>
+ */
+public class EntityDeinitionNameCheckValidator extends DefinitionNameCheckValidator {
+
+	@Override
+	public String getErrorMessage(String definitionName) {
+		return this.getMessage("impl.metadata.validator.regularExpression.invalidEntityName");
+	}
+
+	@Override
+	public String getRegularExpression() {
+		return DefinitionNameValidatorConstants.ENTITY_NAME_REG_EXP_PATH_PERIOD;
+	}
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/metadata/validation/NoCheckValidator.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/metadata/validation/NoCheckValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.metadata.validation;
+
+import java.util.Optional;
+
+/**
+ * メタデータ定義名チェックしないValidatorクラス
+ * 
+ * <p>
+ * メタデータ定義名チェックしない場合に利用
+ * </p>
+ * 
+ */
+public class NoCheckValidator extends DefinitionNameCheckValidator {
+
+	@Override
+	public String getErrorMessage(String definitionName) {
+		return null;
+	}
+
+	@Override
+	public String getRegularExpression() {
+		return null;
+	}
+
+	@Override
+	public Optional<String> validate(String definitionName) {
+		return Optional.empty();
+	}
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/metadata/validation/PathSlashNamePeriodCheckValidator.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/metadata/validation/PathSlashNamePeriodCheckValidator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.metadata.validation;
+
+/**
+ * メタデータ定義名が下記になってるかチェックするValidatorクラス
+ * <ul>
+ * <li>英数字、ハイフン、アンダースコア、ピリオドのみ</li>
+ * <li>パスにはスラッシュを利用</li>
+ * </ul>
+ */
+public class PathSlashNamePeriodCheckValidator extends DefinitionNameCheckValidator {
+
+	@Override
+	public String getErrorMessage(String definitionName) {
+		return this.getMessage("impl.metadata.validator.regularExpression.invalidPathSlashNamePeriod");
+	}
+
+	@Override
+	public String getRegularExpression() {
+		return DefinitionNameValidatorConstants.NAME_REG_EXP_PATH_SLASH_NAME_PERIOD;
+	}
+}

--- a/iplass-core/src/main/resources/mtp-core-messages_ja.properties
+++ b/iplass-core/src/main/resources/mtp-core-messages_ja.properties
@@ -80,6 +80,11 @@ impl.lob.Lob.cantUpdate                                                         
 impl.lob.LobHandler.cantUpdate                                                        = 対象のデータは既に削除されたか、別ユーザーにて更新処理中のため、更新ができませんでした。
 impl.lob.LobHandler.noPermission                                                      = {0}権限がありません
 impl.metadata.duplicatePath                                                           = 重複した名前が既に存在します。
+impl.metadata.validator.regularExpression.invalidPathPeriod                           = 名前には英数字、ハイフン、アンダースコアのみ利用することができます。パスにはピリオドを利用します。
+impl.metadata.validator.regularExpression.invalidPathSlash                            = 名前には英数字、ハイフン、アンダースコア、スラッシュのみ利用することができます。
+impl.metadata.validator.regularExpression.invalidPathSlashNamePeriod                  = 名前には英数字、ハイフン、アンダースコア、スラッシュ、ピリオドのみ利用することができます。
+impl.metadata.validator.regularExpression.invalidEntityName                           = 名前には英数字、アンダースコアのみ利用することができます。先頭は英字のみ利用することができます。パスにはピリオドを利用します。
+impl.metadata.validator.regularExpression.invalidPath                                 = パスの指定に誤りがあります。
 impl.transaction.LocalTransaction.duplicate                                           = 重複した値が既に存在します。
 impl.web.WebRequestContext.canNotConv                                                 = 型の変換が正常に行えません。パラメータ名:{0}
 impl.web.fileupload.UploadFileHandleImpl.invalidFileMsg                               = 不正なファイルの為アップロードできません。
@@ -91,3 +96,4 @@ view.filter.incorrectErr      = 指定された条件式が不正です。
 view.filter.nullValueErr      = 条件式 {0} には条件値が指定されていません。
 view.filter.numberNotFoundErr = 条件式 {0} に該当する条件が存在しません。
 view.filter.unsupportErr      = 指定された条件式はサポートされていません。{0}
+

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/EntityViewRuntime.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/EntityViewRuntime.java
@@ -24,13 +24,18 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
+import org.iplass.gem.command.GemResourceBundleUtil;
 import org.iplass.mtp.entity.query.PreparedQuery;
 import org.iplass.mtp.impl.metadata.BaseMetaDataRuntime;
+import org.iplass.mtp.impl.metadata.MetaDataRuntimeException;
+import org.iplass.mtp.impl.metadata.validation.DefinitionNameValidatorConstants;
 import org.iplass.mtp.impl.script.template.GroovyTemplate;
 import org.iplass.mtp.impl.view.generic.common.MetaAutocompletionSetting.AutocompletionSettingRuntime;
 import org.iplass.mtp.impl.view.generic.element.ElementRuntime;
 import org.iplass.mtp.impl.view.generic.element.MetaButton.ButtonRuntime;
+import org.iplass.mtp.util.StringUtil;
 
 /**
  * 画面定義のランタイム
@@ -68,6 +73,7 @@ public class EntityViewRuntime extends BaseMetaDataRuntime {
 			this.metaData = metaData;
 			if (metaData.getViews().size() > 0) {
 				for (MetaFormView view : metaData.getViews()) {
+					this.validateViewName(view);
 					this.addFormView(view.createRuntime(this));
 				}
 			}
@@ -76,17 +82,40 @@ public class EntityViewRuntime extends BaseMetaDataRuntime {
 		}
 	}
 
+	private void validateViewName(MetaFormView view) {
+		if (Objects.isNull(view)) {
+			return;
+		}
+
+		// View名取得
+		String viewName = view.getName();
+		if (StringUtil.isEmpty(viewName)) {
+			return;
+		}
+
+		// View名整合性チェック
+		if (viewName.matches(DefinitionNameValidatorConstants.NAME_REG_EXP_PATH_PERIOD)) {
+			return;
+		}
+
+		// チェックエラー
+		setIllegalStateException(
+				new MetaDataRuntimeException(GemResourceBundleUtil.resourceString("view.generic.EntityViewRuntime.validationErr", viewName)));
+	}
+
 	/**
 	 * レイアウト情報のランタイムを追加
 	 * @param formView レイアウト情報
 	 */
 	private void addFormView(FormViewRuntime formView) {
-		if (this.formViews == null) this.formViews = new ArrayList<>();
+		if (this.formViews == null)
+			this.formViews = new ArrayList<>();
 		this.formViews.add(formView);
 	}
 
 	public List<FormViewRuntime> getFormViews() {
-		if (this.formViews == null) this.formViews = new ArrayList<>();
+		if (this.formViews == null)
+			this.formViews = new ArrayList<>();
 		return formViews;
 	}
 
@@ -97,7 +126,8 @@ public class EntityViewRuntime extends BaseMetaDataRuntime {
 	 */
 	public void addTemplate(String key, GroovyTemplate template) {
 		checkState();
-		if (templates == null) templates = new HashMap<>();
+		if (templates == null)
+			templates = new HashMap<>();
 		templates.put(key, template);
 	}
 
@@ -122,7 +152,8 @@ public class EntityViewRuntime extends BaseMetaDataRuntime {
 	 */
 	public void addQuery(String key, PreparedQuery query) {
 		checkState();
-		if (queries == null) queries = new HashMap<>();
+		if (queries == null)
+			queries = new HashMap<>();
 		queries.put(key, query);
 	}
 
@@ -154,7 +185,8 @@ public class EntityViewRuntime extends BaseMetaDataRuntime {
 	 * @param customStyleMap カスタムスタイルの格納されたマップ
 	 */
 	public void addCustomStyle(String key, Map<String, GroovyTemplate> customStyleMap) {
-		if (customStylesMap == null) customStylesMap = new HashMap<>();
+		if (customStylesMap == null)
+			customStylesMap = new HashMap<>();
 		customStylesMap.put(key, customStyleMap);
 	}
 
@@ -174,7 +206,8 @@ public class EntityViewRuntime extends BaseMetaDataRuntime {
 	 * @param handler エレメントハンドラ
 	 */
 	public void addElement(ElementRuntime element) {
-		if (elementMap == null) elementMap = new HashMap<>();
+		if (elementMap == null)
+			elementMap = new HashMap<>();
 		if (element.getMetaData().getElementRuntimeId() != null) {
 			elementMap.put(element.getMetaData().getElementRuntimeId(), element);
 		}
@@ -186,7 +219,8 @@ public class EntityViewRuntime extends BaseMetaDataRuntime {
 	 * @return エレメントハンドラ
 	 */
 	public ElementRuntime getElement(String elementRuntimeId) {
-		if (elementMap == null) return null;
+		if (elementMap == null)
+			return null;
 		return elementMap.get(elementRuntimeId);
 	}
 
@@ -195,7 +229,8 @@ public class EntityViewRuntime extends BaseMetaDataRuntime {
 	 * @param handler
 	 */
 	public void addButton(ButtonRuntime button) {
-		if (buttonMap == null) buttonMap = new HashMap<>();
+		if (buttonMap == null)
+			buttonMap = new HashMap<>();
 		if (button.getMetaData().getCustomDisplayTypeScriptKey() != null) {
 			buttonMap.put(button.getMetaData().getCustomDisplayTypeScriptKey(), button);
 		}
@@ -207,7 +242,8 @@ public class EntityViewRuntime extends BaseMetaDataRuntime {
 	 * @return
 	 */
 	public ButtonRuntime getButton(String key) {
-		if (buttonMap == null) return null;
+		if (buttonMap == null)
+			return null;
 		return buttonMap.get(key);
 	}
 
@@ -216,7 +252,8 @@ public class EntityViewRuntime extends BaseMetaDataRuntime {
 	 * @param handler
 	 */
 	public void addAutocompletionSetting(AutocompletionSettingRuntime setting) {
-		if (autocompletionSettingMap == null) autocompletionSettingMap = new HashMap<>();
+		if (autocompletionSettingMap == null)
+			autocompletionSettingMap = new HashMap<>();
 		if (setting.getMetaData().getRuntimeKey() != null) {
 			autocompletionSettingMap.put(setting.getMetaData().getRuntimeKey(), setting);
 		}

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/MetaEntityView.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/MetaEntityView.java
@@ -32,10 +32,12 @@ import org.iplass.mtp.impl.entity.EntityHandler;
 import org.iplass.mtp.impl.entity.MetaEntity;
 import org.iplass.mtp.impl.metadata.BaseRootMetaData;
 import org.iplass.mtp.impl.metadata.MetaDataConfig;
+import org.iplass.mtp.impl.metadata.validation.DefinitionNameCheckValidator;
+import org.iplass.mtp.impl.metadata.validation.EntityDeinitionNameCheckValidator;
 import org.iplass.mtp.impl.util.ObjectUtil;
-import org.iplass.mtp.view.generic.ViewControlSetting;
 import org.iplass.mtp.view.generic.EntityView;
 import org.iplass.mtp.view.generic.FormView;
+import org.iplass.mtp.view.generic.ViewControlSetting;
 
 /**
  * 画面定義
@@ -76,7 +78,8 @@ public class MetaEntityView extends BaseRootMetaData implements DefinableMetaDat
 	 * @return レイアウト情報
 	 */
 	public List<MetaFormView> getViews() {
-		if (this.views == null) this.views = new ArrayList<MetaFormView>();
+		if (this.views == null)
+			this.views = new ArrayList<MetaFormView>();
 		return views;
 	}
 
@@ -97,7 +100,8 @@ public class MetaEntityView extends BaseRootMetaData implements DefinableMetaDat
 	}
 
 	public List<MetaViewControlSetting> getViewControlSettings() {
-		if (this.viewControlSettings == null) this.viewControlSettings = new ArrayList<>();
+		if (this.viewControlSettings == null)
+			this.viewControlSettings = new ArrayList<>();
 		return viewControlSettings;
 	}
 
@@ -190,5 +194,15 @@ public class MetaEntityView extends BaseRootMetaData implements DefinableMetaDat
 			}
 		}
 		return entityView;
+	}
+
+	@Override
+	public String pathPrefix() {
+		return EntityViewService.ENTITY_META_PATH;
+	}
+
+	@Override
+	public Class<? extends DefinitionNameCheckValidator> definitionNameCheckValidatorClass() {
+		return EntityDeinitionNameCheckValidator.class;
 	}
 }

--- a/iplass-gem/src/main/resources/mtp-gem-messages_ja.properties
+++ b/iplass-gem/src/main/resources/mtp-gem-messages_ja.properties
@@ -504,3 +504,5 @@ layout.preview.updatedPreviewDateMsg = プレビュー日時を変更しまし�
 menu.menu.home   = ホーム
 menu.menu.menu   = メニュー
 menu.menu.widget = ウィジェット
+
+view.generic.EntityViewRuntime.validationErr = View名には英数字、ハイフン、アンダースコア、ピリオドのみ利用することができます。 : View名 = {0}

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/metaport/MetaDataPortingServiceImpl.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/metaport/MetaDataPortingServiceImpl.java
@@ -29,14 +29,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Marshaller;
-import jakarta.xml.bind.Unmarshaller;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.sax.SAXSource;
 
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.iplass.mtp.ManagerLocator;
 import org.iplass.mtp.auth.login.IdPasswordCredential;
 import org.iplass.mtp.impl.auth.AuthContextHolder;
@@ -59,9 +61,9 @@ import org.iplass.mtp.impl.metadata.MetaDataEntry;
 import org.iplass.mtp.impl.metadata.MetaDataEntry.RepositoryType;
 import org.iplass.mtp.impl.metadata.MetaDataEntry.State;
 import org.iplass.mtp.impl.metadata.MetaDataEntryInfo;
+import org.iplass.mtp.impl.metadata.MetaDataIllegalStateException;
 import org.iplass.mtp.impl.metadata.MetaDataJAXBService;
 import org.iplass.mtp.impl.metadata.RootMetaData;
-import org.iplass.mtp.impl.metadata.xmlfile.XmlFileMetaDataStore;
 import org.iplass.mtp.impl.metadata.xmlresource.ContextPath;
 import org.iplass.mtp.impl.metadata.xmlresource.MetaDataEntryList;
 import org.iplass.mtp.impl.metadata.xmlresource.XmlResourceMetaDataEntryThinWrapper;
@@ -110,7 +112,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 		metaTenantService = config.getDependentService(MetaTenantService.class);
 		tContextService = config.getDependentService(TenantContextService.class);
 
-		importHandler = (MetaDataImportHandler)config.getBean("importHandler");
+		importHandler = (MetaDataImportHandler) config.getBean("importHandler");
 	}
 
 	@Override
@@ -136,7 +138,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 			writeHeader(writer);
 
 			String beforeContextPath = "";
-			boolean isWriteContext = false;	//有効なEntityがない場合の時用
+			boolean isWriteContext = false; //有効なEntityがない場合の時用
 			for (String path : paths) {
 				MetaDataEntry entry = MetaDataContext.getContext().getMetaDataEntry(path);
 				if (entry == null) {
@@ -199,7 +201,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 	}
 
 	@Override
-	public void writeHistory(PrintWriter writer, String definitionId, String[] versions){
+	public void writeHistory(PrintWriter writer, String definitionId, String[] versions) {
 		writeHistory(writer, definitionId, versions, new MetaDataWriteLoggingCallback());
 
 	}
@@ -218,7 +220,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 			writeHeader(writer);
 
 			String beforeContextPath = "";
-			boolean isWriteContext = false;	//有効なEntityがない場合の時用
+			boolean isWriteContext = false; //有効なEntityがない場合の時用
 			for (String temp : versions) {
 
 				int version = Integer.parseInt(temp);
@@ -538,8 +540,8 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 		SAXParserFactory f = SAXParserFactory.newInstance();
 		f.setNamespaceAware(true);
 		f.setValidating(false);
-	    f = new SecureSAXParserFactory(f);
-	    try {
+		f = new SecureSAXParserFactory(f);
+		try {
 			return new SAXSource(f.newSAXParser().getXMLReader(), new InputSource(is));
 		} catch (SAXException | ParserConfigurationException e) {
 			throw new JAXBException(e);
@@ -570,7 +572,8 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 		return filterInfo;
 	}
 
-	private MetaDataImportResult doImportMetaData(XMLEntryInfo entryInfo, final List<MetaDataEntry> entryList, final MetaDataImportResult result, final Tenant importTenant) {
+	private MetaDataImportResult doImportMetaData(XMLEntryInfo entryInfo, final List<MetaDataEntry> entryList, final MetaDataImportResult result,
+			final Tenant importTenant) {
 
 		String curPath = null;
 		//対象メタデータのステータスをチェックして、順番を振り分ける
@@ -657,7 +660,6 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 				}
 			}
 
-
 			if (!combiIdList.isEmpty()) {
 				//コンビデータが含まれている場合は、normalList、individualListから抜き出す(先に更新するため)
 				for (String combiId : combiIdList) {
@@ -678,13 +680,18 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 
 		//通常の更新処理
 		if (!result.isError()) {
-			doImportNormalMetaData(removeList, normalCombiList, new ArrayList<>(normalList.values()) ,
+			doImportNormalMetaData(removeList, normalCombiList, new ArrayList<>(normalList.values()),
 					importTenant, needTenantReload, needMetaContextReload, result);
 		}
 
 		//特殊の更新処理
 		if (!result.isError()) {
-			doImportIndividualMetaData(individualCombiList, new ArrayList<>(individualList.values()) ,result);
+			doImportIndividualMetaData(individualCombiList, new ArrayList<>(individualList.values()), result);
+		}
+
+		// 正常終了してる場合は、RuntimeのcheckStatus結果を追加する
+		if (!result.isError()) {
+			this.addCheckStatusResult(result, entryList);
 		}
 
 		return result;
@@ -692,8 +699,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 
 	private void doImportNormalMetaData(final List<ImportMetaDataInfo> removeList,
 			final List<ImportMetaDataInfo> normalCombiList, final List<ImportMetaDataInfo> normalList,
-			final Tenant importTenant
-			, final boolean needTenantReload, final boolean needMetaContextReload, final MetaDataImportResult result) {
+			final Tenant importTenant, final boolean needTenantReload, final boolean needMetaContextReload, final MetaDataImportResult result) {
 
 		if (removeList.isEmpty() && normalList.isEmpty()) {
 			return;
@@ -709,7 +715,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 
 			@Override
 			public void updated(String path, String pathBefore) {
-				logger.debug("metadata context updated. path=" + path +" pathBefore=" + pathBefore);
+				logger.debug("metadata context updated. path=" + path + " pathBefore=" + pathBefore);
 			}
 
 			@Override
@@ -728,65 +734,64 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 			//削除と通常のインポート処理はまとめて１トランザクションで行う
 			Transaction.requiresNew(t -> {
 
-					//個別にリロードするかの判定
-					boolean doAutoReload = (!needTenantReload && !needMetaContextReload);
+				//個別にリロードするかの判定
+				boolean doAutoReload = (!needTenantReload && !needMetaContextReload);
 
-					MetaDataContext.getContext().addMetaDataContextListener(listener);
+				MetaDataContext.getContext().addMetaDataContextListener(listener);
 
-					//削除から開始
-					for (ImportMetaDataInfo info : removeList) {
-						try {
-							importHandler.removeMetaData(info.path, info.metaData, doAutoReload);
+				//削除から開始
+				for (ImportMetaDataInfo info : removeList) {
+					try {
+						importHandler.removeMetaData(info.path, info.metaData, doAutoReload);
 
-							logger.debug("metadata removed. path=" + info.path);
-							result.addMessages(getRS("removeMeta", info.path));
-						} catch (Exception e) {
-							errorForImportMetaDataEntry(info.path, e, result);
-							return null;
-						}
+						logger.debug("metadata removed. path=" + info.path);
+						result.addMessages(getRS("removeMeta", info.path));
+					} catch (Exception e) {
+						errorForImportMetaDataEntry(info.path, e, result);
+						return null;
 					}
+				}
 
-					//登録処理(Combi)
-					for (ImportMetaDataInfo info : normalCombiList) {
-						try {
-							doImportNormalMetaData(info, importTenant, doAutoReload, result);
-						} catch (Exception e) {
-							errorForImportMetaDataEntry(info.path, e, result);
-							return null;
-						}
+				//登録処理(Combi)
+				for (ImportMetaDataInfo info : normalCombiList) {
+					try {
+						doImportNormalMetaData(info, importTenant, doAutoReload, result);
+					} catch (Exception e) {
+						errorForImportMetaDataEntry(info.path, e, result);
+						return null;
 					}
+				}
 
-					//登録処理(通常)
-					for (ImportMetaDataInfo info : normalList) {
-						try {
-							doImportNormalMetaData(info, importTenant, doAutoReload, result);
-						} catch (Exception e) {
-							errorForImportMetaDataEntry(info.path, e, result);
-							return null;
-						}
+				//登録処理(通常)
+				for (ImportMetaDataInfo info : normalList) {
+					try {
+						doImportNormalMetaData(info, importTenant, doAutoReload, result);
+					} catch (Exception e) {
+						errorForImportMetaDataEntry(info.path, e, result);
+						return null;
 					}
+				}
 
-					return null;
+				return null;
 			});
 
 			//リロード処理(別トランザクションで実行)
 			Transaction.requiresNew(t -> {
-					if (needTenantReload) {
-						tContextService.reloadTenantContext(ExecuteContext.getCurrentContext().getTenantContext().getTenantId(), false);
-						logger.debug("reload tenant context. trigger is metadata import.");
-						result.addMessages(getRS("reloadTenantContext"));
-					} else if (needMetaContextReload) {
-						MetaDataContext.getContext().clearAllCache();
-						logger.debug("clear metadata context. trigger is metadata import.");
-						result.addMessages(getRS("clearAllMetaDataContext"));
-					} else {
-						//それ以外の場合は個別に反映される
-						logger.debug("update metadata context only target. trigger is metadata import.");
-						result.addMessages(getRS("updateMetaDataContext"));
-					}
+				if (needTenantReload) {
+					tContextService.reloadTenantContext(ExecuteContext.getCurrentContext().getTenantContext().getTenantId(), false);
+					logger.debug("reload tenant context. trigger is metadata import.");
+					result.addMessages(getRS("reloadTenantContext"));
+				} else if (needMetaContextReload) {
+					MetaDataContext.getContext().clearAllCache();
+					logger.debug("clear metadata context. trigger is metadata import.");
+					result.addMessages(getRS("clearAllMetaDataContext"));
+				} else {
+					//それ以外の場合は個別に反映される
+					logger.debug("update metadata context only target. trigger is metadata import.");
+					result.addMessages(getRS("updateMetaDataContext"));
+				}
 
 			});
-
 
 		} finally {
 			MetaDataContext.getContext().removeMetaDataContextListener(listener);
@@ -846,7 +851,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 		Transaction.requiresNew(t -> {
 			final ExecuteContext current = ExecuteContext.getCurrentContext();
 			TenantContext tenantContext = tContextService.getTenantContext(ExecuteContext.getCurrentContext().getCurrentTenant().getId());
-			ExecuteContext.executeAs(tenantContext, ()->{
+			ExecuteContext.executeAs(tenantContext, () -> {
 				ExecuteContext.getCurrentContext().setLanguage(current.getLanguage());
 
 				//特殊メタデータについては個別にリロードする
@@ -918,6 +923,53 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 		}
 	}
 
+	/**
+	 * 
+	 * <p>
+	 * メタデータ新規作成や定義名変更した場合、別トランザクションで
+	 * {@link org.iplass.mtp.impl.metadata.MetaDataContext#checkState(String) checkState}を実行しないと</br>
+	 * MetaDataRuntimeが見つからないエラーが返ってきてしまって、実際はcheckStatusエラーではないのcheckStatusエラーになってしまう</br>
+	 * なので、新規トランザクションでcheckStatusを実行する
+	 * </p>
+	 * 
+	 * @param result インポート結果
+	 * @param entryList インポートしたメタデータ
+	 */
+	private void addCheckStatusResult(final MetaDataImportResult result, final List<MetaDataEntry> entryList) {
+		if (CollectionUtils.isEmpty(entryList)) {
+			return;
+		}
+
+		List<String> errorPathList = Transaction.requiresNew(t -> {
+			return entryList.stream().filter(entry -> {
+				String path = entry.getPath();
+				if (StringUtil.isEmpty(path)) {
+					return false;
+				}
+
+				try {
+					MetaDataContext.getContext().checkState(entry.getPath());
+					return false;
+				} catch (MetaDataIllegalStateException e) {
+					return true;
+				}
+			}).map(MetaDataEntry::getPath).toList();
+		});
+
+		if (CollectionUtils.isEmpty(errorPathList)) {
+			return;
+		}
+
+		// TODO メッセージにする
+		result.addMessages("-----------------------------------------");
+		result.addMessages("以下インポートしたメタデータに不整合が発生している可能性があります。");
+		result.addMessages("詳しくはStatusCheckで確認してください。");
+
+		errorPathList.forEach(path -> {
+			result.addMessages(String.format("[%1$s]", path));
+		});
+	}
+
 	private void writeHeader(PrintWriter writer) {
 		writer.println("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
 		writer.println("<metaDataList>");
@@ -946,7 +998,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 		if (path.endsWith(checkName)) {
 			contextPath = path.substring(0, path.length() - checkName.length() - 1);
 		} else if (path.endsWith(name)) {
-				contextPath = path.substring(0, path.length() - name.length() - 1);
+			contextPath = path.substring(0, path.length() - name.length() - 1);
 		} else {
 			contextPath = path;
 		}
@@ -960,7 +1012,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 	private XMLEntryInfo parse(MetaDataEntryList metaList) {
 		XMLEntryInfo entryInfo = new XMLEntryInfo();
 		if (metaList.getContextPath() != null) {
-			for (ContextPath context: metaList.getContextPath()) {
+			for (ContextPath context : metaList.getContextPath()) {
 				parseContextPath(entryInfo, context, "", context.getName());
 			}
 		}
@@ -969,13 +1021,13 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 
 	private void parseContextPath(XMLEntryInfo entryInfo, ContextPath context, String prefixPath, String rootPath) {
 		if (context.getContextPath() != null) {
-			for (ContextPath child: context.getContextPath()) {
+			for (ContextPath child : context.getContextPath()) {
 				parseContextPath(entryInfo, child, prefixPath + context.getName() + "/", rootPath);
 			}
 		}
 
 		if (context.getEntry() != null) {
-			for (XmlResourceMetaDataEntryThinWrapper xmlEntry: context.getEntry()) {
+			for (XmlResourceMetaDataEntryThinWrapper xmlEntry : context.getEntry()) {
 
 				if (xmlEntry.getMetaData() == null) {
 					//現在存在しないMetaDataが指定されたなどして、MetaDataが読めていない可能性。
@@ -994,7 +1046,8 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 					path = convertPath(prefixPath + context.getName() + "/" + xmlEntry.getMetaData().getName());
 				}
 
-				MetaDataEntry entry = new MetaDataEntry(path, xmlEntry.getMetaData(), State.VALID, 0, xmlEntry.isOverwritable(), xmlEntry.isSharable(), xmlEntry.isDataSharable(), xmlEntry.isPermissionSharable());
+				MetaDataEntry entry = new MetaDataEntry(path, xmlEntry.getMetaData(), State.VALID, 0, xmlEntry.isOverwritable(), xmlEntry.isSharable(),
+						xmlEntry.isDataSharable(), xmlEntry.isPermissionSharable());
 
 				entryInfo.putPathEntry(path, entry);
 				if (StringUtil.isEmpty(entry.getMetaData().getId())) {
@@ -1015,7 +1068,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 				|| path.startsWith(EntityFilterService.META_PATH)
 				|| path.startsWith(EntityWebApiService.META_PATH)
 				|| path.startsWith(GroovyScriptService.UTILITY_CLASS_META_PATH)) {
-			return path.replace(".","/");
+			return path.replace(".", "/");
 		}
 		return path;
 	}
@@ -1031,8 +1084,8 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 	private class ImportMetaDataInfo {
 		String path;
 		RootMetaData metaData;
-		MetaDataEntry entry;	/* 削除の場合は未設定 */
-		MetaDataImportStatus status;	/* 削除の場合は未設定 */
+		MetaDataEntry entry; /* 削除の場合は未設定 */
+		MetaDataImportStatus status; /* 削除の場合は未設定 */
 
 		public ImportMetaDataInfo(String path, RootMetaData metaData) {
 			this.path = path;
@@ -1064,12 +1117,12 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 
 	@Override
 	public void patchEntityData(final PatchEntityDataParameter param) {
-		ConfigImpl newConfig = new ConfigImpl("forPatchNew", new NameValue[] {new NameValue("filePath", param.getNewMetaDataFilePath())}, null);
+		ConfigImpl newConfig = new ConfigImpl("forPatchNew", new NameValue[] { new NameValue("filePath", param.getNewMetaDataFilePath()) }, null);
 		newConfig.addDependentService(MetaDataJAXBService.class.getName(), jaxbService);
 		XmlResourceMetaDataStore newRepo = new XmlResourceMetaDataStore();
 		newRepo.inited(null, newConfig);
 
-		ConfigImpl oldConfig = new ConfigImpl("forPatchOld", new NameValue[] {new NameValue("filePath", param.getOldMetaDataFilePath())}, null);
+		ConfigImpl oldConfig = new ConfigImpl("forPatchOld", new NameValue[] { new NameValue("filePath", param.getOldMetaDataFilePath()) }, null);
 		oldConfig.addDependentService(MetaDataJAXBService.class.getName(), jaxbService);
 		XmlResourceMetaDataStore oldRepo = new XmlResourceMetaDataStore();
 		oldRepo.inited(null, oldConfig);
@@ -1086,7 +1139,8 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 						StoreService storeService = ServiceRegistry.getRegistry().getService(StoreService.class);
 						DataStore srds = storeService.getDataStore();
 						EntityContext ec = EntityContext.getCurrentContext();
-						srds.getApplyMetaDataStrategy().patchData(newMetaEntity, oldMetaEntity, ec, EntityContext.getCurrentContext().getLocalTenantId());
+						srds.getApplyMetaDataStrategy().patchData(newMetaEntity, oldMetaEntity, ec,
+								EntityContext.getCurrentContext().getLocalTenantId());
 					}
 				});
 			}
@@ -1113,8 +1167,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 	@Override
 	public void patchEntityDataWithUserAuth(final PatchEntityDataParameter param, String userId, String password) {
 		try {
-			authService.login(StringUtil.isNotEmpty(password) ?
-					new IdPasswordCredential(userId, password) : new InternalCredential(userId));
+			authService.login(StringUtil.isNotEmpty(password) ? new IdPasswordCredential(userId, password) : new InternalCredential(userId));
 			authService.doSecuredAction(AuthContextHolder.getAuthContext(), () -> {
 				patchEntityData(param);
 				return null;

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/actionmapping/MetaActionMapping.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/actionmapping/MetaActionMapping.java
@@ -45,6 +45,8 @@ import org.iplass.mtp.impl.i18n.I18nUtil;
 import org.iplass.mtp.impl.metadata.BaseMetaDataRuntime;
 import org.iplass.mtp.impl.metadata.BaseRootMetaData;
 import org.iplass.mtp.impl.metadata.MetaDataConfig;
+import org.iplass.mtp.impl.metadata.validation.DefinitionNameCheckValidator;
+import org.iplass.mtp.impl.metadata.validation.PathSlashNamePeriodCheckValidator;
 import org.iplass.mtp.impl.util.ObjectUtil;
 import org.iplass.mtp.impl.web.ParameterValueMap;
 import org.iplass.mtp.impl.web.RequestPath.PathType;
@@ -208,7 +210,6 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 		this.synchronizeOnSession = synchronizeOnSession;
 	}
 
-
 	public MetaCacheCriteria getCacheCriteria() {
 		return cacheCriteria;
 	}
@@ -246,7 +247,7 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 		//新しい属性の方が有効
 		return privileged;
 	}
- 
+
 	public void setPrivileged(boolean isPrivileged) {
 		//保存時に古い属性をnullにセットするようにする
 		this.privileged = isPrivileged;
@@ -382,7 +383,6 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 
 		needTrustedAuthenticate = definition.isNeedTrustedAuthenticate();
 
-
 		if (definition.getAllowRequestContentTypes() != null) {
 			allowRequestContentTypes = new String[definition.getAllowRequestContentTypes().length];
 			System.arraycopy(definition.getAllowRequestContentTypes(), 0, allowRequestContentTypes, 0, allowRequestContentTypes.length);
@@ -463,6 +463,16 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 		return definition;
 	}
 
+	@Override
+	public String pathPrefix() {
+		return ActionMappingService.ACTION_MAPPING_META_PATH;
+	}
+
+	@Override
+	public Class<? extends DefinitionNameCheckValidator> definitionNameCheckValidatorClass() {
+		return PathSlashNamePeriodCheckValidator.class;
+	}
+
 	public class ActionMappingRuntime extends BaseMetaDataRuntime {
 
 		private CommandRuntime cmd;
@@ -514,7 +524,7 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 
 				if (paramMap != null) {
 					paramMapRuntimes = new HashMap<>();
-					for (ParamMap p: paramMap) {
+					for (ParamMap p : paramMap) {
 						ParamMapRuntime pmr = p.createRuntime();
 						List<ParamMapRuntime> pmrList = paramMapRuntimes.get(p.getName());
 						if (pmrList == null) {
@@ -547,7 +557,7 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 						}
 						if (allowMethod != null && allowMethod.length > 0) {
 							ArrayList<String> aml = new ArrayList<>(allowMethod.length);
-							for (HttpMethodType hmt: allowMethod) {
+							for (HttpMethodType hmt : allowMethod) {
 								aml.add(hmt.toString());
 							}
 							requestRestrictionRuntime.setAllowMethods(aml);
@@ -580,7 +590,7 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 
 		private String allowString() {
 			StringBuilder sb = new StringBuilder();
-			for (String m: requestRestrictionRuntime.getAllowMethods()) {
+			for (String m : requestRestrictionRuntime.getAllowMethods()) {
 				switch (m) {
 				case GET:
 					sb.append(GET).append(", ").append(HEAD).append(", ");
@@ -662,10 +672,10 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 
 			Enumeration<String> reqHeaderEnum = req.getRequest().getHeaderNames();
 
-			while( reqHeaderEnum.hasMoreElements() ) {
+			while (reqHeaderEnum.hasMoreElements()) {
 				String headerName = reqHeaderEnum.nextElement();
 				buffer.append(CRLF).append(headerName).append(": ")
-				.append(req.getRequest().getHeader(headerName));
+						.append(req.getRequest().getHeader(headerName));
 			}
 
 			buffer.append(CRLF);
@@ -776,7 +786,7 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 				}
 			}
 
-			WebInvocationImpl invoke =  new WebInvocationImpl(reqInterceptors, cmdInterceptors, cmd, requestContext, req, this);
+			WebInvocationImpl invoke = new WebInvocationImpl(reqInterceptors, cmdInterceptors, cmd, requestContext, req, this);
 
 			if (isSynchronizeOnSession()) {
 				synchronized (requestContext.getSession()) {


### PR DESCRIPTION
<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->
fixes https://github.com/dentsusoken/iPLAss/issues/1699

- EntityView作成ダイアログにてOKボタン押下時にView名チェックをするように修正
- MetaDataExplorerにてメタデータインポート時に各メタデータの定義名に対してAdminConsole画面からメタデータ作成（変更）時と同じ入力チェックを実施するように修正（View名チェックについてはcheckStatus）

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->

## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->