### PR TITLE
GEM: EntityViewのView名に予約文字が含まれないようにする

### DIFF
--- a/iplass-core/src/main/java/org/iplass/mtp/impl/definition/AbstractTypedMetaDataService.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/definition/AbstractTypedMetaDataService.java
@@ -21,10 +21,12 @@
 package org.iplass.mtp.impl.definition;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.iplass.mtp.impl.metadata.MetaDataContext;
 import org.iplass.mtp.impl.metadata.MetaDataEntryInfo;
 import org.iplass.mtp.impl.metadata.MetaDataRuntime;
+import org.iplass.mtp.impl.metadata.MetaDataRuntimeException;
 import org.iplass.mtp.impl.metadata.RootMetaData;
 import org.iplass.mtp.impl.util.KeyGenerator;
 
@@ -34,12 +36,17 @@ public abstract class AbstractTypedMetaDataService<M extends RootMetaData, R ext
 
 	@Override
 	public void createMetaData(M meta) {
+		// メタデータ定義名チェック
+		this.checkDefinitionName(meta);
+
 		meta.setId(generator.generateId());
 		MetaDataContext.getContext().store(DefinitionService.getInstance().getPathByMeta(getMetaDataType(), meta.getName()), meta);
 	}
 
 	@Override
 	public void updateMetaData(M meta) {
+		// メタデータ定義名チェック
+		this.checkDefinitionName(meta);
 		MetaDataContext.getContext().update(DefinitionService.getInstance().getPathByMeta(getMetaDataType(), meta.getName()), meta);
 	}
 
@@ -78,6 +85,17 @@ public abstract class AbstractTypedMetaDataService<M extends RootMetaData, R ext
 	@Override
 	public List<MetaDataEntryInfo> list(String path) {
 		return MetaDataContext.getContext().definitionList(DefinitionService.getInstance().getPathByMeta(getMetaDataType(), path));
+	}
+
+	protected void checkDefinitionName(M meta) throws MetaDataRuntimeException {
+		DefinitionService definitionService = DefinitionService.getInstance();
+		Class<M> metaDataType = getMetaDataType();
+
+		// メタデータ定義名チェック TODO ここではパスはDefinitionServiceから取得してるためパスチェックは不要
+		Optional<String> checkResult = definitionService.checkDefinitionNameWithoutPath(metaDataType, meta.getName());
+		if (checkResult.isPresent()) {
+			throw new MetaDataRuntimeException(checkResult.get());
+		}
 	}
 
 	private String getFixedPath() {

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/definition/DefinitionManagerImpl.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/definition/DefinitionManagerImpl.java
@@ -22,6 +22,7 @@ package org.iplass.mtp.impl.definition;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.iplass.mtp.definition.Definition;
 import org.iplass.mtp.definition.DefinitionEntry;
@@ -36,13 +37,13 @@ import org.iplass.mtp.impl.core.ExecuteContext;
 import org.iplass.mtp.impl.metadata.MetaDataConfig;
 import org.iplass.mtp.impl.metadata.MetaDataContext;
 import org.iplass.mtp.impl.metadata.MetaDataEntry;
+import org.iplass.mtp.impl.metadata.MetaDataEntry.RepositoryType;
+import org.iplass.mtp.impl.metadata.MetaDataEntry.State;
 import org.iplass.mtp.impl.metadata.MetaDataEntryInfo;
 import org.iplass.mtp.impl.metadata.MetaDataIllegalStateException;
 import org.iplass.mtp.impl.metadata.MetaDataRepository;
 import org.iplass.mtp.impl.metadata.MetaDataRuntimeException;
 import org.iplass.mtp.impl.metadata.RootMetaData;
-import org.iplass.mtp.impl.metadata.MetaDataEntry.RepositoryType;
-import org.iplass.mtp.impl.metadata.MetaDataEntry.State;
 import org.iplass.mtp.spi.ServiceRegistry;
 
 public class DefinitionManagerImpl implements DefinitionManager {
@@ -259,6 +260,13 @@ public class DefinitionManagerImpl implements DefinitionManager {
 		MetaDataEntry current = metaContext.getMetaDataEntry(oldPath);
 		if (current == null) {
 			throw new MetaDataRuntimeException(oldDefinitionName + "of " + type.getName() + " not found");
+		}
+
+		// TODO AdminConsoleからリネームする場合、AbstractTypedMetaDataServiceやAbstractTypedDefinitionManagerは経由していない
+		// パスはnewPathが自動生成されるので、ここでのパスチェックは不要
+		Optional<String> checkResult = defService.checkDefinitionNameByTypeWithoutPath(type, newDefinitionName);
+		if (checkResult.isPresent()) {
+			throw new MetaDataRuntimeException(checkResult.get());
 		}
 
 		RootMetaData renamed = current.getMetaData().copy();

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/definition/DefinitionMetaDataTypeMap.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/definition/DefinitionMetaDataTypeMap.java
@@ -19,20 +19,27 @@
  */
 package org.iplass.mtp.impl.definition;
 
+import java.util.Objects;
+import java.util.Optional;
+
 import org.iplass.mtp.definition.Definition;
 import org.iplass.mtp.definition.TypedDefinitionManager;
 import org.iplass.mtp.impl.metadata.RootMetaData;
+import org.iplass.mtp.impl.util.CoreResourceBundleUtil;
+import org.iplass.mtp.util.StringUtil;
 
 public abstract class DefinitionMetaDataTypeMap<D extends Definition, M extends RootMetaData> {
 	protected String pathPrefix;
 	protected Class<M> metaType;
 	protected Class<D> defType;
+	private DefinitionNameChecker definitionNameChecker;
 //	boolean replaceDot;
 
 	protected DefinitionMetaDataTypeMap(String pathPrefix, Class<M> metaType, Class<D> defType) {
 		this.pathPrefix = pathPrefix;
 		this.metaType = metaType;
 		this.defType = defType;
+		this.definitionNameChecker = this.createDefinitionNameChecker();
 //		this.replaceDot = replaceDot;
 	}
 
@@ -53,5 +60,44 @@ public abstract class DefinitionMetaDataTypeMap<D extends Definition, M extends 
 	}
 	public String typeName() {
 		return defType.getSimpleName();
+	}
+
+	/**
+	 * メタデータ定義名Checker生成
+	 * TODO コンパイルエラー回避のため一旦abstractメソッドにしない
+	 * TODO 全体的にメタデータ定義名の制限を確認して、パスがスラッシュで名前にピリオド許可してるものがほとんどだったらabstractにしない
+	 * 
+	 * @return メタデータ定義名Checker
+	 */
+	protected DefinitionNameChecker createDefinitionNameChecker() {
+		return DefinitionNameChecker.getDefaultDefinitionNameChecker();
+	}
+
+	/**
+	 * メタデータ定義名チェック
+	 * 
+	 * <p>
+	 * 以下のチェックをする
+	 * <ul>
+	 * <li>メタデータのパスがメタデータ定義のパスに一致するかどうか</li>
+	 * <li>メタデータ定義名に指定できない文字列が含まれていないかどうか</li>
+	 * </ul>
+	 * </p>
+	 * 
+	 * @param defName メタデータ定義名
+	 * @return エラーメッセージ（チェックエラーの場合）
+	 */
+	public Optional<String> checkDefinitionName(String path, String defName) {
+		// パスチェック
+		if (StringUtil.isNotEmpty(path) && !path.startsWith(this.pathPrefix)) {
+			return Optional.of(CoreResourceBundleUtil.resourceString("impl.definition.DefinitionService.invalidPath"));
+		}
+
+		if (Objects.isNull(this.definitionNameChecker) || StringUtil.isEmpty(defName)) {
+			return Optional.empty();
+		}
+
+		// メタデータ定義名チェック
+		return this.definitionNameChecker.check(defName);
 	}
 }

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/definition/DefinitionNameChecker.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/definition/DefinitionNameChecker.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.definition;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import org.iplass.mtp.impl.util.CoreResourceBundleUtil;
+import org.iplass.mtp.util.StringUtil;
+
+/**
+ * メタデータ定義名チェッククラス
+ */
+public class DefinitionNameChecker {
+
+	private static final String DEFAULT_PATTERN = "^[0-9a-zA-Z_][0-9a-zA-Z_-]*(/[0-9a-zA-Z_-]+)*(\\.[0-9a-zA-Z_-]+)*$";
+	private static final String DEFAULT_MESSAGE_KEY = "impl.definition.DefinitionNameChecker.invalidPattern";
+
+	private Pattern definitionNamePattern;
+	private String messageKey;
+
+	/**
+	 * デフォルトの定義名Checkerを返却
+	 * 
+	 * <p>
+	 * メタデータ定義名が「パスにスラッシュを利用、名前にピリオド含む」になってるかチェックするChecker
+	 * </p>
+	 * 
+	 * @return デフォルトの定義名Checker
+	 */
+	public static DefinitionNameChecker getDefaultDefinitionNameChecker() {
+		return new DefinitionNameChecker(DEFAULT_PATTERN, DEFAULT_MESSAGE_KEY);
+	}
+
+	/**
+	 * コンストラクター
+	 * 
+	 * <p>
+	 * メタデータ定義名のパターン（正規表現）を指定する場合に利用する
+	 * </p>
+	 * 
+	 * @param definitionNamePattern 定義名のパターン（正規表現）
+	 * @param messageKey エラーメッセージキー
+	 */
+	public DefinitionNameChecker(String definitionNamePattern, String messageKey) {
+		// パターンかメッセージキーのどちらかが未指定だった場合はデフォルトの定義名チェックにする
+		if (StringUtil.isEmpty(definitionNamePattern) || StringUtil.isEmpty(messageKey)) {
+			this.definitionNamePattern = Pattern.compile(DEFAULT_PATTERN);
+			this.messageKey = DEFAULT_MESSAGE_KEY;
+			return;
+		}
+
+		this.definitionNamePattern = Pattern.compile(definitionNamePattern);
+		this.messageKey = messageKey;
+	}
+
+	/**
+	 * エラーメッセージを返却
+	 * 
+	 * <p>
+	 * メッセージの取得元を変更する場合はオーバーライドする
+	 * </p>
+	 * 
+	 * @param messageKey メッセージキー
+	 * @param definitionName メタデータ定義名
+	 * @return エラーメッセージ
+	 */
+	protected String getErrorMessage(String messageKey, String definitionName) {
+		return CoreResourceBundleUtil.resourceString(messageKey, definitionName);
+	}
+
+	/**
+	 * メタデータ定義名チェック
+	 * 
+	 * @param definitionName メタデータ定義名
+	 * @return チェックOKの場合は空、チェックNGの場合はチェックエラーメッセージ
+	 */
+	public Optional<String> check(String definitionName) {
+		// メタデータ定義名未指定ならチェックしない（チェックOKとする）
+		if (StringUtil.isEmpty(definitionName)) {
+			return Optional.empty();
+		}
+
+		String errorMessage = this.getErrorMessage(this.messageKey, definitionName);
+		return this.definitionNamePattern.matcher(definitionName).matches() ? Optional.empty() : Optional.of(errorMessage);
+	}
+
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/definition/DefinitionService.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/definition/DefinitionService.java
@@ -22,6 +22,8 @@ package org.iplass.mtp.impl.definition;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.iplass.mtp.definition.Definition;
 import org.iplass.mtp.definition.TypedDefinitionManager;
@@ -191,6 +193,82 @@ public class DefinitionService implements Service {
 	public String getDefinitionName(String path) {
 		//Definitionクラスが未指定の場合は、Pathの先頭からチェックして返す
 		return contextNode.toName(path);
+	}
+
+	/**
+	 * メタデータ定義名チェック
+	 * 
+	 * @param <M> メタデータの型
+	 * @param metaType メタデータのクラス
+	 * @param path パス
+	 * @param defName 定義名
+	 * @return チェックエラーメッセージ
+	 */
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public <M extends RootMetaData> Optional<String> checkDefinitionName(Class<M> metaType, String path, String defName) {
+		if (Objects.isNull(metaType)) {
+			return Optional.empty();
+		}
+
+		// メタデータ定義Map取得
+		DefinitionMetaDataTypeMap typeMap = getByMeta(metaType);
+		if (Objects.isNull(typeMap)) {
+			return Optional.empty();
+
+		}
+
+		return typeMap.checkDefinitionName(path, defName);
+	}
+
+	/**
+	 * メタデータ定義名チェック（パスチェックは実施しない）
+	 * 
+	 * @param <M> メタデータの型
+	 * @param metaType メタデータのクラス
+	 * @param defName 定義名
+	 * @return チェックエラーメッセージ
+	 */
+	public <M extends RootMetaData> Optional<String> checkDefinitionNameWithoutPath(Class<M> metaType, String defName) {
+		return this.checkDefinitionName(metaType, null, defName);
+	}
+
+	/**
+	 * メタデータ定義名チェック
+	 * 
+	 * 
+	 * @param <D> 定義の型
+	 * @param defType 定義のクラス
+	 * @param path パス
+	 * @param defName 定義名
+	 * @return チェックエラーメッセージ
+	 */
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public <D extends Definition> Optional<String> checkDefinitionNameByType(Class<D> defType, String path, String defName) {
+		if (Objects.isNull(defType)) {
+			return Optional.empty();
+		}
+
+		// メタデータ定義Map取得
+		DefinitionMetaDataTypeMap typeMap = getByDef(defType);
+		if (Objects.isNull(typeMap)) {
+			return Optional.empty();
+
+		}
+
+		return typeMap.checkDefinitionName(null, defName);
+	}
+
+	/**
+	 * メタデータ定義名チェック（パスチェックは実施しない）
+	 * 
+	 * 
+	 * @param <D> 定義の型
+	 * @param defType 定義のクラス
+	 * @param defName 定義名
+	 * @return チェックエラーメッセージ
+	 */
+	public <D extends Definition> Optional<String> checkDefinitionNameByTypeWithoutPath(Class<D> defType, String defName) {
+		return this.checkDefinitionNameByType(defType, null, defName);
 	}
 
 	private static class MetaDataContextNode<D extends Definition> {

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/entity/EntityDefinitionNameChecker.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/entity/EntityDefinitionNameChecker.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2025 DENTSU SOKEN INC. All Rights Reserved.
+ */
+
+package org.iplass.mtp.impl.entity;
+
+import org.iplass.mtp.impl.definition.DefinitionNameChecker;
+
+/**
+ * Entity定義名Checkerクラス
+ * 
+ * TODO EntityViewなどでも利用する
+ */
+public class EntityDefinitionNameChecker extends DefinitionNameChecker {
+
+	public EntityDefinitionNameChecker() {
+		super("^[a-zA-Z_][0-9a-zA-Z_]*(\\.[a-zA-Z_][0-9a-zA-Z_]*)*$", "impl.entity.EntityDefinitionNameChecker.invalidPattern");
+	}
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/entity/EntityService.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/entity/EntityService.java
@@ -48,6 +48,7 @@ import org.iplass.mtp.impl.datastore.strategy.ApplyMetaDataStrategy;
 import org.iplass.mtp.impl.datastore.strategy.EntityStoreStrategy;
 import org.iplass.mtp.impl.definition.AbstractTypedMetaDataService;
 import org.iplass.mtp.impl.definition.DefinitionMetaDataTypeMap;
+import org.iplass.mtp.impl.definition.DefinitionNameChecker;
 import org.iplass.mtp.impl.entity.property.MetaProperty;
 import org.iplass.mtp.impl.entity.versioning.NonVersionController;
 import org.iplass.mtp.impl.entity.versioning.NumberbaseVersionController;
@@ -95,6 +96,11 @@ public class EntityService extends AbstractTypedMetaDataService<MetaEntity, Enti
 		@Override
 		public String toDefName(String path) {
 			return path.substring(pathPrefix.length()).replace("/", ".");
+		}
+
+		@Override
+		protected DefinitionNameChecker createDefinitionNameChecker() {
+			return new EntityDefinitionNameChecker();
 		}
 	}
 
@@ -179,6 +185,8 @@ public class EntityService extends AbstractTypedMetaDataService<MetaEntity, Enti
 	}
 
 	private String doCreate(final MetaEntity newMeta, final MetaDataConfig config, final EntityContext context, boolean doAutoReload) {
+		// メタデータ定義名チェック TODO Entityはメタデータ登録時にcreateMetaDataメソッドが呼ばれないので個別にチェックする
+		this.checkDefinitionName(newMeta);
 
 		//TODO 同名のメタデータ存在チェック、設定値の妥当性の検証など
 
@@ -453,6 +461,14 @@ public class EntityService extends AbstractTypedMetaDataService<MetaEntity, Enti
 	}
 
 	public Future<String> updateDataModelSchema(final MetaEntity newMeta, final MetaDataConfig config) {
+		// メタデータ定義名チェック
+		// TODO Entityはメタデータ更新時にupdateMetaDataメソッドが呼ばれないので個別にチェックする
+		// TODO 更新時はEntityRuntimeExceptionスローしないとAdminConsole側でエラーハンドリングができない
+		try {
+			this.checkDefinitionName(newMeta);
+		} catch (MetaDataRuntimeException e) {
+			throw new EntityRuntimeException(e.getMessage(), e);
+		}
 
 		//非同期でスキーマ変更する。
 		//TODO 同名のメタデータ存在チェック、設定値の妥当性の検証など

--- a/iplass-core/src/main/resources/mtp-core-messages_ja.properties
+++ b/iplass-core/src/main/resources/mtp-core-messages_ja.properties
@@ -65,6 +65,8 @@ impl.csv.EntityCsvReader.invalidValue                                           
 impl.csv.EntityCsvReader.invalidValueType                                             = プロパティ名[{0}]のデータの型変換で失敗しました。型は{1}ですが、値には{2}が設定されています。
 impl.csv.EntityCsvReader.mismatchHeadSize                                             = データの項目数がヘッダーの項目数と一致しません。 (ヘッダ＝{0}、データ＝{1})
 impl.csv.EntityCsvReader.rowError                                                     = {0}行目：{1}
+impl.definition.DefinitionNameChecker.invalidPattern                                  = 名前には英数字、ハイフン、アンダースコア、スラッシュ、ピリオドのみ利用することができます。名前：{0}
+impl.definition.DefinitionService.invalidPath                                         = パスの指定に誤りがあります。
 impl.datastore.schemalessrdb.strategy.SLREntityStoreStrategy.alreadyOperated          = 対象のデータは、既に更新されたか削除されました。
 impl.entity.auth.EntityAuthInterceptor.noDelete                                       = {0}の削除権限がないか、一部のデータ範囲に対する削除権限がありません。
 impl.entity.auth.EntityAuthInterceptor.noDeleteAll                                    = {0}の一部のデータ範囲に対する削除権限がありません。
@@ -75,6 +77,7 @@ impl.entity.auth.EntityAuthInterceptor.noUndo                                   
 impl.entity.auth.EntityAuthInterceptor.noUndoAll                                      = {0}の一部のデータ範囲に対する削除（復活）権限がありません。
 impl.entity.auth.EntityAuthInterceptor.noUpdate                                       = {0}の更新権限がありません。
 impl.entity.auth.EntityAuthInterceptor.noUpdateProperty                               = {0}の項目：{1}の更新権限がありません。
+impl.entity.EntityDefinitionNameChecker.invalidPattern                                = 名前には英数字、アンダースコアのみ利用することができます。先頭は英字のみ利用することができます。パスにはピリオドを利用します。名前：{0}
 impl.entity.queryTimeout                                                              = 検索処理がタイムアウトしました。
 impl.lob.Lob.cantUpdate                                                               = 対象のデータは既に削除されたか、別ユーザーにて更新処理中のため、更新ができませんでした。
 impl.lob.LobHandler.cantUpdate                                                        = 対象のデータは既に削除されたか、別ユーザーにて更新処理中のため、更新ができませんでした。

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/EntityViewService.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/EntityViewService.java
@@ -24,6 +24,8 @@ import org.iplass.mtp.ManagerLocator;
 import org.iplass.mtp.definition.TypedDefinitionManager;
 import org.iplass.mtp.impl.definition.AbstractTypedMetaDataService;
 import org.iplass.mtp.impl.definition.DefinitionMetaDataTypeMap;
+import org.iplass.mtp.impl.definition.DefinitionNameChecker;
+import org.iplass.mtp.impl.entity.EntityDefinitionNameChecker;
 import org.iplass.mtp.spi.Config;
 import org.iplass.mtp.spi.Service;
 import org.iplass.mtp.view.generic.EntityView;
@@ -53,6 +55,11 @@ public class EntityViewService extends AbstractTypedMetaDataService<MetaEntityVi
 		@Override
 		public String toDefName(String path) {
 			return path.substring(pathPrefix.length()).replace("/", ".");
+		}
+
+		@Override
+		protected DefinitionNameChecker createDefinitionNameChecker() {
+			return new EntityDefinitionNameChecker();
 		}
 	}
 

--- a/iplass-gem/src/main/resources/mtp-gem-messages_ja.properties
+++ b/iplass-gem/src/main/resources/mtp-gem-messages_ja.properties
@@ -504,3 +504,6 @@ layout.preview.updatedPreviewDateMsg = プレビュー日時を変更しまし�
 menu.menu.home   = ホーム
 menu.menu.menu   = メニュー
 menu.menu.widget = ウィジェット
+
+view.generic.EntityViewRuntime.viewCheckErr    = View名【{0}】に指定できない文字が含まれています。View名には英数字、ハイフン、アンダースコア、ピリオドのみ利用することができます。
+view.generic.EntityViewRuntime.settingCheckErr = Viewの管理：View名【{0}】に指定できない文字が含まれています。View名には英数字、ハイフン、アンダースコア、ピリオドのみ利用することができます。

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/metaport/MetaDataImportHandlerImpl.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/metaport/MetaDataImportHandlerImpl.java
@@ -20,14 +20,18 @@
 
 package org.iplass.mtp.impl.tools.metaport;
 
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import org.iplass.mtp.impl.definition.DefinitionService;
 import org.iplass.mtp.impl.entity.EntityService;
 import org.iplass.mtp.impl.entity.MetaEntity;
 import org.iplass.mtp.impl.metadata.MetaDataConfig;
 import org.iplass.mtp.impl.metadata.MetaDataContext;
 import org.iplass.mtp.impl.metadata.MetaDataEntry;
+import org.iplass.mtp.impl.metadata.MetaDataRuntimeException;
 import org.iplass.mtp.impl.metadata.RootMetaData;
 import org.iplass.mtp.impl.tenant.MetaTenantService;
 import org.iplass.mtp.impl.util.KeyGenerator;
@@ -41,10 +45,12 @@ public class MetaDataImportHandlerImpl implements MetaDataImportHandler {
 	private static Logger auditLogger = LoggerFactory.getLogger("mtp.audit.porting.metadata");
 
 	private EntityService ehService;
+	private DefinitionService definitionService;
 
 	@Override
 	public void inited(MetaDataPortingService service, Config config) {
 		ehService = config.getDependentService(EntityService.class);
+		definitionService = config.getDependentService(DefinitionService.class);
 	}
 
 	@Override
@@ -55,6 +61,9 @@ public class MetaDataImportHandlerImpl implements MetaDataImportHandler {
 	public void storeMetaData(String path, RootMetaData importMeta, MetaDataEntry entry, boolean doAutoReload) {
 
 		auditLogger.info("store metadata," + importMeta.getClass().getName() + ",path:" + path);
+
+		// メタデータ定義名チェック TODO Entity以外はこのメソッド内でMetaDataContext呼び出してしまってるためチェック処理の追加が必要
+		this.checkDefinitionName(path, importMeta);
 
 		if (StringUtil.isEmpty(importMeta.getId())) {
 			importMeta.setId((new KeyGenerator()).generateId());
@@ -79,6 +88,9 @@ public class MetaDataImportHandlerImpl implements MetaDataImportHandler {
 
 		auditLogger.info("update metadata," + importMeta.getClass().getName() + ",path:" + path);
 
+		// メタデータ定義名チェック TODO Entity以外はこのメソッド内でMetaDataContext呼び出してしまってるためチェック処理の追加が必要
+		this.checkDefinitionName(path, importMeta);
+
 		if (importMeta instanceof MetaEntity) {
 			updateMetaEntity(path, (MetaEntity)importMeta, entry, doAutoReload);
 		} else {
@@ -100,6 +112,17 @@ public class MetaDataImportHandlerImpl implements MetaDataImportHandler {
 			throw new MetaDataPortingRuntimeException("exception occured during entity definition update:" + e.getCause().getMessage(), e);
 		} catch (InterruptedException e) {
 			throw new MetaDataPortingRuntimeException("execution interrrupted during entity definition update:" + e.getMessage(), e);
+		}
+	}
+
+	private void checkDefinitionName(String path, RootMetaData importMeta) throws MetaDataRuntimeException {
+		if (StringUtil.isEmpty(path) || Objects.isNull(importMeta)) {
+			return;
+		}
+
+		Optional<String> errorMessage = definitionService.checkDefinitionName(importMeta.getClass(), path, importMeta.getName());
+		if (errorMessage.isPresent()) {
+			throw new MetaDataRuntimeException(errorMessage.get());
 		}
 	}
 

--- a/iplass-tools/src/main/resources/mtp-tools-service-config.xml
+++ b/iplass-tools/src/main/resources/mtp-tools-service-config.xml
@@ -48,6 +48,7 @@
 		<depend>org.iplass.mtp.impl.core.TenantContextService</depend>
 		<depend>org.iplass.mtp.impl.entity.EntityService</depend>
 		<depend>org.iplass.mtp.impl.auth.AuthService</depend>
+		<depend>org.iplass.mtp.impl.definition.DefinitionService</depend>
 
 		<property name="importHandler" class="org.iplass.mtp.impl.tools.metaport.MetaDataImportHandlerImpl" />
 	</service>


### PR DESCRIPTION
<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->
fixes #1699 

- AdminConsoleにてメタデータ登録更新時にメタデータ定義名チェック追加
- Tools（メタデータインポートなど）にてメタデータ定義名チェック追加
- メタデータ定義関連WebAPIやカスタムコード（[AbstractTypedDefinitionManager](https://github.com/dentsusoken/iPLAss/blob/master/iplass-core/src/main/java/org/iplass/mtp/impl/definition/AbstractTypedDefinitionManager.java)経由でのメタデータ更新）でのメタデータ更新時にメタデータ定義名チェック追加
- EntityViewにてView名のチェックを追加（CheckStatus）

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->

## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->