### PR TITLE
GEM: 詳細画面から特定バージョンに遷移した場合でもEntityを更新できるよう修正

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/command/Constants.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/Constants.java
@@ -42,6 +42,7 @@ public class Constants {
 	public static final String VERSION = "version";
 	public static final String TIMESTAMP = "timestamp";
 	public static final String NEWVERSION = "newversion";
+	public static final String VERSION_SPECIFIED = "versionSpecified";
 	public static final String MESSAGE = "message";
 	public static final String ERROR_PROP = "errorProperty";
 	public static final String DATA = "data";

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/DetailCommandContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/DetailCommandContext.java
@@ -518,6 +518,10 @@ public class DetailCommandContext extends RegistrationCommandContext
 					}
 				}
 			}
+			// 詳細画面の「別バージョンを参照」で参照されたか確認
+			if (isVersionSpecified()) {
+				return true;
+			}
 		} else {
 			// 検索時に保存時データを検索しているかを確認
 			String searchCond = getSearchCond();
@@ -534,6 +538,15 @@ public class DetailCommandContext extends RegistrationCommandContext
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * 詳細画面の「別バージョンを参照」で指定されたバージョンのEntityデータをロードするかを取得します。
+	 * @return
+	 */
+	public boolean isVersionSpecified() {
+		String versionSpecified = getParam(Constants.VERSION_SPECIFIED);
+		return versionSpecified != null && "true".equals(versionSpecified);
 	}
 
 	@Override

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/DetailViewCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/DetailViewCommand.java
@@ -64,111 +64,135 @@ import org.slf4j.LoggerFactory;
  * @author lis3wg
  */
 @ActionMappings({
-	@ActionMapping(name=DetailViewCommand.VIEW_ACTION_NAME,
-		displayName="詳細表示",
-		paramMapping={
-			@ParamMapping(name=Constants.DEF_NAME, mapFrom="${0}", condition="subPath.length==2"),
-			@ParamMapping(name=Constants.OID, mapFrom="${1}", condition="subPath.length==2"),
-			@ParamMapping(name=Constants.VIEW_NAME, mapFrom="${0}", condition="subPath.length==3"),
-			@ParamMapping(name=Constants.DEF_NAME, mapFrom="${1}", condition="subPath.length==3"),
-			@ParamMapping(name=Constants.OID, mapFrom="${2}", condition="subPath.length==3")
-		},
-		command=@CommandConfig(commandClass=DetailViewCommand.class, value="cmd.detail=false;"),
-		result={
-			@Result(status=Constants.CMD_EXEC_SUCCESS, type=Type.TEMPLATE, value=Constants.TEMPLATE_VIEW),
-			@Result(status=Constants.CMD_EXEC_ERROR_LOCK, type=Type.TEMPLATE, value=Constants.TEMPLATE_VIEW),
-			@Result(status=Constants.CMD_EXEC_ERROR_VIEW, type=Type.TEMPLATE, value=Constants.TEMPLATE_COMMON_ERROR,
-					layoutActionName=Constants.LAYOUT_NORMAL_ACTION),
-			@Result(status=Constants.CMD_EXEC_ERROR_NODATA,type=Type.TEMPLATE, value=Constants.TEMPLATE_COMMON_ERROR,
-					layoutActionName=Constants.LAYOUT_NORMAL_ACTION)
-		}
-	),
-	@ActionMapping(name=DetailViewCommand.REF_VIEW_ACTION_NAME,
-		displayName="参照詳細表示",
-		paramMapping={
-			@ParamMapping(name=Constants.DEF_NAME, mapFrom="${0}", condition="subPath.length==2"),
-			@ParamMapping(name=Constants.OID, mapFrom="${1}", condition="subPath.length==2"),
-			@ParamMapping(name=Constants.VIEW_NAME, mapFrom="${0}", condition="subPath.length==3"),
-			@ParamMapping(name=Constants.DEF_NAME, mapFrom="${1}", condition="subPath.length==3"),
-			@ParamMapping(name=Constants.OID, mapFrom="${2}", condition="subPath.length==3")
-		},
-		command=@CommandConfig(commandClass=DetailViewCommand.class, value="cmd.detail=false;"),
-		result={
-			@Result(status=Constants.CMD_EXEC_SUCCESS, type=Type.TEMPLATE, value=Constants.TEMPLATE_REF_VIEW),
-			@Result(status=Constants.CMD_EXEC_ERROR_LOCK, type=Type.TEMPLATE, value=Constants.TEMPLATE_REF_VIEW),
-			@Result(status=Constants.CMD_EXEC_ERROR_VIEW, type=Type.TEMPLATE,
-					value=Constants.TEMPLATE_COMMON_ERROR,
-					layoutActionName=Constants.LAYOUT_POPOUT_ACTION),
-			@Result(status=Constants.CMD_EXEC_ERROR_NODATA, type=Type.TEMPLATE,
-					value=Constants.TEMPLATE_COMMON_ERROR,
-					layoutActionName=Constants.LAYOUT_POPOUT_ACTION)
-		}
-	),
-	@ActionMapping(name=DetailViewCommand.DETAIL_ACTION_NAME,
-		displayName="詳細編集",
-		paramMapping={
-			@ParamMapping(name=Constants.DEF_NAME, mapFrom="${0}", condition="subPath.length==1"),
-			@ParamMapping(name=Constants.VIEW_NAME, mapFrom="${0}", condition="subPath.length==2"),
-			@ParamMapping(name=Constants.DEF_NAME, mapFrom="${1}", condition="subPath.length==2")
-		},
-		command=@CommandConfig(commandClass=DetailViewCommand.class, value="cmd.detail=true;"),
-		result={
-			@Result(status=Constants.CMD_EXEC_SUCCESS, type=Type.TEMPLATE, value=Constants.TEMPLATE_EDIT),
-			@Result(status=Constants.CMD_EXEC_ERROR_LOCK, type=Type.TEMPLATE, value=Constants.TEMPLATE_VIEW),
-			@Result(status=Constants.CMD_EXEC_ERROR_VALIDATE, type=Type.TEMPLATE, value=Constants.TEMPLATE_VIEW),
-			@Result(status=Constants.CMD_EXEC_ERROR_VIEW, type=Type.TEMPLATE, value=Constants.TEMPLATE_COMMON_ERROR,
-					layoutActionName=Constants.LAYOUT_NORMAL_ACTION),
-			@Result(status=Constants.CMD_EXEC_ERROR_NODATA, type=Type.TEMPLATE, value=Constants.TEMPLATE_COMMON_ERROR,
-					layoutActionName=Constants.LAYOUT_NORMAL_ACTION)
-		}
-	),
-	@ActionMapping(name=DetailViewCommand.REF_DETAIL_ACTION_NAME,
-		displayName="参照詳細編集",
-		paramMapping={
-			@ParamMapping(name=Constants.DEF_NAME, mapFrom="${0}", condition="subPath.length==1"),
-			@ParamMapping(name=Constants.VIEW_NAME, mapFrom="${0}", condition="subPath.length==2"),
-			@ParamMapping(name=Constants.DEF_NAME, mapFrom="${1}", condition="subPath.length==2")
-		},
-		command=@CommandConfig(commandClass=DetailViewCommand.class, value="cmd.detail=true;"),
-		result={
-			@Result(status=Constants.CMD_EXEC_SUCCESS, type=Type.TEMPLATE, value=Constants.TEMPLATE_REF_EDIT),
-			@Result(status=Constants.CMD_EXEC_ERROR_LOCK, type=Type.TEMPLATE, value=Constants.TEMPLATE_REF_VIEW),
-			@Result(status=Constants.CMD_EXEC_ERROR_VIEW, type=Type.TEMPLATE,
-					value=Constants.TEMPLATE_COMMON_ERROR,
-					layoutActionName=Constants.LAYOUT_POPOUT_ACTION),
-			@Result(status=Constants.CMD_EXEC_ERROR_NODATA, type=Type.TEMPLATE,
-					value=Constants.TEMPLATE_COMMON_ERROR,
-					layoutActionName=Constants.LAYOUT_POPOUT_ACTION)
-		}
-	)
+		@ActionMapping(
+				name = DetailViewCommand.VIEW_ACTION_NAME,
+				displayName = "詳細表示",
+				paramMapping = {
+						@ParamMapping(name = Constants.DEF_NAME, mapFrom = "${0}", condition = "subPath.length==2"),
+						@ParamMapping(name = Constants.OID, mapFrom = "${1}", condition = "subPath.length==2"),
+						@ParamMapping(name = Constants.VIEW_NAME, mapFrom = "${0}", condition = "subPath.length==3"),
+						@ParamMapping(name = Constants.DEF_NAME, mapFrom = "${1}", condition = "subPath.length==3"),
+						@ParamMapping(name = Constants.OID, mapFrom = "${2}", condition = "subPath.length==3")
+				},
+				command = @CommandConfig(commandClass = DetailViewCommand.class, value = "cmd.detail=false;"),
+				result = {
+						@Result(status = Constants.CMD_EXEC_SUCCESS, type = Type.TEMPLATE, value = Constants.TEMPLATE_VIEW),
+						@Result(status = Constants.CMD_EXEC_ERROR_LOCK, type = Type.TEMPLATE, value = Constants.TEMPLATE_VIEW),
+						@Result(
+								status = Constants.CMD_EXEC_ERROR_VIEW,
+								type = Type.TEMPLATE,
+								value = Constants.TEMPLATE_COMMON_ERROR,
+								layoutActionName = Constants.LAYOUT_NORMAL_ACTION),
+						@Result(
+								status = Constants.CMD_EXEC_ERROR_NODATA,
+								type = Type.TEMPLATE,
+								value = Constants.TEMPLATE_COMMON_ERROR,
+								layoutActionName = Constants.LAYOUT_NORMAL_ACTION)
+				}
+		),
+		@ActionMapping(
+				name = DetailViewCommand.REF_VIEW_ACTION_NAME,
+				displayName = "参照詳細表示",
+				paramMapping = {
+						@ParamMapping(name = Constants.DEF_NAME, mapFrom = "${0}", condition = "subPath.length==2"),
+						@ParamMapping(name = Constants.OID, mapFrom = "${1}", condition = "subPath.length==2"),
+						@ParamMapping(name = Constants.VIEW_NAME, mapFrom = "${0}", condition = "subPath.length==3"),
+						@ParamMapping(name = Constants.DEF_NAME, mapFrom = "${1}", condition = "subPath.length==3"),
+						@ParamMapping(name = Constants.OID, mapFrom = "${2}", condition = "subPath.length==3")
+				},
+				command = @CommandConfig(commandClass = DetailViewCommand.class, value = "cmd.detail=false;"),
+				result = {
+						@Result(status = Constants.CMD_EXEC_SUCCESS, type = Type.TEMPLATE, value = Constants.TEMPLATE_REF_VIEW),
+						@Result(status = Constants.CMD_EXEC_ERROR_LOCK, type = Type.TEMPLATE, value = Constants.TEMPLATE_REF_VIEW),
+						@Result(
+								status = Constants.CMD_EXEC_ERROR_VIEW,
+								type = Type.TEMPLATE,
+								value = Constants.TEMPLATE_COMMON_ERROR,
+								layoutActionName = Constants.LAYOUT_POPOUT_ACTION),
+						@Result(
+								status = Constants.CMD_EXEC_ERROR_NODATA,
+								type = Type.TEMPLATE,
+								value = Constants.TEMPLATE_COMMON_ERROR,
+								layoutActionName = Constants.LAYOUT_POPOUT_ACTION)
+				}
+		),
+		@ActionMapping(
+				name = DetailViewCommand.DETAIL_ACTION_NAME,
+				displayName = "詳細編集",
+				paramMapping = {
+						@ParamMapping(name = Constants.DEF_NAME, mapFrom = "${0}", condition = "subPath.length==1"),
+						@ParamMapping(name = Constants.VIEW_NAME, mapFrom = "${0}", condition = "subPath.length==2"),
+						@ParamMapping(name = Constants.DEF_NAME, mapFrom = "${1}", condition = "subPath.length==2")
+				},
+				command = @CommandConfig(commandClass = DetailViewCommand.class, value = "cmd.detail=true;"),
+				result = {
+						@Result(status = Constants.CMD_EXEC_SUCCESS, type = Type.TEMPLATE, value = Constants.TEMPLATE_EDIT),
+						@Result(status = Constants.CMD_EXEC_ERROR_LOCK, type = Type.TEMPLATE, value = Constants.TEMPLATE_VIEW),
+						@Result(status = Constants.CMD_EXEC_ERROR_VALIDATE, type = Type.TEMPLATE, value = Constants.TEMPLATE_VIEW),
+						@Result(
+								status = Constants.CMD_EXEC_ERROR_VIEW,
+								type = Type.TEMPLATE,
+								value = Constants.TEMPLATE_COMMON_ERROR,
+								layoutActionName = Constants.LAYOUT_NORMAL_ACTION),
+						@Result(
+								status = Constants.CMD_EXEC_ERROR_NODATA,
+								type = Type.TEMPLATE,
+								value = Constants.TEMPLATE_COMMON_ERROR,
+								layoutActionName = Constants.LAYOUT_NORMAL_ACTION)
+				}
+		),
+		@ActionMapping(
+				name = DetailViewCommand.REF_DETAIL_ACTION_NAME,
+				displayName = "参照詳細編集",
+				paramMapping = {
+						@ParamMapping(name = Constants.DEF_NAME, mapFrom = "${0}", condition = "subPath.length==1"),
+						@ParamMapping(name = Constants.VIEW_NAME, mapFrom = "${0}", condition = "subPath.length==2"),
+						@ParamMapping(name = Constants.DEF_NAME, mapFrom = "${1}", condition = "subPath.length==2")
+				},
+				command = @CommandConfig(commandClass = DetailViewCommand.class, value = "cmd.detail=true;"),
+				result = {
+						@Result(status = Constants.CMD_EXEC_SUCCESS, type = Type.TEMPLATE, value = Constants.TEMPLATE_REF_EDIT),
+						@Result(status = Constants.CMD_EXEC_ERROR_LOCK, type = Type.TEMPLATE, value = Constants.TEMPLATE_REF_VIEW),
+						@Result(
+								status = Constants.CMD_EXEC_ERROR_VIEW,
+								type = Type.TEMPLATE,
+								value = Constants.TEMPLATE_COMMON_ERROR,
+								layoutActionName = Constants.LAYOUT_POPOUT_ACTION),
+						@Result(
+								status = Constants.CMD_EXEC_ERROR_NODATA,
+								type = Type.TEMPLATE,
+								value = Constants.TEMPLATE_COMMON_ERROR,
+								layoutActionName = Constants.LAYOUT_POPOUT_ACTION)
+				}
+		)
 })
-@CommandClass(name="gem/generic/detail/DetailViewCommand", displayName="詳細表示")
+@CommandClass(name = "gem/generic/detail/DetailViewCommand", displayName = "詳細表示")
 @Templates({
-	@Template(
-			name=Constants.TEMPLATE_VIEW,
-			path=Constants.CMD_RSLT_JSP_VIEW,
-			layoutActionName=Constants.LAYOUT_NORMAL_ACTION
-	),
-	@Template(
-			name=Constants.TEMPLATE_REF_VIEW,
-			path=Constants.CMD_RSLT_JSP_REF_VIEW,
-			layoutActionName=Constants.LAYOUT_POPOUT_ACTION
-	),
-	@Template(
-			name=Constants.TEMPLATE_EDIT,
-			path=Constants.CMD_RSLT_JSP_EDIT,
-			layoutActionName=Constants.LAYOUT_NORMAL_ACTION
-	),
-	@Template(
-			name=Constants.TEMPLATE_REF_EDIT,
-			path=Constants.CMD_RSLT_JSP_REF_EDIT,
-			layoutActionName=Constants.LAYOUT_POPOUT_ACTION
-	),
-	@Template(
-			name=Constants.TEMPLATE_COMPLETED,
-			path=Constants.CMD_RSLT_JSP_COMPLETED,
-			contentType="text/html; charset=utf-8"
-	)
+		@Template(
+				name = Constants.TEMPLATE_VIEW,
+				path = Constants.CMD_RSLT_JSP_VIEW,
+				layoutActionName = Constants.LAYOUT_NORMAL_ACTION
+		),
+		@Template(
+				name = Constants.TEMPLATE_REF_VIEW,
+				path = Constants.CMD_RSLT_JSP_REF_VIEW,
+				layoutActionName = Constants.LAYOUT_POPOUT_ACTION
+		),
+		@Template(
+				name = Constants.TEMPLATE_EDIT,
+				path = Constants.CMD_RSLT_JSP_EDIT,
+				layoutActionName = Constants.LAYOUT_NORMAL_ACTION
+		),
+		@Template(
+				name = Constants.TEMPLATE_REF_EDIT,
+				path = Constants.CMD_RSLT_JSP_REF_EDIT,
+				layoutActionName = Constants.LAYOUT_POPOUT_ACTION
+		),
+		@Template(
+				name = Constants.TEMPLATE_COMPLETED,
+				path = Constants.CMD_RSLT_JSP_COMPLETED,
+				contentType = "text/html; charset=utf-8"
+		)
 })
 public final class DetailViewCommand extends DetailCommandBase {
 
@@ -190,8 +214,7 @@ public final class DetailViewCommand extends DetailCommandBase {
 				Entity.OID, Entity.VERSION,
 				Entity.CREATE_BY, Entity.CREATE_DATE,
 				Entity.UPDATE_BY, Entity.UPDATE_DATE,
-				Entity.LOCKED_BY
-				));
+				Entity.LOCKED_BY));
 	}
 
 	/** ActionMappingDefinitionManager */
@@ -227,7 +250,7 @@ public final class DetailViewCommand extends DetailCommandBase {
 		String oid = context.getOid();
 		Long version = context.getVersion();
 		String searchCond = context.getSearchCond();
-		if(oid == null || oid.length() == 0) {
+		if (oid == null || oid.length() == 0) {
 			// SearchCommandからのChainの可能性があるので、Attributeから取得する
 			oid = (String) request.getAttribute(Constants.OID);
 		}
@@ -368,16 +391,17 @@ public final class DetailViewCommand extends DetailCommandBase {
 
 		if (isDetail()) {
 			if (context instanceof ShowEditViewEventHandler) {
-				((ShowEditViewEventHandler)context).fireShowEditViewEvent(data);
+				((ShowEditViewEventHandler) context).fireShowEditViewEvent(data);
 			}
 		} else {
 			if (context instanceof ShowDetailViewEventHandler) {
-				((ShowDetailViewEventHandler)context).fireShowDetailViewEvent(data);
+				((ShowDetailViewEventHandler) context).fireShowDetailViewEvent(data);
 			}
 		}
 
 		request.setAttribute(Constants.DATA, data);
 		request.setAttribute(Constants.SEARCH_COND, searchCond);
+		request.setAttribute(Constants.VERSION_SPECIFIED, context.isVersionSpecified());
 		return ret;
 	}
 
@@ -387,7 +411,8 @@ public final class DetailViewCommand extends DetailCommandBase {
 	 * @param entity Entity
 	 */
 	protected void initCopyProperty(DetailCommandContext context, Entity entity) {
-		if (entity == null) return;
+		if (entity == null)
+			return;
 
 		for (PropertyDefinition pd : context.getPropertyList()) {
 			if (EXCLUDED_COPY_PROPERTIES.contains(pd.getName())) {
@@ -408,7 +433,8 @@ public final class DetailViewCommand extends DetailCommandBase {
 				if (pd.getMultiplicity() == 1) {
 					BinaryReference br = entity.getValue(pd.getName());
 					// データをSHALLOWコピーするか判断
-					if (br != null) value = context.isShallowCopyLobData() ? shallowCopyBinary(br) : copyBinary(br);
+					if (br != null)
+						value = context.isShallowCopyLobData() ? shallowCopyBinary(br) : copyBinary(br);
 				} else {
 					BinaryReference[] br = entity.getValue(pd.getName());
 					if (br != null && br.length > 0) {
@@ -424,9 +450,11 @@ public final class DetailViewCommand extends DetailCommandBase {
 			}
 		}
 	}
+
 	private BinaryReference copyBinary(BinaryReference br) {
 		return em.createBinaryReference(br.getName(), br.getType(), em.getInputStream(br));
 	}
+
 	private BinaryReference shallowCopyBinary(BinaryReference br) {
 		return br.copy();
 	}

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/UpdateCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/UpdateCommand.java
@@ -53,46 +53,66 @@ import org.iplass.mtp.view.generic.DetailFormView;
  * @author lis3wg
  */
 @ActionMappings({
-	@ActionMapping(name=UpdateCommand.UPDATE_ACTION_NAME,
-		displayName="更新",
-		paramMapping={
-			@ParamMapping(name=Constants.DEF_NAME, mapFrom="${0}", condition="subPath.length==1"),
-			@ParamMapping(name=Constants.VIEW_NAME, mapFrom="${0}", condition="subPath.length==2"),
-			@ParamMapping(name=Constants.DEF_NAME, mapFrom="${1}", condition="subPath.length==2")
-		},
-		result={
-			@Result(status=Constants.CMD_EXEC_SUCCESS, type=Type.TEMPLATE, value=Constants.TEMPLATE_VIEW),
-			@Result(status=Constants.CMD_EXEC_ERROR, type=Type.TEMPLATE, value=Constants.TEMPLATE_EDIT),
-			@Result(status=Constants.CMD_EXEC_ERROR_TOKEN, type=Type.TEMPLATE, value=Constants.TEMPLATE_COMMON_ERROR,
-					layoutActionName=Constants.LAYOUT_NORMAL_ACTION),
-			@Result(status=Constants.CMD_EXEC_ERROR_VIEW, type=Type.TEMPLATE, value=Constants.TEMPLATE_COMMON_ERROR,
-					layoutActionName=Constants.LAYOUT_NORMAL_ACTION),
-			@Result(status=Constants.CMD_EXEC_ERROR_NODATA,type=Type.TEMPLATE, value=Constants.TEMPLATE_COMMON_ERROR,
-					layoutActionName=Constants.LAYOUT_NORMAL_ACTION)
-		},
-		tokenCheck=@TokenCheck
-	),
-	@ActionMapping(name=UpdateCommand.REF_UPDATE_ACTION_NAME,
-		displayName="参照更新",
-		paramMapping={
-			@ParamMapping(name=Constants.DEF_NAME, mapFrom="${0}", condition="subPath.length==1"),
-			@ParamMapping(name=Constants.VIEW_NAME, mapFrom="${0}", condition="subPath.length==2"),
-			@ParamMapping(name=Constants.DEF_NAME, mapFrom="${1}", condition="subPath.length==2")
-		},
-		result={
-			@Result(status=Constants.CMD_EXEC_SUCCESS, type=Type.TEMPLATE, value=Constants.TEMPLATE_COMPLETED),
-			@Result(status=Constants.CMD_EXEC_ERROR, type=Type.TEMPLATE, value=Constants.TEMPLATE_REF_EDIT),
-			@Result(status=Constants.CMD_EXEC_ERROR_TOKEN, type=Type.TEMPLATE, value=Constants.TEMPLATE_COMMON_ERROR,
-					layoutActionName=Constants.LAYOUT_POPOUT_ACTION),
-			@Result(status=Constants.CMD_EXEC_ERROR_VIEW, type=Type.TEMPLATE, value=Constants.TEMPLATE_COMMON_ERROR,
-					layoutActionName=Constants.LAYOUT_POPOUT_ACTION),
-			@Result(status=Constants.CMD_EXEC_ERROR_NODATA, type=Type.TEMPLATE, value=Constants.TEMPLATE_COMMON_ERROR,
-					layoutActionName=Constants.LAYOUT_POPOUT_ACTION)
-		},
-		tokenCheck=@TokenCheck
-	)
+		@ActionMapping(
+				name = UpdateCommand.UPDATE_ACTION_NAME,
+				displayName = "更新",
+				paramMapping = {
+						@ParamMapping(name = Constants.DEF_NAME, mapFrom = "${0}", condition = "subPath.length==1"),
+						@ParamMapping(name = Constants.VIEW_NAME, mapFrom = "${0}", condition = "subPath.length==2"),
+						@ParamMapping(name = Constants.DEF_NAME, mapFrom = "${1}", condition = "subPath.length==2")
+				},
+				result = {
+						@Result(status = Constants.CMD_EXEC_SUCCESS, type = Type.TEMPLATE, value = Constants.TEMPLATE_VIEW),
+						@Result(status = Constants.CMD_EXEC_ERROR, type = Type.TEMPLATE, value = Constants.TEMPLATE_EDIT),
+						@Result(
+								status = Constants.CMD_EXEC_ERROR_TOKEN,
+								type = Type.TEMPLATE,
+								value = Constants.TEMPLATE_COMMON_ERROR,
+								layoutActionName = Constants.LAYOUT_NORMAL_ACTION),
+						@Result(
+								status = Constants.CMD_EXEC_ERROR_VIEW,
+								type = Type.TEMPLATE,
+								value = Constants.TEMPLATE_COMMON_ERROR,
+								layoutActionName = Constants.LAYOUT_NORMAL_ACTION),
+						@Result(
+								status = Constants.CMD_EXEC_ERROR_NODATA,
+								type = Type.TEMPLATE,
+								value = Constants.TEMPLATE_COMMON_ERROR,
+								layoutActionName = Constants.LAYOUT_NORMAL_ACTION)
+				},
+				tokenCheck = @TokenCheck
+		),
+		@ActionMapping(
+				name = UpdateCommand.REF_UPDATE_ACTION_NAME,
+				displayName = "参照更新",
+				paramMapping = {
+						@ParamMapping(name = Constants.DEF_NAME, mapFrom = "${0}", condition = "subPath.length==1"),
+						@ParamMapping(name = Constants.VIEW_NAME, mapFrom = "${0}", condition = "subPath.length==2"),
+						@ParamMapping(name = Constants.DEF_NAME, mapFrom = "${1}", condition = "subPath.length==2")
+				},
+				result = {
+						@Result(status = Constants.CMD_EXEC_SUCCESS, type = Type.TEMPLATE, value = Constants.TEMPLATE_COMPLETED),
+						@Result(status = Constants.CMD_EXEC_ERROR, type = Type.TEMPLATE, value = Constants.TEMPLATE_REF_EDIT),
+						@Result(
+								status = Constants.CMD_EXEC_ERROR_TOKEN,
+								type = Type.TEMPLATE,
+								value = Constants.TEMPLATE_COMMON_ERROR,
+								layoutActionName = Constants.LAYOUT_POPOUT_ACTION),
+						@Result(
+								status = Constants.CMD_EXEC_ERROR_VIEW,
+								type = Type.TEMPLATE,
+								value = Constants.TEMPLATE_COMMON_ERROR,
+								layoutActionName = Constants.LAYOUT_POPOUT_ACTION),
+						@Result(
+								status = Constants.CMD_EXEC_ERROR_NODATA,
+								type = Type.TEMPLATE,
+								value = Constants.TEMPLATE_COMMON_ERROR,
+								layoutActionName = Constants.LAYOUT_POPOUT_ACTION)
+				},
+				tokenCheck = @TokenCheck
+		)
 })
-@CommandClass(name="gem/generic/detail/UpdateCommand", displayName="更新")
+@CommandClass(name = "gem/generic/detail/UpdateCommand", displayName = "更新")
 public final class UpdateCommand extends DetailCommandBase {
 
 	public static final String UPDATE_ACTION_NAME = "gem/generic/detail/update";
@@ -125,7 +145,8 @@ public final class UpdateCommand extends DetailCommandBase {
 		if (StringUtil.isNotEmpty(oid)) {
 			Entity current = null;
 			if (view.isLoadDefinedReferenceProperty()) {
-				current = loadBeforeUpdateEntity(context, oid, version, context.getDefinitionName(), context.getReferencePropertyName(), context.isLoadVersioned());
+				current = loadBeforeUpdateEntity(context, oid, version, context.getDefinitionName(), context.getReferencePropertyName(),
+						context.isLoadVersioned());
 			} else {
 				current = loadBeforeUpdateEntity(context, oid, version, context.getDefinitionName(), (List<String>) null, context.isLoadVersioned());
 			}
@@ -162,14 +183,17 @@ public final class UpdateCommand extends DetailCommandBase {
 						if (context.isVersioned()) {
 							if (context.isNewVersion()) {
 								//新しいバージョンで登録時はそのデータを表示
-								data.setEntity(loadViewEntity(context, oid, updatedVersion, context.getDefinitionName(), context.getReferencePropertyName(), context.isLoadVersioned()));
+								data.setEntity(loadViewEntity(context, oid, updatedVersion, context.getDefinitionName(), context.getReferencePropertyName(),
+										context.isLoadVersioned()));
 							} else {
 								//特定バージョンの場合だけバージョン指定でロード
 								Long version = context.getVersion();
-								data.setEntity(loadViewEntity(context, oid, version, context.getDefinitionName(), context.getReferencePropertyName(), context.isLoadVersioned()));
+								data.setEntity(
+										loadViewEntity(context, oid, version, context.getDefinitionName(), context.getReferencePropertyName(), context.isLoadVersioned()));
 							}
 						} else {
-							data.setEntity(loadViewEntity(context, oid, null, context.getDefinitionName(), context.getReferencePropertyName(), context.isLoadVersioned()));
+							data.setEntity(
+									loadViewEntity(context, oid, null, context.getDefinitionName(), context.getReferencePropertyName(), context.isLoadVersioned()));
 						}
 
 						//更新成功時
@@ -180,7 +204,7 @@ public final class UpdateCommand extends DetailCommandBase {
 							//Handler実行
 							if (data.getEntity().getOid() != null) {
 								if (context instanceof ShowDetailViewEventHandler) {
-									((ShowDetailViewEventHandler)context).fireShowDetailViewEvent(data);
+									((ShowDetailViewEventHandler) context).fireShowDetailViewEvent(data);
 								}
 							}
 						}
@@ -220,17 +244,18 @@ public final class UpdateCommand extends DetailCommandBase {
 			//Handler実行
 			if (retKey == Constants.CMD_EXEC_SUCCESS) {
 				if (context instanceof ShowDetailViewEventHandler) {
-					((ShowDetailViewEventHandler)context).fireShowDetailViewEvent(data);
+					((ShowDetailViewEventHandler) context).fireShowDetailViewEvent(data);
 				}
-			} else if (retKey == Constants.CMD_EXEC_ERROR){
+			} else if (retKey == Constants.CMD_EXEC_ERROR) {
 				if (context instanceof ShowEditViewEventHandler) {
-					((ShowEditViewEventHandler)context).fireShowEditViewEvent(data);
+					((ShowEditViewEventHandler) context).fireShowEditViewEvent(data);
 				}
 			}
 		}
 
 		request.setAttribute(Constants.DATA, data);
 		request.setAttribute(Constants.SEARCH_COND, context.getSearchCond());
+		request.setAttribute(Constants.VERSION_SPECIFIED, context.isVersionSpecified());
 
 		return retKey;
 	}

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/detail/edit.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/detail/edit.jsp
@@ -48,7 +48,7 @@
 	DetailFormViewData data = (DetailFormViewData) request.getAttribute(Constants.DATA);
 	String searchCond = (String) request.getAttribute(Constants.SEARCH_COND);
 	String message = (String) request.getAttribute(Constants.MESSAGE);
-	boolean isVersionSpecified = (request.getAttribute(Constants.VERSION_SPECIFIED)) == Boolean.TRUE;
+	boolean isVersionSpecified = Boolean.TRUE.equals(request.getAttribute(Constants.VERSION_SPECIFIED));
 
 	OutputType type = OutputType.EDIT;
 	String contextPath = TemplateUtil.getTenantContextPath();

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/detail/edit.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/detail/edit.jsp
@@ -48,6 +48,7 @@
 	DetailFormViewData data = (DetailFormViewData) request.getAttribute(Constants.DATA);
 	String searchCond = (String) request.getAttribute(Constants.SEARCH_COND);
 	String message = (String) request.getAttribute(Constants.MESSAGE);
+	boolean isVersionSpecified = (request.getAttribute(Constants.VERSION_SPECIFIED)) == Boolean.TRUE;
 
 	OutputType type = OutputType.EDIT;
 	String contextPath = TemplateUtil.getTenantContextPath();
@@ -232,6 +233,9 @@ function cancel() {
 <%	if (!moveToSearchList) {
 		//一覧に戻らない場合
 %>
+		<% if (moveToView && isVersionSpecified) { %>
+		<%=Constants.VERSION_SPECIFIED%>:$(":hidden[name='versionSpecified']").val(),
+		<% } %>
 		<%=Constants.VERSION%>:$(":hidden[name='version']").val(),
 		<%=Constants.BACK_PATH%>:$(":hidden[name='backPath']").val(),
 <%	}
@@ -297,6 +301,11 @@ $(function(){
 	if (version != null) {
 %>
 <input type="hidden" name="<%=Constants.VERSION%>" value="<c:out value="<%=version%>"/>" />
+<%
+	}
+	if (isVersionSpecified) {
+%>
+<input type="hidden" name="<%=Constants.VERSION_SPECIFIED%>" value="true" />
 <%
 	}
 %>

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/detail/view.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/detail/view.jsp
@@ -55,7 +55,7 @@
 	DetailFormViewData data = (DetailFormViewData) request.getAttribute(Constants.DATA);
 	String searchCond = (String) request.getAttribute(Constants.SEARCH_COND);
 	String message = (String) request.getAttribute(Constants.MESSAGE);
-	boolean isVersionSpecified = request.getAttribute(Constants.VERSION_SPECIFIED) == Boolean.TRUE;
+	boolean isVersionSpecified = Boolean.TRUE.equals(request.getAttribute(Constants.VERSION_SPECIFIED));
 
 	OutputType type = OutputType.VIEW;
 	String contextPath = TemplateUtil.getTenantContextPath();

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/detail/view.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/detail/view.jsp
@@ -55,6 +55,7 @@
 	DetailFormViewData data = (DetailFormViewData) request.getAttribute(Constants.DATA);
 	String searchCond = (String) request.getAttribute(Constants.SEARCH_COND);
 	String message = (String) request.getAttribute(Constants.MESSAGE);
+	boolean isVersionSpecified = request.getAttribute(Constants.VERSION_SPECIFIED) == Boolean.TRUE;
 
 	OutputType type = OutputType.VIEW;
 	String contextPath = TemplateUtil.getTenantContextPath();
@@ -259,6 +260,11 @@ function dataUnlock() {
 	if (version != null) {
 %>
 <input type="hidden" name="<%=Constants.VERSION%>" value="<c:out value="<%=version%>"/>" />
+<%	
+  }
+	if (isVersionSpecified) {
+%>
+<input type="hidden" name="<%=Constants.VERSION_SPECIFIED%>" value="true" />
 <%
 	}
 %>

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/element/section/VersionSection.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/element/section/VersionSection.jsp
@@ -90,6 +90,8 @@ $(function() {
 							$(":hidden[name='version']").val(version);
 							var urlPath = "<%=StringUtil.escapeJavaScript(urlPath)%>" + "/" + oid;
 							var $form = $("#detailForm");
+							// 特定バージョンの詳細画面であることを示すフラグを設定
+							$form.append("<input type='hidden' name='<%=Constants.VERSION_SPECIFIED%>' value='true' />");
 							$form.attr("action", contextPath + "/<%=DetailViewCommand.VIEW_ACTION_NAME%>" + urlPath);
 							$form.submit();
 						});


### PR DESCRIPTION
<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->

- バージョン指定して詳細画面に遷移する際に、リクエスト情報に `versionSpecified = true` を設定
  - この詳細画面から編集画面に遷移する際も、同様に `versionSpecified = true` を設定

これにより更新時に `RegistrationCommandBase#update()` で `targetVersion` に `TargetVersion.SPECIFIC` が設定され、特定バージョンのデータを更新できるようになる。

fixes #1688 

### その他修正

* Improved code formatting for better readability in `DetailViewCommand.java` and `UpdateCommand.java`. [[1]](diffhunk://#diff-7df0302a506a72f728a16b6a445d88416883606f00b351856370d226b540a681L67-R68) [[2]](diffhunk://#diff-29b77823b7d58d4aaff8609fd7b33fb3cf2c53d707d30574481d2b48ab50822bL56-R57)

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->

任意のバージョン管理されたEntityについて、複数バージョンのデータを作成する。
その後、EntityViewの検索画面でEntityデータを検索し、上記データの詳細画面を開く。
以下、この詳細画面を `状態A` とする。

1. 状態Aの「別バージョンを参照」から特定バージョンの詳細画面 → 編集画面へと遷移し、データを更新できること
2. 状態Aから現バージョンの編集画面を開き、キャンセルボタンを押して詳細画面に戻る。その後「1」を実施し、データを更新できること
3. 「1」の編集画面でキャンセルボタンを押し、特定バージョンの詳細画面に戻る。その後再度編集画面を開き、データを更新できること
4. 「1」でのデータ更新後、再度「1」を実施しデータを更新できること
