### PR TITLE
GEM: 多重度が1以上のプロパティを未入力のまま一括更新すると、画面の表示が崩れる（3.2）

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/bulk/bulkEdit.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/bulk/bulkEdit.jsp
@@ -83,7 +83,9 @@
 	String getPropertyDisplayValue(PropertyDefinition p, Object propValue, PropertyEditor editor) {
 		String dispValue = "";
 		boolean isMultiple = p.getMultiplicity() != 1;
-		if (isMultiple) {
+		if (propValue == null) {
+			return "";
+		} else if (isMultiple) {
 			Object[] values = (Object[]) propValue;
 			String[] tmp = new String[values.length];
 			for (int i = 0; i < values.length; i++) {


### PR DESCRIPTION
## 対応内容
backport of #1811 
closes #1813 

## 動作確認・スクリーンショット（任意）
4.0と同じケースを使用してテストを実施しました
※ケースが完全に一致しているため、エビデンスは作成しておりません。
## レビュー観点・補足情報（任意）
