### PR TITLE
GEM: 表示順プロパティを設定したNestTableが複数存在する場合に、1つ目のNestTableの表示順で他のNestTableがソートされてしまう（3.2）

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/bulk/BulkCommandContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/bulk/BulkCommandContext.java
@@ -348,7 +348,7 @@ public class BulkCommandContext extends RegistrationCommandContext {
 			//データあり
 			String paramPrefix = prefix + p.getName() + "[" + Integer.toString(i) + "].";
 			String errorPrefix = (i != list.size() ? prefix + p.getName() + "[" + Integer.toString(list.size()) + "]." : null);
-			Entity entity = createEntityInternal(paramPrefix, errorPrefix);
+			Entity entity = createEntityRef(paramPrefix, errorPrefix);
 
 			//入力エラー時に再Loadされないようにフラグ設定
 			entity.setValue(Constants.REF_RELOAD, Boolean.FALSE);
@@ -369,7 +369,7 @@ public class BulkCommandContext extends RegistrationCommandContext {
 				entity.setDefinitionName(defName);
 				entity.setValue(Constants.REF_INDEX, list.size());
 
-				Long orderIndex = getLongValue("tableOrderIndex[" + i + "]");
+				Long orderIndex = getLongValue("tableOrderIndex." + p.getName() + "[" + i + "]");
 				if (orderIndex != null) {
 					entity.setValue(Constants.REF_TABLE_ORDER_INDEX, orderIndex);
 				}
@@ -386,6 +386,26 @@ public class BulkCommandContext extends RegistrationCommandContext {
 		}
 
 		return list;
+	}
+
+	private Entity createEntityRef(String paramPrefix, String errorPrefix) {
+		Entity entity = newEntity();
+		for (PropertyDefinition p : getPropertyList()) {
+			if (skipProps.contains(p.getName())) {
+				continue;
+			}
+			Object value = getPropValue(p, paramPrefix);
+			entity.setValue(p.getName(), value);
+			if (errorPrefix != null) {
+				String name = paramPrefix + p.getName();
+				// Entity生成時にエラーが発生していないかチェックして置き換え
+				String errorName = errorPrefix + p.getName();
+				getErrors().stream()
+						.filter(error -> error.getPropertyName().equals(name))
+						.forEach(error -> error.setPropertyName(errorName));
+			}
+		}
+		return entity;
 	}
 
 	private void addNestTableRegistHandler(ReferenceProperty p, List<Entity> list, EntityDefinition red, PropertyColumn property) {

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/DetailCommandContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/DetailCommandContext.java
@@ -792,7 +792,7 @@ public class DetailCommandContext extends RegistrationCommandContext
 				entity.setDefinitionName(defName);
 				entity.setValue(Constants.REF_INDEX, list.size());
 
-				Long orderIndex = getLongValue("tableOrderIndex[" + i + "]");
+				Long orderIndex = getLongValue("tableOrderIndex." + p.getName() + "[" + i + "]");
 				if (orderIndex != null) {
 					entity.setValue(Constants.REF_TABLE_ORDER_INDEX, orderIndex);
 				}

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Table.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Table.jsp
@@ -664,7 +664,7 @@ ${m:rs("mtp-gem-messages", "generic.editor.reference.ReferencePropertyEditor_Tab
 		if (showUpDownBtn) {
 %>
 <td class="orderCol">
-<input type="hidden" name="tableOrderIndex[<%=Constants.EDITOR_REF_NEST_DUMMY_ROW_INDEX%>]" >
+<input type="hidden" name="tableOrderIndex.<c:out value="<%=propName%>"/>[<%=Constants.EDITOR_REF_NEST_DUMMY_ROW_INDEX%>]" >
 <span class="order-icon up-icon"><i class="fas fa-caret-up"></i></span>
 <span class="order-icon down-icon"><i class="fas fa-caret-down"></i></span>
 </td>
@@ -887,7 +887,7 @@ $(function() {
 					+ ")";
 %>
 <td class="orderCol">
-<input type="hidden" name="tableOrderIndex[<%=i%>]" value="<%=i%>">
+<input type="hidden" name="tableOrderIndex.<c:out value="<%=propName%>"/>[<%=i%>]" value="<%=i%>">
 <span class="order-icon up-icon"><i class="fas fa-caret-up"
  onclick="<c:out value="<%=shiftUp %>"/>"></i></span>
 <span class="order-icon down-icon"><i class="fas fa-caret-down"


### PR DESCRIPTION
<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->
fixes #1746

- 登録（編集）画面内に複数のネストテーブルがある場合でも表示順の変更が正常に動作するように修正
- 一括更新（単項目）時に更新項目にネストテーブル設定したリファレンスプロパティを選択して一括更新したときのエラーを修正

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->

## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->