### PR TITLE
GEM: 参照プロパティの自動補完が一部の表示形式・多重度で正しく反映されない

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyAutocompletion.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyAutocompletion.jsp
@@ -94,6 +94,11 @@ if (multiplicity == 1) {
 }
 
 var _propName = propName.replace(/\[/g, "\\[").replace(/\]/g, "\\]").replace(/\./g, "\\.");
+var clearReferenceItems = function() {
+	if (value.length > 0) {
+		$("#ul_" + _propName).children("li").remove();
+	}
+};
 <%
 	if (editor.getDisplayType() == ReferenceDisplayType.LINK) {
 %>
@@ -101,9 +106,7 @@ var callback = function() {
 	toggleRefInsertBtn("ul_" + _propName, multiplicity, "ins_btn_" + _propName);
 };
 
-if (value.length > 0) {
-	$("#ul_" + _propName).children("li").remove();
-}
+clearReferenceItems();
 for (var i = 0; i < value.length; i++) {
 	if (!value[i]) {
 		continue;
@@ -159,9 +162,7 @@ var callback = function() {
 	toggleRefInsertBtn("ul_" + _propName, multiplicity, "ins_btn_" + _propName);
 };
 
-if (value.length > 0) {
-	$("#ul_" + _propName).children("li").remove();
-}
+clearReferenceItems();
 for (var i = 0; i < value.length; i++) {
 	if (!value[i]) {
 		continue;

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyAutocompletion.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyAutocompletion.jsp
@@ -101,8 +101,10 @@ var callback = function() {
 	toggleRefInsertBtn("ul_" + _propName, multiplicity, "ins_btn_" + _propName);
 };
 
+if (value.length > 0) {
+	$("#ul_" + _propName).children("li").remove();
+}
 for (var i = 0; i < value.length; i++) {
-	$("#li_" + _propName + i).remove();
 	if (!value[i]) {
 		continue;
 	}
@@ -157,8 +159,10 @@ var callback = function() {
 	toggleRefInsertBtn("ul_" + _propName, multiplicity, "ins_btn_" + _propName);
 };
 
+if (value.length > 0) {
+	$("#ul_" + _propName).children("li").remove();
+}
 for (var i = 0; i < value.length; i++) {
-	$("#li_" + _propName + i).remove();
 	if (!value[i]) {
 		continue;
 	}
@@ -170,26 +174,42 @@ toggleRefInsertBtn("ul_" + _propName, multiplicity, "ins_btn_" + _propName);
 <%
 	} else if (editor.getDisplayType() == ReferenceDisplayType.UNIQUE) {
 %>
+<%-- Dummy行が存在するので multiplicity + 1。ただし無制限(-1)は-1のまま(canAddItemの無制限判定を壊さない) --%>
+var uniqueMultiplicity = (multiplicity == -1 ? -1 : multiplicity + 1);
 var callback = function() {
-	<%-- Dummy行が存在するので、 multiplicity + 1 --%>
-	toggleRefInsertBtn("ul_" + _propName, multiplicity + 1, "id_addBtn_" + _propName);
+	toggleRefInsertBtn("ul_" + _propName, uniqueMultiplicity, "id_addBtn_" + _propName);
 };
 
-if (value.length > 0) {
-	$("#ul_" + _propName).children(":visible").remove();
-}
+<%-- 設定すべき実値(非null)が1件でもあるか --%>
+var hasValue = false;
 for (var i = 0; i < value.length; i++) {
-	if (!value[i]) {
-		continue;
+	if (value[i]) {
+		hasValue = true;
+		break;
 	}
-	var key = value[i].oid + "_" + (value[i].version ? value[i].version : "0");
-	var label = <%=editor.getDisplayLabelItem() == null ? "value[i].name" : "value[i]." + editor.getDisplayLabelItem() %>;
-	var unique = <%="value[i]." + editor.getUniqueItem() %>;
-	<%-- Dummy行が存在するので、 multiplicity + 1 --%>
-	addUniqueReference("<%=viewAction %>", key, label, unique, "<%=defName %>", propName, multiplicity + 1, "ul_" + _propName, "id_li_" + propName + "Dummmy", <%=refEdit%>, "id_count_" + propName, callback ,"<%=parentDefName%>", "<%=parentViewName%>", "<%=viewType%>", null, "<%=entityOid%>", "<%=entityVersion%>");
 }
-<%-- Dummy行が存在するので、 multiplicity + 1 --%>
-toggleRefInsertBtn("ul_" + _propName, multiplicity + 1, "id_addBtn_" + _propName);
+
+if (value.length == 0) {
+	<%-- 空配列(対象データなし) → 既存値を維持するため何もしない(他表示形式の多数派に合わせる) --%>
+} else if (!hasValue) {
+	<%-- null(該当なし)返却 → 入力行は消さず値のみクリアして入力可能な状態を維持する --%>
+	$("#ul_" + _propName).children(":visible").each(function() {
+		$(":text", this).val("").change();
+	});
+} else {
+	<%-- 実値あり → 可視の入力行を全消しして返却結果で作り直す --%>
+	$("#ul_" + _propName).children(":visible").remove();
+	for (var i = 0; i < value.length; i++) {
+		if (!value[i]) {
+			continue;
+		}
+		var key = value[i].oid + "_" + (value[i].version ? value[i].version : "0");
+		var label = <%=editor.getDisplayLabelItem() == null ? "value[i].name" : "value[i]." + editor.getDisplayLabelItem() %>;
+		var unique = <%="value[i]." + editor.getUniqueItem() %>;
+		addUniqueReference("<%=viewAction %>", key, label, unique, "<%=defName %>", propName, uniqueMultiplicity, "ul_" + _propName, "id_li_" + propName + "Dummmy", <%=refEdit%>, "id_count_" + propName, callback ,"<%=parentDefName%>", "<%=parentViewName%>", "<%=viewType%>", null, "<%=entityOid%>", "<%=entityVersion%>");
+	}
+}
+toggleRefInsertBtn("ul_" + _propName, uniqueMultiplicity, "id_addBtn_" + _propName);
 <%
 	} else if (editor.getDisplayType() == ReferenceDisplayType.LABEL) {
 %>


### PR DESCRIPTION
## 対応内容
詳細画面の ReferencePropertyEditor 自動補完（ReferencePropertyAutocompletion.jsp）の不具合を修正。
- Link/Tree形式(多重度1): 連続補完で古い選択値が残り重複追加される不具合を修正。 削除はindexベースID・追加はoid_versionベースIDでID体系が不一致だったため、 位置ごとの削除をやめ、検索画面と同じ「全削除→再構築」に統一。
- Unique形式(多重度1): nullが返ると入力欄・ボタンが消えて入力できなくなる不具合を修正。 入力行は削除せず値のみクリアして入力可能状態を維持。
- Unique形式(多重度-1/無制限): 値が追加されない不具合を修正。 multiplicity+1が0になりcanAddItemが常にfalseとなっていたため、 -1は-1のまま渡すよう補正。
- 「対象データなし」時の挙動を他表示形式の多数派に統一（null→クリア／空配列→維持）。
closes #1111 


## 動作確認・スクリーンショット（任意）
自動補完機能を設定した詳細画面で動作確認
LINK形式、TREE形式、Unique形式の多重度1と多重度-1の項目で自動補完時の動作を確認
複数の参照先に切り替えて問題ないことを確認

## レビュー観点・補足情報（任意）
