### PR TITLE
AdminConsole: カラー設定ダイアログの高さが動的に設定されるようにする

### DIFF
--- a/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/tenant/BaseTenantPropertyEditDialog.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/tenant/BaseTenantPropertyEditDialog.java
@@ -456,7 +456,7 @@ public abstract class BaseTenantPropertyEditDialog extends MtpDialog {
 
 	@SuppressWarnings("unchecked")
 	protected void createColorSchemeForm(String name, String title, DynamicForm form) {
-		setHeight(240);
+		setHeight(370);
 		
 		Map<String, String> valueMap = record.getAttributeAsMap("selectItem");
 		List<String> valueList = (List<String>) JSOHelper

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/tenant/BaseTenantPropertyEditDialog.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/tenant/BaseTenantPropertyEditDialog.java
@@ -456,7 +456,6 @@ public abstract class BaseTenantPropertyEditDialog extends MtpDialog {
 
 	@SuppressWarnings("unchecked")
 	protected void createColorSchemeForm(String name, String title, DynamicForm form) {
-		setHeight(370);
 		
 		Map<String, String> valueMap = record.getAttributeAsMap("selectItem");
 		List<String> valueList = (List<String>) JSOHelper
@@ -478,6 +477,7 @@ public abstract class BaseTenantPropertyEditDialog extends MtpDialog {
 			cnt++;
 		}
 		form.setItems(items);
+		setHeight(110 + 26 * cnt);
 	}
 
 	/**


### PR DESCRIPTION
Closes #1756

<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->
## 対応内容
AdminConsoleのカラースキームとダークカラースキームの設定ダイアログの高さを項目数に合わせて調節する。

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください（特に自動テスト化されておらず、手動で確認した場合）。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->
![{952F7E02-B82E-40F2-8BE1-7AA90DB1B165}](https://github.com/user-attachments/assets/304dcec9-3038-454f-b250-2192e31c0fac)

## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->