### PR TITLE
メタデータのプリフェッチ機能（3.2）

### DIFF
--- a/iplass-core/src/main/java/org/iplass/mtp/impl/warmup/MetaDataWarmupTask.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/warmup/MetaDataWarmupTask.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.warmup;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.iplass.mtp.impl.metadata.MetaDataContext;
+import org.iplass.mtp.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * メタデータウォームアップタスク
+ * <p>
+ * テナント単位に事前にメタデータを読み込みキャッシュしておくタスクです。
+ * 設定されたメタデータパスに応じてメタデータを読み込みます。
+ * </p>
+ *
+ * <h3>メタデータパス設定ルール</h3>
+ * <ul>
+ * <li>メタデータの最上位パスは指定必須。（例：エンティティであれば <code>/entity/</code>）</li>
+ * <li>前方一致検索する場合は、末尾にアスタリスク（&#42;）を設定する。（例： <code>/entity/mtp/&#42;</code>）</li>
+ * <li>完全一致検索する場合は、完全なメタデータパスを設定する。（例： <code>/entity/mtp/auth/User</code>）</li>
+ * </ul>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public class MetaDataWarmupTask implements WarmupTask {
+	/** メタデータルートパス指定ありパターン */
+	private static final Pattern METADATA_ROOT_PATH_PATTERN = Pattern.compile("^\\/[a-zA-Z0-9]+\\/.*");
+
+	/** ロガー */
+	private Logger logger = LoggerFactory.getLogger(MetaDataWarmupTask.class);
+
+	// setter によって設定される。init で処理される。
+	/** メタデータパスリスト */
+	private List<String> metadataPathList;
+
+	// init で初期化される。warmup で利用される。
+	/** 前方一致用 メタデータパスリスト */
+	private List<String> metadataPathPrefixList = new ArrayList<>();
+	/** 完全一致用 メタデータパスリスト */
+	private List<String> metadataPathExactMatchList = new ArrayList<>();
+
+	@Override
+	public void init() {
+		if (null == metadataPathList || metadataPathList.isEmpty()) {
+			logger.warn("metadataPathList is empty.");
+			return;
+		}
+
+		for (String metadataPath : metadataPathList) {
+			if (!checkPath(metadataPath)) {
+				logger.warn("Incorrect metadata path \"{}\". Please check the service-config setting.", metadataPath);
+				continue;
+			}
+
+			if (metadataPath.endsWith("*")) {
+				metadataPathPrefixList.add(metadataPath.substring(0, metadataPath.length() - 1));
+			} else {
+				metadataPathExactMatchList.add(metadataPath);
+			}
+		}
+	}
+
+	@Override
+	public void warmup(WarmupContext context) {
+		var metadataContext = MetaDataContext.getContext();
+
+		for (String metadataPathPrefix : metadataPathPrefixList) {
+			loadMetadataPrefix(metadataContext, metadataPathPrefix);
+		}
+
+		loadMetadataList(metadataContext, metadataPathExactMatchList);
+	}
+
+	/**
+	 * メタデータパスリストを取得します。
+	 * @return メタデータパスリスト
+	 */
+	public List<String> getMetadataPathList() {
+		return metadataPathList;
+	}
+
+	/**
+	 * メタデータパスリストを設定します。
+	 * @param metadataPathList メタデータパスリスト
+	 */
+	public void setMetadataPathList(List<String> metadataPathList) {
+		this.metadataPathList = metadataPathList;
+	}
+
+	/**
+	 * 設定されたメタデータパスをチェックする
+	 *
+	 * @param metadataPath メタデータパス
+	 * @return 正しいメタデータパスの場合 true が返却される
+	 */
+	private boolean checkPath(String metadataPath) {
+		if (StringUtil.isBlank(metadataPath)) {
+			// null もしくは空文字
+			return false;
+		}
+
+		// メタデータルートパスが指定されているか確認
+		var matcher = METADATA_ROOT_PATH_PATTERN.matcher(metadataPath);
+		return matcher.matches();
+	}
+
+	/**
+	 * 前方一致するメタデータを読み込む
+	 * @param context メタデータコンテキスト
+	 * @param metadataPathPrefix メタデータパス
+	 */
+	private void loadMetadataPrefix(MetaDataContext context, String metadataPathPrefix) {
+		var searchMetadataPathList = context.pathList(metadataPathPrefix);
+		if (null == searchMetadataPathList || searchMetadataPathList.isEmpty()) {
+			logger.warn("No metadata matching \"{}\" exists.", metadataPathPrefix);
+			return;
+		}
+
+		loadMetadataList(context, searchMetadataPathList);
+	}
+
+	/**
+	 * メタデータを読み込む
+	 * @param context メタデータコンテキスト
+	 * @param metadataPathList メタデータパスリスト
+	 */
+	private void loadMetadataList(MetaDataContext context, List<String> metadataPathList) {
+		for (String metadataPath : metadataPathList) {
+			logger.debug("Load metadata: {}", metadataPath);
+			context.getMetaDataEntry(metadataPath);
+		}
+	}
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/warmup/MetaDataWarmupTask.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/warmup/MetaDataWarmupTask.java
@@ -21,6 +21,7 @@ package org.iplass.mtp.impl.warmup;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.iplass.mtp.impl.metadata.MetaDataContext;
@@ -84,7 +85,7 @@ public class MetaDataWarmupTask implements WarmupTask {
 
 	@Override
 	public void warmup(WarmupContext context) {
-		var metadataContext = MetaDataContext.getContext();
+		MetaDataContext metadataContext = MetaDataContext.getContext();
 
 		for (String metadataPathPrefix : metadataPathPrefixList) {
 			loadMetadataPrefix(metadataContext, metadataPathPrefix);
@@ -122,7 +123,7 @@ public class MetaDataWarmupTask implements WarmupTask {
 		}
 
 		// メタデータルートパスが指定されているか確認
-		var matcher = METADATA_ROOT_PATH_PATTERN.matcher(metadataPath);
+		Matcher matcher = METADATA_ROOT_PATH_PATTERN.matcher(metadataPath);
 		return matcher.matches();
 	}
 
@@ -132,7 +133,7 @@ public class MetaDataWarmupTask implements WarmupTask {
 	 * @param metadataPathPrefix メタデータパス
 	 */
 	private void loadMetadataPrefix(MetaDataContext context, String metadataPathPrefix) {
-		var searchMetadataPathList = context.pathList(metadataPathPrefix);
+		List<String> searchMetadataPathList = context.pathList(metadataPathPrefix);
 		if (null == searchMetadataPathList || searchMetadataPathList.isEmpty()) {
 			logger.warn("No metadata matching \"{}\" exists.", metadataPathPrefix);
 			return;

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/warmup/WarmupContext.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/warmup/WarmupContext.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.warmup;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * ウォームアップコンテキスト
+ * @author SEKIGUCHI Naoya
+ */
+public class WarmupContext {
+	/** コンテキスト本体 */
+	private Map<String, Object> context = new HashMap<>();
+
+	/**
+	 * コンテキストの値を取得する
+	 * @param <T> 値の型
+	 * @param key キー
+	 * @param value 値
+	 */
+	public <T> void set(String key, T value) {
+		context.put(key, value);
+	}
+
+	/**
+	 * コンテキストの値を取得する
+	 * @param <T> 値の型
+	 * @param key キー
+	 * @return 値
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> T get(String key) {
+		return (T) context.get(key);
+	}
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/warmup/WarmupService.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/warmup/WarmupService.java
@@ -1,0 +1,473 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.warmup;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Stream;
+
+import org.iplass.mtp.impl.core.ExecuteContext;
+import org.iplass.mtp.impl.tenant.TenantService;
+import org.iplass.mtp.spi.Config;
+import org.iplass.mtp.spi.Service;
+import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ウォームアップサービス
+ * <p>
+ * アプリケーション起動時にウォームアップ処理を行うサービスです。
+ * 比較的重い初期処理を事前に実行しておくことにより、初回実行時の処理速度の改善を目的とします。
+ * </p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public class WarmupService implements Service {
+	/** ロガー */
+	private Logger logger = LoggerFactory.getLogger(WarmupService.class);
+
+	// service-config 設定値
+	private Boolean enabled;
+	/** ステータスファイルパス */
+	private String statusFile;
+
+	/** ウォームアップタスク */
+	private Map<String, WarmupTask> taskMap;
+	/** アプリケーションのウォームアップタスク名 */
+	private List<String> applicationTaskNameList;
+	/** テナント毎のウォームアップタスク名*/
+	private Map<Integer, List<String>> tenantTaskNameListMap;
+	/** ウォームアップ状態 */
+	private volatile WarmupStatus status = WarmupStatus.NOT_PROCESSING;
+
+	/** 非同期タスク実行 */
+	private InternalSingleThreadAsyncTaskExecutor asyncTaskExecutor;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void init(Config config) {
+		this.enabled = config.getValue("enabled", Boolean.class, Boolean.FALSE);
+
+		if (!enabled) {
+			logger.debug("warmup is disabled.");
+			return;
+		}
+
+		this.statusFile = config.getValue("statusFile", null);
+
+		// taskMap key = タスク名、 value = WarmupTask 実装インスタンス
+		Map<String, WarmupTask> taskMap = config.getValue("taskMap", Map.class, Collections.emptyMap());
+		// applicationTask = カンマ区切りのタスク名
+		String applicationTask = config.getValue("applicationTask", String.class, "");
+		// tenantTaskMap key = カンマ区切りのテナントID、 value = カンマ区切りのタスク名
+		Map<String, String> tenantTaskMap = config.getValue("tenantTaskMap", Map.class, Collections.emptyMap());
+
+		// タスク初期化
+		taskMap.values().forEach(WarmupTask::init);
+
+		// アプリケーションのウォームアップタスク名を設定
+		// カンマ区切りのタスク名を分割
+		var applicationTaskNames = Stream.of(applicationTask.split(","))
+				.filter(t -> StringUtil.isNotEmpty(t))
+				.map(t -> t.trim())
+				.toList();
+
+		applicationTaskNameList = new ArrayList<>();
+		for (String taskName : applicationTaskNames) {
+			if (!taskMap.containsKey(taskName)) {
+				// tenantTaskMap に設定されたタスク名が、taskMap に存在しない場合は警告を出力しスキップ
+				logger.warn("The taskMap is set to the non-existent task name \"{}\". Please check applicationTask.", taskName);
+				continue;
+			}
+
+			// タスクを追加
+			applicationTaskNameList.add(taskName);
+		}
+
+		// 全テナントID
+		var tenantService = ServiceRegistry.getRegistry().getService(TenantService.class);
+		var allTenantIdList = tenantService.getAllTenantIdList();
+
+		Map<Integer, List<String>> tenantTaskNameListMap = new HashMap<>();
+		for (Map.Entry<String, String> entry : tenantTaskMap.entrySet()) {
+			String commaSeparatedTenantId = entry.getKey();
+			String commaSeparatedTaskName = entry.getValue();
+
+			// カンマ区切りのテナントIDを分割。テナントIDは * が指定されていたら、全テナントと判断する。空文字は無視する。
+			List<Integer> tenantIdList = "*".equals(commaSeparatedTenantId) ? allTenantIdList
+					: Stream.of(commaSeparatedTenantId.split(","))
+					.filter(i -> StringUtil.isNotEmpty(i))
+					.map(i -> Integer.parseInt(i.trim()))
+					.toList();
+
+			// カンマ区切りのタスク名を分割
+			var taskNames = Stream.of(commaSeparatedTaskName.split(","))
+					.filter(t -> StringUtil.isNotEmpty(t))
+					.map(t -> t.trim())
+					.toList();
+
+			for (String taskName : taskNames) {
+				if (!taskMap.containsKey(taskName)) {
+					// tenantTaskMap に設定されたタスク名が、taskMap に存在しない場合は警告を出力しスキップ
+					logger.warn("The taskMap is set to the non-existent task name \"{}\". Please check tenantTaskMap.", taskName);
+					continue;
+				}
+
+				// テナント毎にタスクを追加
+				addTaskNameEachTenant(tenantTaskNameListMap, taskName, tenantIdList);
+			}
+		}
+
+		// ステータスファイルの上位ディレクトリを作成
+		var statusFile = getStatusFile();
+		createParentDirectory(statusFile);
+
+		// ステータスファイルが存在していたら削除
+		deleteFile(statusFile);
+		Stream.of(WarmupStatus.values()).forEach(s -> deleteFile(getStatusFile(s)));
+
+		this.taskMap = taskMap;
+		this.tenantTaskNameListMap = tenantTaskNameListMap;
+
+		// 非同期タスク処理
+		asyncTaskExecutor = new InternalSingleThreadAsyncTaskExecutor();
+		// インスタンス初期化
+		asyncTaskExecutor.init(config);
+	}
+
+	@Override
+	public void destroy() {
+		try {
+			if (null != taskMap) {
+				// タスク破棄
+				taskMap.values().forEach(WarmupTask::destroy);
+			}
+
+		} finally {
+			// ステータスファイルを削除
+			deleteFile(getStatusFile());
+			Stream.of(WarmupStatus.values()).forEach(s -> deleteFile(getStatusFile(s)));
+			// インスタンス破棄
+			if (null != asyncTaskExecutor) {
+				asyncTaskExecutor.destroy();
+			}
+		}
+	}
+
+	/**
+	 * ウォームアップが有効かを取得する。
+	 * @return ウォームアップが有効な場合 true を返却する。
+	 */
+	public boolean isEnabled() {
+		return enabled == Boolean.TRUE;
+	}
+
+	/**
+	 * ウォームアップ状態を取得する。
+	 * @return ウォームアップ状態
+	 */
+	public WarmupStatus getStatus() {
+		return status;
+	}
+
+	/**
+	 * ウォームアップ状態を変更する。
+	 * <p>
+	 * ウォームアップ状態が変更可能であれば変更します。
+	 * 詳細は {@link org.iplass.mtp.impl.warmup.WarmupStatus} を確認してください。
+	 * </p>
+	 * <p>
+	 * ウォームアップ状態が COMPLETE, FAILED に変更された場合、ステータスファイルを出力します。
+	 * </p>
+	 *
+	 * @param nextStatus 変更する状態
+	 */
+	public synchronized void changeStatus(WarmupStatus nextStatus) {
+		if (this.status.canChange(nextStatus)) {
+			logger.debug("Warmup status changed from {} to {}.", this.status, nextStatus);
+			this.status = nextStatus;
+
+			if (WarmupStatus.COMPLETE == nextStatus || WarmupStatus.FAILED == nextStatus) {
+				// 最終ステータスの場合、ファイルを作成（DISABLED は作らない）
+				createStatusFile(nextStatus);
+			}
+		} else {
+			logger.warn("Cannot change warmup status from {} to {}.", this.status, nextStatus);
+		}
+	}
+
+	/**
+	 * 指定されたテナントIDのウォームアップ処理が存在しないことを確認する。
+	 * @param tenantId テナントID
+	 * @return ウォームアップ処理が存在しない場合 true を返却する。
+	 */
+	public boolean notExistsTenantWarmup(Integer tenantId) {
+		return !tenantTaskNameListMap.containsKey(tenantId);
+	}
+
+	/**
+	 * アプリケーションのウォームアップ処理を実行する。
+	 * <p>
+	 * アプリケーションに定義されているウォームアップ処理を実行します。
+	 * </p>
+	 * <p>
+	 * enabled が false の場合は、ウォームアップ処理を実行しません。
+	 * </p>
+	 * @param context ウォームアップコンテキスト
+	 */
+	public void warmupApplication(WarmupContext context) {
+		if (!isEnabled()) {
+			logger.debug("Warmup is disabled.");
+			return;
+		}
+
+		for (String taskName : applicationTaskNameList) {
+			logger.debug("Start the application warmup task \"{}\".", taskName);
+			var task = taskMap.get(taskName);
+			task.warmup(context);
+		}
+	}
+
+	/**
+	 * テナントのウォームアップ処理を実行する。
+	 * <p>
+	 * テナント毎に定義されているウォームアップ処理を実行します。
+	 * </p>
+	 * <p>
+	 * enabled が false の場合は、ウォームアップ処理を実行しません。
+	 * </p>
+	 * @param context ウォームアップコンテキスト
+	 */
+	public void warmupTenant(WarmupContext context) {
+		if (!isEnabled()) {
+			logger.debug("Warmup is disabled.");
+			return;
+		}
+
+		var tenantId = ExecuteContext.getCurrentContext().getTenantContext().getTenantId();
+		var taskNameList = tenantTaskNameListMap.get(tenantId);
+
+		if (taskNameList == null) {
+			return;
+		}
+
+		for (String taskName : taskNameList) {
+			logger.debug("Start the tenant warmup task \"{}\".", taskName);
+			var task = taskMap.get(taskName);
+			task.warmup(context);
+		}
+	}
+
+	/**
+	 * 非同期タスクを実行する
+	 * @param <V> 返却データ型
+	 * @param task 非同期タスク
+	 * @return 非同期タスクの実行結果
+	 */
+	public <V> Future<V> execute(Callable<V> task) {
+		if (!isEnabled()) {
+			logger.debug("Warmup is disabled.");
+			return null;
+		}
+
+		// asyncTaskExecutor メソッドに移譲
+		return asyncTaskExecutor.execute(task);
+	}
+
+	/**
+	 * テナント毎のタスク名リストにタスク名を追加する。
+	 * @param tenantTaskNameListMap テナント毎のタスク名リスト
+	 * @param taskName 追加対象のタスク名
+	 * @param tenantIdList 追加対象のテナントIDリスト
+	 */
+	private void addTaskNameEachTenant(Map<Integer, List<String>> tenantTaskNameListMap, String taskName, List<Integer> tenantIdList) {
+		for (int tenantId : tenantIdList) {
+			var taskNameList = tenantTaskNameListMap.get(tenantId);
+			if (taskNameList == null) {
+				taskNameList = new ArrayList<>();
+				tenantTaskNameListMap.put(tenantId, taskNameList);
+			}
+
+			if (!taskNameList.contains(taskName)) {
+				// taskNameList にタスク名が存在しなければ追加（ * で追加されるタスクと、個別指定タスクの重複を考慮 ）
+				taskNameList.add(taskName);
+			}
+		}
+	}
+
+	/**
+	 * ファイルの親ディレクトリを作成します
+	 * @param file ファイル
+	 */
+	private void createParentDirectory(File file) {
+		if (null != file) {
+			var parent = file.getParentFile();
+			parent.mkdirs();
+		}
+	}
+
+	/**
+	 * ファイルを削除します
+	 * @param file ステータスファイル
+	 */
+	private void deleteFile(File file) {
+		if (null != file && file.exists()) {
+			file.delete();
+		}
+	}
+
+	/**
+	 * ステータスファイルを取得します。
+	 * <p>
+	 * 返却するファイルは service-config で設定したステータスファイルです。
+	 * </p>
+	 * @return ステータスファイル
+	 */
+	private File getStatusFile() {
+		if (StringUtil.isEmpty(this.statusFile)) {
+			return null;
+		}
+		return new File(this.statusFile);
+	}
+
+	/**
+	 * 拡張子に状態が付与されたステータスファイルを取得します。
+	 * <p>
+	 * 返却するファイルは service-config で設定したステータスファイルに状態を付与したファイルです。
+	 * 例えば、/path/to/file が設定されていた場合、 /path/to/file.complete や /path/to/file.failed などが返却されます。
+	 * </p>
+	 *
+	 * @param status ウォームアップ状態
+	 * @return ステータスファイル
+	 */
+	private File getStatusFile(WarmupStatus status) {
+		if (StringUtil.isEmpty(this.statusFile)) {
+			return null;
+		}
+		return new File(this.statusFile + "." + status.getStatus());
+	}
+
+	/**
+	 * ステータスファイルを作成します。
+	 * @param status ウォームアップ状態
+	 */
+	private void createStatusFile(WarmupStatus status) {
+		var statusFile = getStatusFile();
+		if (null == statusFile) {
+			// ステータスファイルの設定がない場合は作成しない。
+			return;
+		}
+
+		try (var file = new FileWriter(statusFile, StandardCharsets.UTF_8)) {
+			// /path/to/file に complete|failed を書き込む
+			file.write(status.getStatus());
+			file.flush();
+
+			// /path/to/file.(complete|failed) を作成
+			getStatusFile(status).createNewFile();
+
+		} catch (Exception e) {
+			logger.error("Failed to create status file.", e);
+		}
+	}
+
+	/**
+	 * 内部利用 単一スレッド用の非同期タスク実行
+	 * <p>
+	 * テナントが未確定な状態で利用する非同期処理です。
+	 * </p>
+	 */
+	private static class InternalSingleThreadAsyncTaskExecutor {
+		/** ExecutorService */
+		private ExecutorService executor;
+		/** 実行タスクのFuture */
+		private List<Future<?>> futureList = new ArrayList<>();
+
+		/**
+		 * 初期化ライフサイクルメソッド
+		 * <p>
+		 * 本メソッドを実行することで、インスタンスを利用することができます。
+		 * </p>
+		 *
+		 * @param config 設定情報
+		 */
+		public void init(Config config) {
+			executor = Executors.newSingleThreadExecutor();
+		}
+
+		/**
+		 * 破棄ライフサイクルメソッド
+		 * <p>
+		 * アプリケーション終了時に、本メソッドを実行しリソースを開放します。
+		 * </p>
+		 */
+		public void destroy() {
+			// 未完了でキャンセルされていないタスクをキャンセル
+			futureList.stream().filter(f -> !f.isDone() && !f.isCancelled()).forEach(f -> f.cancel(true));
+
+			if (null != executor) {
+				executor.close();
+			}
+		}
+
+		/**
+		 * 非同期タスクを実行する
+		 * @param <V> 返却データ型
+		 * @param task 非同期タスク
+		 * @return 非同期タスクの実行結果（Future）
+		 */
+		public <V> Future<V> execute(Callable<V> task) {
+			// 完了したタスクのFutureを削除
+			removeDoneFuture();
+			// 新規タスクを実行
+			var future = executor.submit(task);
+			futureList.add(future);
+			return future;
+		}
+
+		/**
+		 * 完了したタスクのFutureを削除する
+		 */
+		private void removeDoneFuture() {
+			List<Future<?>> doneFutureList = new ArrayList<>();
+			for (var future : futureList) {
+				if (future.isDone()) {
+					doneFutureList.add(future);
+				}
+			}
+
+			if (!doneFutureList.isEmpty()) {
+				futureList.removeAll(doneFutureList);
+			}
+		}
+	}
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/warmup/WarmupStatus.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/warmup/WarmupStatus.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.warmup;
+
+/**
+ * ウォームアップステータス
+ * <p>
+ * ウォームアップ状態を表す列挙型です。
+ * ウォームアップ状態は、{@link org.iplass.mtp.impl.warmup.WarmupService} で管理されます。
+ * </p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public enum WarmupStatus {
+
+	/** 処理されていない */
+	NOT_PROCESSING(0, "not_processing"),
+	/** 処理中 */
+	PROCESSING(1, "processing"),
+	/** 完了（正常終了） */
+	COMPLETE(2, "complete"),
+	/** 完了（失敗） */
+	FAILED(2, "failed"),
+	/** 完了（無効） */
+	DISABLED(2, "disabled");
+
+	/** 重み weight == 2 は最終ステータスを表す */
+	private int weight;
+	/** ステータス名 */
+	private String status;
+
+	/**
+	 * コンストラクタ
+	 * @param weight 重み
+	 * @param status ステータス名
+	 */
+	private WarmupStatus(int weight, String status) {
+		this.weight = weight;
+		this.status = status;
+	}
+
+	/**
+	 * ステータス名を取得する
+	 * @return ステータス名
+	 */
+	public String getStatus() {
+		return status;
+	}
+
+	/**
+	 * 次のステータスに変更可能か判定する
+	 * <p>
+	 * ステータス変更の判定は、重みによって判断されます。
+	 * 自身の重みよりも大きいものに変更可能です。
+	 * </p>
+	 *
+	 * @param nextStatus 変更先ステータス
+	 * @return 変更可能な場合は true を返却する。
+	 */
+	public boolean canChange(WarmupStatus nextStatus) {
+		if (this == nextStatus) {
+			return false;
+		}
+
+		return this.weight < nextStatus.weight;
+	}
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/warmup/WarmupTask.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/warmup/WarmupTask.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.warmup;
+
+/**
+ * ウォームアップタスクインターフェース
+ * <p>
+ * WarmupService にタスクを設定することで、アプリケーション起動時にタスクを実行することができます。
+ * 初期化処理が必要な場合は init メソッド、終了処理が必要な場合は destroy メソッドをオーバーライドしてください。
+ * </p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public interface WarmupTask {
+	/**
+	 * タスクの初期化処理を実行します
+	 */
+	default void init() {
+	}
+
+	/**
+	 * タスクの終了処理を実行します
+	 */
+	default void destroy() {
+	}
+
+	/**
+	 * タスクのウォームアップ処理を実行します。
+	 * @param context ウォームアップコンテキスト
+	 */
+	void warmup(WarmupContext context);
+}

--- a/iplass-core/src/main/resources/mtp-core-service-config.xml
+++ b/iplass-core/src/main/resources/mtp-core-service-config.xml
@@ -1180,4 +1180,63 @@
 		</property>
 	</service>
 
+	<!-- ウォームアップ --> 
+	<service>
+		<interface>org.iplass.mtp.impl.warmup.WarmupService</interface>
+		<class>org.iplass.mtp.impl.warmup.WarmupService</class>
+
+		<!-- enabled が true に設定されている場合に、ウォームアップ処理が実行されます。未指定の場合は false が設定されます。 -->
+		<!--
+		<property name="enabled" value="true" />
+		-->
+		<!--
+			statusFile には、ウォームアップ状態を表すファイルパスを設定します。指定されたファイルパスによって、以下の２ファイルを作成します。
+			statusFile の設定値が "/path/to/warmup_status" の場合。
+
+			正常終了時
+				/path/to/warmup_status （ファイルには、complete が記載されている）
+				/path/to/warmup_status.complete （空ファイル）
+
+			異常終了時
+				/path/to/warmup_status （ファイルには、failed が記載されている）
+				/path/to/warmup_status.failed （空ファイル）
+		-->
+		<!--
+		<property name="statusFile" value="/path/to/warmup_status" />
+		-->
+
+		<!--
+			taskMap は Map 形式でプロパティを設定してください。
+				name = ウォームアップタスク名
+				value = org.iplass.mtp.impl.warmup.WarmupTask の実装クラス
+		-->
+		<property name="taskMap">
+			<!-- defaultMetaDataWarmupTask はメタデータウォームアップのデフォルト定義 -->
+			<property name="defaultMetaDataWarmupTask" class="org.iplass.mtp.impl.warmup.MetaDataWarmupTask">
+				<property name="metadataPathList" value="/entity/mtp/*" />
+				<property name="metadataPathList" value="/message/mtp/*" />
+				<property name="metadataPathList" value="/authNPolicy/*" />
+			</property>
+		</property>
+
+		<!--
+			applicationTask には taskMap プロパティで設定したウォームアップタスク名を指定してください。
+			カンマ区切りで複数指定可能です。
+		-->
+		<!--
+		<property name="applicationTask" value="app1Task, app2Task" />
+		-->
+
+		<!--
+			tenantTaskMap には Map 形式でプロパティを設定してください。
+				name = テナントID。"*" は全テナントIDを表す。カンマ区切りで複数指定可能。
+				value = taskMap プロパティで設定したウォームアップタスク名。カンマ区切りで複数指定可能。
+		-->
+		<!--
+		<property name="tenantTaskMap">
+			<property name="1,2" value="taskA,taskB" />
+			<property name="*" value="allTenantTask" />
+		</property>
+		-->
+	</service>
 </serviceDefinition>

--- a/iplass-gem/src/main/resources/gem-service-config.xml
+++ b/iplass-gem/src/main/resources/gem-service-config.xml
@@ -353,4 +353,24 @@
 		<interface>org.iplass.mtp.impl.view.top.TopViewDefinitionService</interface>
 		<class>org.iplass.mtp.impl.view.top.TopViewDefinitionService</class>
 	</service>
+	
+	<!-- ウォームアップ -->
+	<service>
+		<interface>org.iplass.mtp.impl.warmup.WarmupService</interface>
+
+		<!--
+			taskMap は Map 形式でプロパティを設定してください。
+				name = ウォームアップタスク名
+				value = org.iplass.mtp.impl.warmup.WarmupTask の実装クラス
+		-->
+		<property name="taskMap">
+			<!-- defaultMetaDataWarmupTask はメタデータウォームアップのデフォルト定義。core プロジェクトの定義に追加 -->
+			<property name="defaultMetaDataWarmupTask" class="org.iplass.mtp.impl.warmup.MetaDataWarmupTask">
+				<property name="metadataPathList" value="/action/gem/*" additional="true" />
+				<property name="metadataPathList" value="/commandClass/gem/*" additional="true" />
+				<property name="metadataPathList" value="/template/gem/*" additional="true" />
+				<property name="metadataPathList" value="/webapi/gem/*" additional="true" />
+			</property>
+		</property>
+	</service>
 </serviceDefinition>

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/WarmupStatusServlet.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/WarmupStatusServlet.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.web;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.Callable;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.iplass.mtp.impl.tenant.TenantService;
+import org.iplass.mtp.impl.warmup.WarmupContext;
+import org.iplass.mtp.impl.warmup.WarmupService;
+import org.iplass.mtp.impl.warmup.WarmupStatus;
+import org.iplass.mtp.impl.web.warmup.WebWarmupContextConstant;
+import org.iplass.mtp.runtime.EntryPoint;
+import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ウォームアップ状態サーブレット
+ * <p>
+ * ウォームアップ状態を取得するためのサーブレットです。
+ * ウォームアップ処理は、本サーブレットの初期化処理で開始されます。
+ * ウォームアップ処理・状態は {@link org.iplass.mtp.impl.warmup.WarmupService} によって管理されます。
+ * </p>
+ *
+ * <h3>状態遷移</h3>
+ * <pre>
+ * NOT_PROCESSING
+ *   |
+ *   +--> PROCESSING
+ *   |      |
+ *   |      +--> COMPLETE
+ *   |      |
+ *   |      +--> FAILED
+ *   |
+ *   +---------> DISABLED
+ * </pre>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public class WarmupStatusServlet extends HttpServlet {
+	/** serialVersionUID */
+	private static final long serialVersionUID = -3645969923289588830L;
+	/** デフォルト：ウォームアップ処理待ち時間（秒） */
+	private static final long DEFAULT_WAIT_ON_WARMUP = 1;
+
+	@Override
+	public void init() throws ServletException {
+		ServletConfig config = super.getServletConfig();
+		String configWaitOnWarmup =  config.getInitParameter("waitOnWarmup");
+		long waitOnWarmup = StringUtil.isNotEmpty(configWaitOnWarmup) ? Long.valueOf(configWaitOnWarmup) : DEFAULT_WAIT_ON_WARMUP;
+
+		var warmupService = ServiceRegistry.getRegistry().getService(WarmupService.class);
+		if (warmupService.isEnabled()) {
+			// ウォームアップが有効な場合、非同期でウォームアップする
+			var warmupTaskExecutor = createWarmupTaskExecutor(waitOnWarmup);
+			warmupService.execute(warmupTaskExecutor);
+
+		} else {
+			// ウォームアップが無効な場合、処理無しで終了する。
+			warmupService.changeStatus(WarmupStatus.DISABLED);
+		}
+	}
+
+	@Override
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		var warmupService = ServiceRegistry.getRegistry().getService(WarmupService.class);
+		var status = warmupService.getStatus();
+
+		int httpStatus = getHttpStatus(status);
+		response.getWriter().write(status.getStatus());
+		response.setStatus(httpStatus);
+	}
+
+	/**
+	 * ウォームアップタスク実行インスタンスを生成します。
+	 * @param waitOnWarmup ウォームアップ処理待ち時間（秒）
+	 * @return ウォームアップタスク実行インスタンス
+	 */
+	protected WarmupTaskExecutor createWarmupTaskExecutor(long waitOnWarmup) {
+		return new WarmupTaskExecutor(waitOnWarmup, getServletConfig());
+	}
+
+	/**
+	 * ウォームアップ状態に対応するHTTPステータスを取得します。
+	 * @param status ウォームアップ状態
+	 * @return HTTPステータス
+	 */
+	private int getHttpStatus(WarmupStatus status) {
+		switch (status) {
+		case NOT_PROCESSING:
+			return HttpServletResponse.SC_SERVICE_UNAVAILABLE;
+		case PROCESSING:
+			return HttpServletResponse.SC_SERVICE_UNAVAILABLE;
+		case COMPLETE:
+			return HttpServletResponse.SC_OK;
+		case FAILED:
+			return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+		case DISABLED:
+			return HttpServletResponse.SC_NOT_FOUND;
+		default:
+			// null を想定
+			return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+		}
+	}
+
+	/**
+	 * ウォームアップタスク実行
+	 * <p>
+	 * サーブレットの初期化処理で非同期実行されるウォームアップ処理のエントリポイントです。
+	 * </p>
+	 */
+	protected static class WarmupTaskExecutor implements Callable<Void> {
+		/** ロガー */
+		private Logger logger = LoggerFactory.getLogger(WarmupTaskExecutor.class);
+		/** ウォームアップ処理待ち時間（秒） */
+		private long waitOnWarmup;
+		/** サーブレットコンフィグ */
+		private ServletConfig servletConfig;
+
+		/**
+		 * コンストラクタ
+		 * @param waitOnWarmup ウォームアップ処理待ち時間（秒）
+		 * @param servletConfig サーブレットコンフィグ
+		 */
+		public WarmupTaskExecutor(long waitOnWarmup, ServletConfig servletConfig) {
+			this.waitOnWarmup = waitOnWarmup;
+			this.servletConfig = servletConfig;
+		}
+
+		@Override
+		public Void call() throws Exception {
+			try {
+				// ウォームアップ処理待ち
+				sleep(waitOnWarmup);
+
+				logger.info("Start the warmup.");
+
+				// ウォームアップ処理開始
+				long elapsedTime = timer(() -> startWarmup());
+
+				logger.info("End the warmup. elapsed time is {} ms.", elapsedTime);
+
+				return null;
+
+			} catch (Exception e) {
+				logger.error("Warmup failed.", e);
+				throw e;
+			}
+		}
+
+		/**
+		 * ウォームアップ処理を開始する
+		 * <p>
+		 * 全テナントに対してウォームアップ処理を実行します。
+		 * ウォームアップ処理はテナント単位で、順次実行します。
+		 * </p>
+		 */
+		private void startWarmup() {
+			var tenantService = ServiceRegistry.getRegistry().getService(TenantService.class);
+			var warmupService = ServiceRegistry.getRegistry().getService(WarmupService.class);
+			warmupService.changeStatus(WarmupStatus.PROCESSING);
+
+			boolean isError = false;
+
+			try {
+				logger.debug("Application warmup start.");
+
+				var warmupContext = createWarmupContext();
+				warmupService.warmupApplication(warmupContext);
+
+				logger.debug("Application warmup finish.");
+
+			} catch (RuntimeException e) {
+				logger.error("Application warmup failed.", e);
+				isError = true;
+			}
+
+			var tenantIdList = tenantService.getAllTenantIdList();
+			for (int tenantId : tenantIdList) {
+				// テナント毎にウォームアップ処理を実行
+
+				// スレッド状態判定
+				if (Thread.currentThread().isInterrupted()) {
+					// スレッドが中断された場合、ウォームアップ処理を終了する
+					logger.debug("Warmup task interrupted.");
+					break;
+				}
+
+				try {
+					if (warmupService.notExistsTenantWarmup(tenantId)) {
+						// ウォームアップ処理が存在しなければ、テナントをスキップ
+						logger.debug("No warmup task is configured for tenant {}.", tenantId);
+						continue;
+					}
+
+					logger.debug("Tenant {} warmup start.", tenantId);
+
+					EntryPoint.getInstance().withTenant(tenantId).run(() -> {
+						// NOTE: コンテキストはテナント単位で作成する
+						var warmupContext = createWarmupContext();
+						warmupService.warmupTenant(warmupContext);
+					});
+
+					logger.debug("Tenant {} warmup finish.", tenantId);
+
+				} catch (RuntimeException e) {
+					logger.error("Tenant {} warmup failed.", tenantId, e);
+					isError = true;
+				}
+			}
+
+			warmupService.changeStatus(isError ? WarmupStatus.FAILED : WarmupStatus.COMPLETE);
+		}
+
+		/**
+		 * ウォームアップコンテキストを生成します。
+		 * @return ウォームアップコンテキスト
+		 */
+		protected WarmupContext createWarmupContext() {
+			var warmupContext = new WarmupContext();
+			warmupContext.set(WebWarmupContextConstant.SERVLET_CONFIG, servletConfig);
+			return warmupContext;
+		}
+
+		/**
+		 * 指定秒数スリープします。
+		 * @param seconds スリープ秒数
+		 * @throws InterruptedException
+		 */
+		private void sleep(long seconds) throws InterruptedException {
+			if (seconds > 0) {
+				Thread.sleep(Duration.ofSeconds(seconds));
+			}
+		}
+
+		/**
+		 * 指定処理の実行時間を計測します。
+		 * @param fn 処理
+		 * @return 実行時間（ミリ秒）
+		 */
+		private long timer(Runnable fn) {
+			long startTime = System.currentTimeMillis();
+
+			fn.run();
+
+			long endTime = System.currentTimeMillis();
+			return endTime - startTime;
+		}
+	}
+}

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/warmup/WebWarmupContextConstant.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/warmup/WebWarmupContextConstant.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.web.warmup;
+
+/**
+ * webプロジェクト用ウォームアップコンテキスト定数
+ * <p>
+ * {@link org.iplass.mtp.impl.warmup.WarmupContext} で使用する定数を定義します。
+ * </p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public class WebWarmupContextConstant {
+	/** ServletConfig */
+	public static final String SERVLET_CONFIG = "servletConfig";
+
+	/**
+	 * プライベートコンストラクタ
+	 */
+	private WebWarmupContextConstant() {
+	}
+}

--- a/iplass-web/src/main/resources/META-INF/web-fragment.xml
+++ b/iplass-web/src/main/resources/META-INF/web-fragment.xml
@@ -59,4 +59,21 @@
 		<url-pattern>/checkStatus</url-pattern>
 	</servlet-mapping>
 
+	<!-- for web app warmup -->
+	<servlet>
+		<description></description>
+		<display-name>WarmupStatusServlet</display-name>
+		<servlet-name>WarmupStatusServlet</servlet-name>
+		<servlet-class>org.iplass.mtp.impl.web.WarmupStatusServlet</servlet-class>
+		<init-param>
+			<param-name>waitOnWarmup</param-name>
+			<param-value>1</param-value>
+		</init-param>
+		<load-on-startup>200</load-on-startup>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>WarmupStatusServlet</servlet-name>
+		<url-pattern>/warmupStatus</url-pattern>
+	</servlet-mapping>
+
 </web-fragment>

--- a/iplass-web/src/main/resources/mtp-web-service-config.xml
+++ b/iplass-web/src/main/resources/mtp-web-service-config.xml
@@ -273,7 +273,7 @@
 		<!-- static contents -->
 		<property name="excludePath" value="(/errorhtml/.*)|(/images/.*)|(/scripts/.*)|(/styles/.*)|(/favicon.ico)|(/webjars/.*)" />
 		<!-- servlet implementation -->
-		<property name="excludePath" value="(/checkStatus)|(/cmcs)" />
+		<property name="excludePath" value="(/checkStatus)|(/warmupStatus)|(/cmcs)" />
 
 		<!-- WebAPI(REST)のpathの定義 -->
 		<property name="restPath" value="/api/" />


### PR DESCRIPTION
## 対応内容
- ウェブアプリ起動時ウォームアップおよび状態取得するサーブレットを追加
- ウォームアップサービスを追加
- メタデータウォームアップタスクを追加
- core, gem でデフォルトのメタデータウォームアップ設定を追加

## 動作確認・スクリーンショット（任意）
- アプリケーション起動し、ウォームアップ機能が動作することの確認
- ステータスサーブレットの確認

## レビュー観点・補足情報（任意）
- #1730 のバックポートです