### PR TITLE
GEM: EntityViewのView名に予約文字が含まれないようにする

### DIFF
--- a/iplass-core/src/main/java/org/iplass/mtp/impl/definition/DefinitionMetaDataTypeMap.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/definition/DefinitionMetaDataTypeMap.java
@@ -19,21 +19,30 @@
  */
 package org.iplass.mtp.impl.definition;
 
+import java.util.Objects;
+import java.util.Optional;
+
 import org.iplass.mtp.definition.Definition;
 import org.iplass.mtp.definition.TypedDefinitionManager;
+import org.iplass.mtp.impl.definition.validation.DefaultDefinitionNameCheckValidator;
+import org.iplass.mtp.impl.definition.validation.DefinitionNameCheckValidator;
 import org.iplass.mtp.impl.metadata.RootMetaData;
+import org.iplass.mtp.impl.util.CoreResourceBundleUtil;
+import org.iplass.mtp.util.StringUtil;
 
 public abstract class DefinitionMetaDataTypeMap<D extends Definition, M extends RootMetaData> {
 	protected String pathPrefix;
 	protected Class<M> metaType;
 	protected Class<D> defType;
-//	boolean replaceDot;
+	private DefinitionNameCheckValidator definitionNameCheckValidator;
+	//	boolean replaceDot;
 
 	protected DefinitionMetaDataTypeMap(String pathPrefix, Class<M> metaType, Class<D> defType) {
 		this.pathPrefix = pathPrefix;
 		this.metaType = metaType;
 		this.defType = defType;
-//		this.replaceDot = replaceDot;
+		this.definitionNameCheckValidator = this.createDefinitionNameCheckValidator();
+		//		this.replaceDot = replaceDot;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -43,15 +52,56 @@ public abstract class DefinitionMetaDataTypeMap<D extends Definition, M extends 
 		}
 		return null;
 	};
+
 	public abstract TypedDefinitionManager<D> typedDefinitionManager();
 
 	public String toPath(String defName) {
 		return pathPrefix + defName;
 	}
+
 	public String toDefName(String path) {
 		return path.substring(pathPrefix.length());
 	}
+
 	public String typeName() {
 		return defType.getSimpleName();
+	}
+
+	/**
+	 * メタデータ定義名チェックValidator生成
+	 * TODO コンパイルエラー回避のため一旦abstractメソッドにしない
+	 * 
+	 * @return メタデータ定義名チェックValidator
+	 */
+	protected DefinitionNameCheckValidator createDefinitionNameCheckValidator() {
+		return new DefaultDefinitionNameCheckValidator();
+	}
+
+	/**
+	 * メタデータ定義名のValidationチェック
+	 * 
+	 * <p>
+	 * 以下のチェックをする
+	 * <ul>
+	 * <li>メタデータのパスがメタデータ定義のパスに一致するかどうか</li>
+	 * <li>メタデータ定義名に指定できない文字列が含まれていないかどうか</li>
+	 * </ul>
+	 * </p>
+	 * 
+	 * @param defName メタデータ定義名
+	 * @return エラーメッセージ（チェックエラーの場合）
+	 */
+	public Optional<String> validateDefinitionName(String path, String defName) {
+		// パスチェック
+		if (StringUtil.isNotEmpty(path) && !path.startsWith(this.pathPrefix)) {
+			return Optional.of(CoreResourceBundleUtil.resourceString("impl.definition.DefinitionNameCheckPattern.regExp.invalidPath"));
+		}
+
+		if (Objects.isNull(this.definitionNameCheckValidator) || StringUtil.isEmpty(defName)) {
+			return Optional.empty();
+		}
+
+		// 定義名チェック
+		return this.definitionNameCheckValidator.validate(defName);
 	}
 }

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/definition/DefinitionService.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/definition/DefinitionService.java
@@ -22,6 +22,8 @@ package org.iplass.mtp.impl.definition;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.iplass.mtp.definition.Definition;
 import org.iplass.mtp.definition.TypedDefinitionManager;
@@ -61,7 +63,7 @@ public class DefinitionService implements Service {
 		contextNode = new MetaDataContextNode("root");
 
 		if (config.getNames() != null) {
-			for (String typeMapClass: config.getValues("typeMap")) {
+			for (String typeMapClass : config.getValues("typeMap")) {
 				try {
 					DefinitionMetaDataTypeMap typeMap = (DefinitionMetaDataTypeMap) Class.forName(typeMapClass).newInstance();
 					defMap.put(typeMap.defType, typeMap);
@@ -89,7 +91,7 @@ public class DefinitionService implements Service {
 			return null;
 		}
 	}
-	
+
 	/**
 	 * MetaDataのパスからDefinitionの型、Definitionのプレフィックスパス以降の相対パスを取得。
 	 * 
@@ -101,10 +103,10 @@ public class DefinitionService implements Service {
 		if (typeMap == null) {
 			return null;
 		}
-		
+
 		return new DefinitionPath(typeMap.defType, path.substring(typeMap.pathPrefix.length()));
 	}
-	
+
 	@SuppressWarnings("rawtypes")
 	private <D extends Definition> DefinitionMetaDataTypeMap getByDef(Class<D> defType) {
 		DefinitionMetaDataTypeMap ret = defMap.get(defType);
@@ -170,7 +172,6 @@ public class DefinitionService implements Service {
 		return td.toPath(defName);
 	}
 
-
 	@SuppressWarnings("unchecked")
 	public <D extends Definition, M extends RootMetaData> Class<D> getDefinitionType(Class<M> metaType) {
 		return (Class<D>) getByMeta(metaType).defType;
@@ -191,6 +192,31 @@ public class DefinitionService implements Service {
 	public String getDefinitionName(String path) {
 		//Definitionクラスが未指定の場合は、Pathの先頭からチェックして返す
 		return contextNode.toName(path);
+	}
+
+	/**
+	 * メタデータ定義名チェック
+	 * 
+	 * @param <M> メタデータの型
+	 * @param metaType メタデータのクラス
+	 * @param path パス
+	 * @param defName 定義名
+	 * @return チェックエラーメッセージ
+	 */
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public <M extends RootMetaData> Optional<String> validateDefinitionName(Class<M> metaType, String path, String defName) {
+		if (Objects.isNull(metaType)) {
+			return Optional.empty();
+		}
+
+		// メタデータ定義Map取得
+		DefinitionMetaDataTypeMap typeMap = getByMeta(metaType);
+		if (Objects.isNull(typeMap)) {
+			return Optional.empty();
+
+		}
+
+		return typeMap.validateDefinitionName(path, defName);
 	}
 
 	private static class MetaDataContextNode<D extends Definition> {

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/definition/validation/BaseDefinitionNameCheckValidator.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/definition/validation/BaseDefinitionNameCheckValidator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.definition.validation;
+
+/**
+ * メタデータ定義名チェックValidatorクラス
+ * 
+ * <p>
+ * {@link DefinitionNameCheckPattern}で定義されてる定義名Patternから生成
+ * </p>
+ */
+public class BaseDefinitionNameCheckValidator extends DefinitionNameCheckValidator {
+
+	private String errorMessage;
+
+	public BaseDefinitionNameCheckValidator(DefinitionNameCheckPattern checkPattern) {
+		super(checkPattern.getDefinitionNamePattern());
+		this.errorMessage = this.getMessage(checkPattern.getMessageKey());
+	}
+
+	@Override
+	protected String getErrorMessage(String definitionName) {
+		return this.errorMessage;
+	}
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/definition/validation/DefaultDefinitionNameCheckValidator.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/definition/validation/DefaultDefinitionNameCheckValidator.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.definition.validation;
+
+/**
+ * デフォルトメタデータ定義名チェックValidator
+ * 
+ * <p>
+ * メタデータ定義名の制限で一番ゆるいメタデータチェック用
+ * </p>
+ */
+public class DefaultDefinitionNameCheckValidator extends BaseDefinitionNameCheckValidator {
+
+	public DefaultDefinitionNameCheckValidator() {
+		// TODO 暫定
+		super(DefinitionNameCheckPattern.PATH_SLASH_NAME_PERIOD);
+	}
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/definition/validation/DefinitionNameCheckPattern.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/definition/validation/DefinitionNameCheckPattern.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015 DENTSU SOKEN INC. All Rights Reserved.
+ */
+package org.iplass.mtp.impl.definition.validation;
+
+import java.util.regex.Pattern;
+
+/**
+ * メタデータ定義名チェックパターンEnum
+ */
+public enum DefinitionNameCheckPattern {
+
+	/** 名前の正規表現(パスにピリオドを利用) */
+	PATH_PERIOD("^[0-9a-zA-Z_][0-9a-zA-Z_-]*(\\.[0-9a-zA-Z_-]+)*$", "impl.definition.DefinitionNameCheckPattern.regExp.invalidPathPeriod"),
+	/** 名前の正規表現(パスにスラッシュを利用) */
+	PATH_SLASH("^[0-9a-zA-Z_][0-9a-zA-Z_-]*(/[0-9a-zA-Z_-]+)*$", "impl.definition.DefinitionNameCheckPattern.regExp.invalidPathSlash"),
+	/** 名前の正規表現(パスにスラッシュを利用、名前にピリオド含む) */
+	PATH_SLASH_NAME_PERIOD("^[0-9a-zA-Z_][0-9a-zA-Z_-]*(/[0-9a-zA-Z_-]+)*(\\.[0-9a-zA-Z_-]+)*$",
+			"impl.definition.DefinitionNameCheckPattern.regExp.invalidPathSlashNamePeriod"),
+	/** Entity名の正規表現(英数、アンダスコア、パスにピリオド、先頭の数字不可、マイナス不可) */
+	ENTITY_NAME("^[a-zA-Z_][0-9a-zA-Z_]*(\\.[a-zA-Z_][0-9a-zA-Z_]*)*$", "impl.definition.DefinitionNameCheckPattern.regExp.invalidPathPeriod");
+
+	private String messageKey;
+	private Pattern definitionNamePattern;
+
+	private DefinitionNameCheckPattern(String regularExpression, String messageKey) {
+		this.messageKey = messageKey;
+		this.definitionNamePattern = Pattern.compile(regularExpression);
+	}
+
+	/**
+	 * 定義名の正規表現パターンを返却
+	 * 
+	 * @return 定義名の正規表現パターン
+	 */
+	public Pattern getDefinitionNamePattern() {
+		return this.definitionNamePattern;
+	}
+
+	/**
+	 * メッセージキーを返却
+	 * 
+	 * @return メッセージキー
+	 */
+	public String getMessageKey() {
+		return this.messageKey;
+	}
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/definition/validation/DefinitionNameCheckValidator.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/definition/validation/DefinitionNameCheckValidator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.definition.validation;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import org.iplass.mtp.impl.util.CoreResourceBundleUtil;
+import org.iplass.mtp.util.StringUtil;
+
+/**
+ * メタデータ定義名チェックValidatorクラス
+ */
+public abstract class DefinitionNameCheckValidator {
+
+	private Pattern definitionNamePattern;
+
+	public DefinitionNameCheckValidator(Pattern definitionNamePattern) {
+		this.definitionNamePattern = definitionNamePattern;
+	}
+
+	/**
+	 * エラーメッセージを返却
+	 * 
+	 * @param definitionName メタデータ定義名
+	 * @return エラーメッセージ
+	 */
+	protected abstract String getErrorMessage(String definitionName);
+
+	/**
+	 * メタデータ定義名チェック
+	 * 
+	 * @param definitionName メタデータ定義名
+	 * @return チェックOKの場合は空、チェックNGの場合はチェックエラーメッセージ
+	 */
+	public Optional<String> validate(String definitionName) {
+		// 必要な情報がなかったらチェックしない（チェックOKとする）
+		String errorMessage = this.getErrorMessage(definitionName);
+		if (Objects.isNull(this.definitionNamePattern) ||
+				StringUtil.isEmpty(errorMessage) ||
+				StringUtil.isEmpty(definitionName)) {
+			return Optional.empty();
+		}
+
+		return this.definitionNamePattern.matcher(definitionName).matches() ? Optional.empty() : Optional.of(errorMessage);
+	}
+
+	/**
+	 * メッセージ取得
+	 * 
+	 * @param key メッセージキー
+	 * @param args メッセージ引数
+	 * @return メッセージ
+	 */
+	protected String getMessage(String key, Object... args) {
+		return CoreResourceBundleUtil.resourceString(key, args);
+	}
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/definition/validation/EntityDefinitionNameCheckValidator.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/definition/validation/EntityDefinitionNameCheckValidator.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.definition.validation;
+
+/**
+ * Entity定義名（英数、アンダスコア、パスにピリオド、先頭の数字不可、マイナス不可）チェックValidator
+ */
+public class EntityDefinitionNameCheckValidator extends BaseDefinitionNameCheckValidator {
+
+	public EntityDefinitionNameCheckValidator() {
+		super(DefinitionNameCheckPattern.ENTITY_NAME);
+	}
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/definition/validation/PathSlashNamePeriodCheckValidator.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/definition/validation/PathSlashNamePeriodCheckValidator.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.definition.validation;
+
+/**
+ * メタデータ定義名（パスにスラッシュを利用、名前にピリオド含む）チェックValidator
+ */
+public class PathSlashNamePeriodCheckValidator extends BaseDefinitionNameCheckValidator {
+
+	public PathSlashNamePeriodCheckValidator() {
+		super(DefinitionNameCheckPattern.PATH_SLASH_NAME_PERIOD);
+	}
+}

--- a/iplass-core/src/main/resources/mtp-core-messages_ja.properties
+++ b/iplass-core/src/main/resources/mtp-core-messages_ja.properties
@@ -66,6 +66,11 @@ impl.csv.EntityCsvReader.invalidValueType                                       
 impl.csv.EntityCsvReader.mismatchHeadSize                                             = データの項目数がヘッダーの項目数と一致しません。 (ヘッダ＝{0}、データ＝{1})
 impl.csv.EntityCsvReader.rowError                                                     = {0}行目：{1}
 impl.datastore.schemalessrdb.strategy.SLREntityStoreStrategy.alreadyOperated          = 対象のデータは、既に更新されたか削除されました。
+impl.definition.DefinitionNameCheckPattern.regExp.invalidPathPeriod                   = 名前には英数字、ハイフン、アンダースコアのみ利用することができます。パスにはピリオドを利用します。
+impl.definition.DefinitionNameCheckPattern.regExp.invalidPathSlash                    = 名前には英数字、ハイフン、アンダースコア、スラッシュのみ利用することができます。
+impl.definition.DefinitionNameCheckPattern.regExp.invalidPathSlashNamePeriod          = 名前には英数字、ハイフン、アンダースコア、スラッシュ、ピリオドのみ利用することができます。
+impl.definition.DefinitionNameCheckPattern.regExp.invalidEntityName                   = 名前には英数字、アンダースコアのみ利用することができます。先頭は英字のみ利用することができます。パスにはピリオドを利用します。
+impl.definition.DefinitionNameCheckPattern.regExp.invalidPath                         = パスの指定に誤りがあります。
 impl.entity.auth.EntityAuthInterceptor.noDelete                                       = {0}の削除権限がないか、一部のデータ範囲に対する削除権限がありません。
 impl.entity.auth.EntityAuthInterceptor.noDeleteAll                                    = {0}の一部のデータ範囲に対する削除権限がありません。
 impl.entity.auth.EntityAuthInterceptor.noReference                                    = {0}の参照権限がありません。

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/EntityViewService.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/EntityViewService.java
@@ -24,6 +24,8 @@ import org.iplass.mtp.ManagerLocator;
 import org.iplass.mtp.definition.TypedDefinitionManager;
 import org.iplass.mtp.impl.definition.AbstractTypedMetaDataService;
 import org.iplass.mtp.impl.definition.DefinitionMetaDataTypeMap;
+import org.iplass.mtp.impl.definition.validation.DefinitionNameCheckValidator;
+import org.iplass.mtp.impl.definition.validation.EntityDefinitionNameCheckValidator;
 import org.iplass.mtp.spi.Config;
 import org.iplass.mtp.spi.Service;
 import org.iplass.mtp.view.generic.EntityView;
@@ -42,17 +44,25 @@ public class EntityViewService extends AbstractTypedMetaDataService<MetaEntityVi
 		public TypeMap() {
 			super(getFixedPath(), MetaEntityView.class, EntityView.class);
 		}
+
 		@Override
 		public TypedDefinitionManager<EntityView> typedDefinitionManager() {
 			return ManagerLocator.getInstance().getManager(EntityViewManager.class);
 		}
+
 		@Override
 		public String toPath(String defName) {
 			return pathPrefix + defName.replace('.', '/');
 		}
+
 		@Override
 		public String toDefName(String path) {
 			return path.substring(pathPrefix.length()).replace("/", ".");
+		}
+
+		@Override
+		protected DefinitionNameCheckValidator createDefinitionNameCheckValidator() {
+			return new EntityDefinitionNameCheckValidator();
 		}
 	}
 

--- a/iplass-gem/src/main/resources/mtp-gem-messages_ja.properties
+++ b/iplass-gem/src/main/resources/mtp-gem-messages_ja.properties
@@ -504,3 +504,6 @@ layout.preview.updatedPreviewDateMsg = プレビュー日時を変更しまし�
 menu.menu.home   = ホーム
 menu.menu.menu   = メニュー
 menu.menu.widget = ウィジェット
+
+view.generic.EntityViewRuntime.definitionValidationErr = View名【{0}】に指定できない文字が含まれています。View名には英数字、ハイフン、アンダースコア、ピリオドのみ利用することができます。
+view.generic.EntityViewRuntime.settingValidationErr    = Viewの管理：View名【{0}】に指定できない文字が含まれています。View名には英数字、ハイフン、アンダースコア、ピリオドのみ利用することができます。

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/metaport/MetaDataPortingServiceImpl.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/metaport/MetaDataPortingServiceImpl.java
@@ -29,14 +29,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Marshaller;
-import jakarta.xml.bind.Unmarshaller;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.sax.SAXSource;
 
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.iplass.mtp.ManagerLocator;
 import org.iplass.mtp.auth.login.IdPasswordCredential;
 import org.iplass.mtp.impl.auth.AuthContextHolder;
@@ -59,9 +61,9 @@ import org.iplass.mtp.impl.metadata.MetaDataEntry;
 import org.iplass.mtp.impl.metadata.MetaDataEntry.RepositoryType;
 import org.iplass.mtp.impl.metadata.MetaDataEntry.State;
 import org.iplass.mtp.impl.metadata.MetaDataEntryInfo;
+import org.iplass.mtp.impl.metadata.MetaDataIllegalStateException;
 import org.iplass.mtp.impl.metadata.MetaDataJAXBService;
 import org.iplass.mtp.impl.metadata.RootMetaData;
-import org.iplass.mtp.impl.metadata.xmlfile.XmlFileMetaDataStore;
 import org.iplass.mtp.impl.metadata.xmlresource.ContextPath;
 import org.iplass.mtp.impl.metadata.xmlresource.MetaDataEntryList;
 import org.iplass.mtp.impl.metadata.xmlresource.XmlResourceMetaDataEntryThinWrapper;
@@ -110,7 +112,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 		metaTenantService = config.getDependentService(MetaTenantService.class);
 		tContextService = config.getDependentService(TenantContextService.class);
 
-		importHandler = (MetaDataImportHandler)config.getBean("importHandler");
+		importHandler = (MetaDataImportHandler) config.getBean("importHandler");
 	}
 
 	@Override
@@ -136,7 +138,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 			writeHeader(writer);
 
 			String beforeContextPath = "";
-			boolean isWriteContext = false;	//有効なEntityがない場合の時用
+			boolean isWriteContext = false; //有効なEntityがない場合の時用
 			for (String path : paths) {
 				MetaDataEntry entry = MetaDataContext.getContext().getMetaDataEntry(path);
 				if (entry == null) {
@@ -199,7 +201,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 	}
 
 	@Override
-	public void writeHistory(PrintWriter writer, String definitionId, String[] versions){
+	public void writeHistory(PrintWriter writer, String definitionId, String[] versions) {
 		writeHistory(writer, definitionId, versions, new MetaDataWriteLoggingCallback());
 
 	}
@@ -218,7 +220,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 			writeHeader(writer);
 
 			String beforeContextPath = "";
-			boolean isWriteContext = false;	//有効なEntityがない場合の時用
+			boolean isWriteContext = false; //有効なEntityがない場合の時用
 			for (String temp : versions) {
 
 				int version = Integer.parseInt(temp);
@@ -538,8 +540,8 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 		SAXParserFactory f = SAXParserFactory.newInstance();
 		f.setNamespaceAware(true);
 		f.setValidating(false);
-	    f = new SecureSAXParserFactory(f);
-	    try {
+		f = new SecureSAXParserFactory(f);
+		try {
 			return new SAXSource(f.newSAXParser().getXMLReader(), new InputSource(is));
 		} catch (SAXException | ParserConfigurationException e) {
 			throw new JAXBException(e);
@@ -570,7 +572,8 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 		return filterInfo;
 	}
 
-	private MetaDataImportResult doImportMetaData(XMLEntryInfo entryInfo, final List<MetaDataEntry> entryList, final MetaDataImportResult result, final Tenant importTenant) {
+	private MetaDataImportResult doImportMetaData(XMLEntryInfo entryInfo, final List<MetaDataEntry> entryList, final MetaDataImportResult result,
+			final Tenant importTenant) {
 
 		String curPath = null;
 		//対象メタデータのステータスをチェックして、順番を振り分ける
@@ -657,7 +660,6 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 				}
 			}
 
-
 			if (!combiIdList.isEmpty()) {
 				//コンビデータが含まれている場合は、normalList、individualListから抜き出す(先に更新するため)
 				for (String combiId : combiIdList) {
@@ -678,13 +680,18 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 
 		//通常の更新処理
 		if (!result.isError()) {
-			doImportNormalMetaData(removeList, normalCombiList, new ArrayList<>(normalList.values()) ,
+			doImportNormalMetaData(removeList, normalCombiList, new ArrayList<>(normalList.values()),
 					importTenant, needTenantReload, needMetaContextReload, result);
 		}
 
 		//特殊の更新処理
 		if (!result.isError()) {
-			doImportIndividualMetaData(individualCombiList, new ArrayList<>(individualList.values()) ,result);
+			doImportIndividualMetaData(individualCombiList, new ArrayList<>(individualList.values()), result);
+		}
+
+		// 正常終了してる場合は、RuntimeのcheckStatus結果を追加する
+		if (!result.isError()) {
+			this.addCheckStatusResult(result, entryList);
 		}
 
 		return result;
@@ -692,8 +699,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 
 	private void doImportNormalMetaData(final List<ImportMetaDataInfo> removeList,
 			final List<ImportMetaDataInfo> normalCombiList, final List<ImportMetaDataInfo> normalList,
-			final Tenant importTenant
-			, final boolean needTenantReload, final boolean needMetaContextReload, final MetaDataImportResult result) {
+			final Tenant importTenant, final boolean needTenantReload, final boolean needMetaContextReload, final MetaDataImportResult result) {
 
 		if (removeList.isEmpty() && normalList.isEmpty()) {
 			return;
@@ -709,7 +715,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 
 			@Override
 			public void updated(String path, String pathBefore) {
-				logger.debug("metadata context updated. path=" + path +" pathBefore=" + pathBefore);
+				logger.debug("metadata context updated. path=" + path + " pathBefore=" + pathBefore);
 			}
 
 			@Override
@@ -728,65 +734,64 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 			//削除と通常のインポート処理はまとめて１トランザクションで行う
 			Transaction.requiresNew(t -> {
 
-					//個別にリロードするかの判定
-					boolean doAutoReload = (!needTenantReload && !needMetaContextReload);
+				//個別にリロードするかの判定
+				boolean doAutoReload = (!needTenantReload && !needMetaContextReload);
 
-					MetaDataContext.getContext().addMetaDataContextListener(listener);
+				MetaDataContext.getContext().addMetaDataContextListener(listener);
 
-					//削除から開始
-					for (ImportMetaDataInfo info : removeList) {
-						try {
-							importHandler.removeMetaData(info.path, info.metaData, doAutoReload);
+				//削除から開始
+				for (ImportMetaDataInfo info : removeList) {
+					try {
+						importHandler.removeMetaData(info.path, info.metaData, doAutoReload);
 
-							logger.debug("metadata removed. path=" + info.path);
-							result.addMessages(getRS("removeMeta", info.path));
-						} catch (Exception e) {
-							errorForImportMetaDataEntry(info.path, e, result);
-							return null;
-						}
+						logger.debug("metadata removed. path=" + info.path);
+						result.addMessages(getRS("removeMeta", info.path));
+					} catch (Exception e) {
+						errorForImportMetaDataEntry(info.path, e, result);
+						return null;
 					}
+				}
 
-					//登録処理(Combi)
-					for (ImportMetaDataInfo info : normalCombiList) {
-						try {
-							doImportNormalMetaData(info, importTenant, doAutoReload, result);
-						} catch (Exception e) {
-							errorForImportMetaDataEntry(info.path, e, result);
-							return null;
-						}
+				//登録処理(Combi)
+				for (ImportMetaDataInfo info : normalCombiList) {
+					try {
+						doImportNormalMetaData(info, importTenant, doAutoReload, result);
+					} catch (Exception e) {
+						errorForImportMetaDataEntry(info.path, e, result);
+						return null;
 					}
+				}
 
-					//登録処理(通常)
-					for (ImportMetaDataInfo info : normalList) {
-						try {
-							doImportNormalMetaData(info, importTenant, doAutoReload, result);
-						} catch (Exception e) {
-							errorForImportMetaDataEntry(info.path, e, result);
-							return null;
-						}
+				//登録処理(通常)
+				for (ImportMetaDataInfo info : normalList) {
+					try {
+						doImportNormalMetaData(info, importTenant, doAutoReload, result);
+					} catch (Exception e) {
+						errorForImportMetaDataEntry(info.path, e, result);
+						return null;
 					}
+				}
 
-					return null;
+				return null;
 			});
 
 			//リロード処理(別トランザクションで実行)
 			Transaction.requiresNew(t -> {
-					if (needTenantReload) {
-						tContextService.reloadTenantContext(ExecuteContext.getCurrentContext().getTenantContext().getTenantId(), false);
-						logger.debug("reload tenant context. trigger is metadata import.");
-						result.addMessages(getRS("reloadTenantContext"));
-					} else if (needMetaContextReload) {
-						MetaDataContext.getContext().clearAllCache();
-						logger.debug("clear metadata context. trigger is metadata import.");
-						result.addMessages(getRS("clearAllMetaDataContext"));
-					} else {
-						//それ以外の場合は個別に反映される
-						logger.debug("update metadata context only target. trigger is metadata import.");
-						result.addMessages(getRS("updateMetaDataContext"));
-					}
+				if (needTenantReload) {
+					tContextService.reloadTenantContext(ExecuteContext.getCurrentContext().getTenantContext().getTenantId(), false);
+					logger.debug("reload tenant context. trigger is metadata import.");
+					result.addMessages(getRS("reloadTenantContext"));
+				} else if (needMetaContextReload) {
+					MetaDataContext.getContext().clearAllCache();
+					logger.debug("clear metadata context. trigger is metadata import.");
+					result.addMessages(getRS("clearAllMetaDataContext"));
+				} else {
+					//それ以外の場合は個別に反映される
+					logger.debug("update metadata context only target. trigger is metadata import.");
+					result.addMessages(getRS("updateMetaDataContext"));
+				}
 
 			});
-
 
 		} finally {
 			MetaDataContext.getContext().removeMetaDataContextListener(listener);
@@ -846,7 +851,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 		Transaction.requiresNew(t -> {
 			final ExecuteContext current = ExecuteContext.getCurrentContext();
 			TenantContext tenantContext = tContextService.getTenantContext(ExecuteContext.getCurrentContext().getCurrentTenant().getId());
-			ExecuteContext.executeAs(tenantContext, ()->{
+			ExecuteContext.executeAs(tenantContext, () -> {
 				ExecuteContext.getCurrentContext().setLanguage(current.getLanguage());
 
 				//特殊メタデータについては個別にリロードする
@@ -918,6 +923,53 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 		}
 	}
 
+	/**
+	 * 
+	 * <p>
+	 * メタデータ新規作成や定義名変更した場合、別トランザクションで
+	 * {@link org.iplass.mtp.impl.metadata.MetaDataContext#checkState(String) checkState}を実行しないと</br>
+	 * MetaDataRuntimeが見つからないエラーが返ってきてしまって、実際はcheckStatusエラーではないのcheckStatusエラーになってしまう</br>
+	 * なので、新規トランザクションでcheckStatusを実行する
+	 * </p>
+	 * 
+	 * @param result インポート結果
+	 * @param entryList インポートしたメタデータ
+	 */
+	private void addCheckStatusResult(final MetaDataImportResult result, final List<MetaDataEntry> entryList) {
+		if (CollectionUtils.isEmpty(entryList)) {
+			return;
+		}
+
+		List<String> errorPathList = Transaction.requiresNew(t -> {
+			return entryList.stream().filter(entry -> {
+				String path = entry.getPath();
+				if (StringUtil.isEmpty(path)) {
+					return false;
+				}
+
+				try {
+					MetaDataContext.getContext().checkState(entry.getPath());
+					return false;
+				} catch (MetaDataIllegalStateException e) {
+					return true;
+				}
+			}).map(MetaDataEntry::getPath).toList();
+		});
+
+		if (CollectionUtils.isEmpty(errorPathList)) {
+			return;
+		}
+
+		// TODO メッセージにする
+		result.addMessages("-----------------------------------------");
+		result.addMessages("以下インポートしたメタデータに不整合が発生している可能性があります。");
+		result.addMessages("詳しくはStatusCheckで確認してください。");
+
+		errorPathList.forEach(path -> {
+			result.addMessages(String.format("[%1$s]", path));
+		});
+	}
+
 	private void writeHeader(PrintWriter writer) {
 		writer.println("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
 		writer.println("<metaDataList>");
@@ -946,7 +998,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 		if (path.endsWith(checkName)) {
 			contextPath = path.substring(0, path.length() - checkName.length() - 1);
 		} else if (path.endsWith(name)) {
-				contextPath = path.substring(0, path.length() - name.length() - 1);
+			contextPath = path.substring(0, path.length() - name.length() - 1);
 		} else {
 			contextPath = path;
 		}
@@ -960,7 +1012,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 	private XMLEntryInfo parse(MetaDataEntryList metaList) {
 		XMLEntryInfo entryInfo = new XMLEntryInfo();
 		if (metaList.getContextPath() != null) {
-			for (ContextPath context: metaList.getContextPath()) {
+			for (ContextPath context : metaList.getContextPath()) {
 				parseContextPath(entryInfo, context, "", context.getName());
 			}
 		}
@@ -969,13 +1021,13 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 
 	private void parseContextPath(XMLEntryInfo entryInfo, ContextPath context, String prefixPath, String rootPath) {
 		if (context.getContextPath() != null) {
-			for (ContextPath child: context.getContextPath()) {
+			for (ContextPath child : context.getContextPath()) {
 				parseContextPath(entryInfo, child, prefixPath + context.getName() + "/", rootPath);
 			}
 		}
 
 		if (context.getEntry() != null) {
-			for (XmlResourceMetaDataEntryThinWrapper xmlEntry: context.getEntry()) {
+			for (XmlResourceMetaDataEntryThinWrapper xmlEntry : context.getEntry()) {
 
 				if (xmlEntry.getMetaData() == null) {
 					//現在存在しないMetaDataが指定されたなどして、MetaDataが読めていない可能性。
@@ -994,7 +1046,8 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 					path = convertPath(prefixPath + context.getName() + "/" + xmlEntry.getMetaData().getName());
 				}
 
-				MetaDataEntry entry = new MetaDataEntry(path, xmlEntry.getMetaData(), State.VALID, 0, xmlEntry.isOverwritable(), xmlEntry.isSharable(), xmlEntry.isDataSharable(), xmlEntry.isPermissionSharable());
+				MetaDataEntry entry = new MetaDataEntry(path, xmlEntry.getMetaData(), State.VALID, 0, xmlEntry.isOverwritable(), xmlEntry.isSharable(),
+						xmlEntry.isDataSharable(), xmlEntry.isPermissionSharable());
 
 				entryInfo.putPathEntry(path, entry);
 				if (StringUtil.isEmpty(entry.getMetaData().getId())) {
@@ -1015,7 +1068,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 				|| path.startsWith(EntityFilterService.META_PATH)
 				|| path.startsWith(EntityWebApiService.META_PATH)
 				|| path.startsWith(GroovyScriptService.UTILITY_CLASS_META_PATH)) {
-			return path.replace(".","/");
+			return path.replace(".", "/");
 		}
 		return path;
 	}
@@ -1031,8 +1084,8 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 	private class ImportMetaDataInfo {
 		String path;
 		RootMetaData metaData;
-		MetaDataEntry entry;	/* 削除の場合は未設定 */
-		MetaDataImportStatus status;	/* 削除の場合は未設定 */
+		MetaDataEntry entry; /* 削除の場合は未設定 */
+		MetaDataImportStatus status; /* 削除の場合は未設定 */
 
 		public ImportMetaDataInfo(String path, RootMetaData metaData) {
 			this.path = path;
@@ -1064,12 +1117,12 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 
 	@Override
 	public void patchEntityData(final PatchEntityDataParameter param) {
-		ConfigImpl newConfig = new ConfigImpl("forPatchNew", new NameValue[] {new NameValue("filePath", param.getNewMetaDataFilePath())}, null);
+		ConfigImpl newConfig = new ConfigImpl("forPatchNew", new NameValue[] { new NameValue("filePath", param.getNewMetaDataFilePath()) }, null);
 		newConfig.addDependentService(MetaDataJAXBService.class.getName(), jaxbService);
 		XmlResourceMetaDataStore newRepo = new XmlResourceMetaDataStore();
 		newRepo.inited(null, newConfig);
 
-		ConfigImpl oldConfig = new ConfigImpl("forPatchOld", new NameValue[] {new NameValue("filePath", param.getOldMetaDataFilePath())}, null);
+		ConfigImpl oldConfig = new ConfigImpl("forPatchOld", new NameValue[] { new NameValue("filePath", param.getOldMetaDataFilePath()) }, null);
 		oldConfig.addDependentService(MetaDataJAXBService.class.getName(), jaxbService);
 		XmlResourceMetaDataStore oldRepo = new XmlResourceMetaDataStore();
 		oldRepo.inited(null, oldConfig);
@@ -1086,7 +1139,8 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 						StoreService storeService = ServiceRegistry.getRegistry().getService(StoreService.class);
 						DataStore srds = storeService.getDataStore();
 						EntityContext ec = EntityContext.getCurrentContext();
-						srds.getApplyMetaDataStrategy().patchData(newMetaEntity, oldMetaEntity, ec, EntityContext.getCurrentContext().getLocalTenantId());
+						srds.getApplyMetaDataStrategy().patchData(newMetaEntity, oldMetaEntity, ec,
+								EntityContext.getCurrentContext().getLocalTenantId());
 					}
 				});
 			}
@@ -1113,8 +1167,7 @@ public class MetaDataPortingServiceImpl implements MetaDataPortingService {
 	@Override
 	public void patchEntityDataWithUserAuth(final PatchEntityDataParameter param, String userId, String password) {
 		try {
-			authService.login(StringUtil.isNotEmpty(password) ?
-					new IdPasswordCredential(userId, password) : new InternalCredential(userId));
+			authService.login(StringUtil.isNotEmpty(password) ? new IdPasswordCredential(userId, password) : new InternalCredential(userId));
 			authService.doSecuredAction(AuthContextHolder.getAuthContext(), () -> {
 				patchEntityData(param);
 				return null;

--- a/iplass-tools/src/main/resources/mtp-tools-service-config.xml
+++ b/iplass-tools/src/main/resources/mtp-tools-service-config.xml
@@ -48,6 +48,7 @@
 		<depend>org.iplass.mtp.impl.core.TenantContextService</depend>
 		<depend>org.iplass.mtp.impl.entity.EntityService</depend>
 		<depend>org.iplass.mtp.impl.auth.AuthService</depend>
+		<depend>org.iplass.mtp.impl.definition.DefinitionService</depend>
 
 		<property name="importHandler" class="org.iplass.mtp.impl.tools.metaport.MetaDataImportHandlerImpl" />
 	</service>

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/actionmapping/ActionMappingService.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/actionmapping/ActionMappingService.java
@@ -26,6 +26,8 @@ import org.iplass.mtp.ManagerLocator;
 import org.iplass.mtp.definition.TypedDefinitionManager;
 import org.iplass.mtp.impl.definition.AbstractTypedMetaDataService;
 import org.iplass.mtp.impl.definition.DefinitionMetaDataTypeMap;
+import org.iplass.mtp.impl.definition.validation.DefinitionNameCheckValidator;
+import org.iplass.mtp.impl.definition.validation.PathSlashNamePeriodCheckValidator;
 import org.iplass.mtp.impl.metadata.MetaDataContext;
 import org.iplass.mtp.impl.web.actionmapping.MetaActionMapping.ActionMappingRuntime;
 import org.iplass.mtp.spi.Config;
@@ -33,7 +35,6 @@ import org.iplass.mtp.spi.Service;
 import org.iplass.mtp.web.actionmapping.definition.ActionMappingDefinition;
 import org.iplass.mtp.web.actionmapping.definition.ActionMappingDefinitionManager;
 import org.iplass.mtp.web.interceptor.RequestInterceptor;
-
 
 public class ActionMappingService extends AbstractTypedMetaDataService<MetaActionMapping, ActionMappingRuntime> implements Service {
 
@@ -49,9 +50,15 @@ public class ActionMappingService extends AbstractTypedMetaDataService<MetaActio
 		public TypeMap() {
 			super(getFixedPath(), MetaActionMapping.class, ActionMappingDefinition.class);
 		}
+
 		@Override
 		public TypedDefinitionManager<ActionMappingDefinition> typedDefinitionManager() {
 			return ManagerLocator.getInstance().getManager(ActionMappingDefinitionManager.class);
+		}
+
+		@Override
+		protected DefinitionNameCheckValidator createDefinitionNameCheckValidator() {
+			return new PathSlashNamePeriodCheckValidator();
 		}
 	}
 
@@ -81,7 +88,7 @@ public class ActionMappingService extends AbstractTypedMetaDataService<MetaActio
 		if (context.exists(ACTION_MAPPING_META_PATH, name)) {
 			return context.getMetaDataHandler(ActionMappingRuntime.class, ACTION_MAPPING_META_PATH + name);
 		}
-		
+
 		String path = name;
 		int index = -1;
 		while ((index = path.lastIndexOf("/")) >= 0) {
@@ -104,7 +111,7 @@ public class ActionMappingService extends AbstractTypedMetaDataService<MetaActio
 				&& welcomeActionNameList != null
 				&& (name.length() == 0 || name.endsWith("/"))) {
 			MetaDataContext context = MetaDataContext.getContext();
-			for (String wa: welcomeActionNameList) {
+			for (String wa : welcomeActionNameList) {
 				String waPath = name + wa;
 				if (context.exists(ACTION_MAPPING_META_PATH, waPath)) {
 					actionMapping = context.getMetaDataHandler(ActionMappingRuntime.class, ACTION_MAPPING_META_PATH + waPath);


### PR DESCRIPTION
<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->
fixes https://github.com/dentsusoken/iPLAss/issues/1699

- EntityView作成ダイアログにてOKボタン押下時にView名チェックをするように修正
- MetaDataExplorerにてメタデータインポート時に各メタデータの定義名に対してAdminConsole画面からメタデータ作成（変更）時と同じ入力チェックを実施するように修正（View名チェックについてはcheckStatus）

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->

## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->