### PR TITLE
GEM: テキストエリアを画面幅以上に拡大できてしまう（3.2）

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/string/StringPropertyEditor_Edit.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/string/StringPropertyEditor_Edit.jsp
@@ -301,7 +301,7 @@ $(function() {
 					//テキストエリア
 					selector = "textarea";
 %>
-<textarea class="form-size-05 inpbr" style="<c:out value="<%=customStyle%>"/>" rows="5" cols="30"></textarea>
+<textarea class="form-size-05 inpbr width-constraint" style="<c:out value="<%=customStyle%>"/>" rows="5" cols="30"></textarea>
 <%
 				} else if (editor.getDisplayType() == StringDisplayType.RICHTEXT) {
 					//リッチテキスト
@@ -340,7 +340,7 @@ $(function() {
 						} else if (editor.getDisplayType() == StringDisplayType.TEXTAREA) {
 							//テキストエリア
 %>
-<textarea name="<c:out value="<%=propName %>"/>" class="form-size-05 inpbr" style="<c:out value="<%=customStyle%>"/>" rows="5" cols="30"><c:out value="<%=str %>"/></textarea>
+<textarea name="<c:out value="<%=propName %>"/>" class="form-size-05 inpbr width-constraint" style="<c:out value="<%=customStyle%>"/>" rows="5" cols="30"><c:out value="<%=str %>"/></textarea>
 <%
 						} else if (editor.getDisplayType() == StringDisplayType.RICHTEXT) {
 							//リッチテキスト
@@ -457,7 +457,7 @@ function <%=toggleAddBtnFunc%>(){
 				} else if (editor.getDisplayType() == StringDisplayType.TEXTAREA) {
 					//テキストエリア
 %>
-<textarea name="<c:out value="<%=propName%>"/>" rows="5" cols="30" class="form-size-05 inpbr" style="<c:out value="<%=customStyle%>"/>"><c:out value="<%=str %>"/></textarea>
+<textarea name="<c:out value="<%=propName%>"/>" rows="5" cols="30" class="form-size-05 inpbr width-constraint" style="<c:out value="<%=customStyle%>"/>"><c:out value="<%=str %>"/></textarea>
 <%
 				} else if (editor.getDisplayType() == StringDisplayType.RICHTEXT) {
 					//リッチテキスト

--- a/iplass-gem/src/main/resources/META-INF/resources/styles/gem/skin/flat/module.css
+++ b/iplass-gem/src/main/resources/META-INF/resources/styles/gem/skin/flat/module.css
@@ -245,6 +245,9 @@ input.timepicker {
 .timeselect-field select {
   width: auto !important; }
 
+textarea.width-constraint {
+  max-width: 100%; }
+
 .tp {
   vertical-align: middle;
   position: relative;

--- a/iplass-gem/src/main/resources/META-INF/resources/styles/gem/skin/horizontal/module.css
+++ b/iplass-gem/src/main/resources/META-INF/resources/styles/gem/skin/horizontal/module.css
@@ -377,6 +377,9 @@ ul.list-check-01 li {
   ul.list-check-01 li label {
     display: inline-block; }
 
+textarea.width-constraint {
+  max-width: calc(100% - 8px); }
+
 .modal-overlay {
   position: absolute;
   left: 0;

--- a/iplass-gem/src/main/resources/META-INF/resources/styles/gem/skin/vertical/module.css
+++ b/iplass-gem/src/main/resources/META-INF/resources/styles/gem/skin/vertical/module.css
@@ -377,6 +377,9 @@ ul.list-check-01 li {
   ul.list-check-01 li label {
     display: inline-block; }
 
+textarea.width-constraint {
+  max-width: calc(100% - 8px); }
+
 .modal-overlay {
   position: absolute;
   left: 0;

--- a/iplass-gem/src/main/sass/basedesign/module/common/_input.scss
+++ b/iplass-gem/src/main/sass/basedesign/module/common/_input.scss
@@ -255,3 +255,7 @@ ul {
 		}
 	}
 }
+
+textarea.width-constraint {
+	max-width: calc(100% - 8px);
+}

--- a/iplass-gem/src/main/sass/flat/module/common/_input.scss
+++ b/iplass-gem/src/main/sass/flat/module/common/_input.scss
@@ -225,3 +225,6 @@ input {
 .timeselect-field select {
 	width: auto !important;
 }
+textarea.width-constraint {
+	max-width: 100%;
+}


### PR DESCRIPTION

## 対応内容
backport of #1679 
closes #1736 

## 動作確認・スクリーンショット（任意）
Entityの新規作成画面と編集画面に、テキストエリアコンポーネントの右下をドラッグし、幅が親コンポーネントの範囲を超えません
※単件と複数件、両方も確認した
※全スキンで動作確認追加、問題なし
