### PR TITLE
PostgreSQL/SQL Server利用時、SelectValueプロパティをソート条件にdistinctして検索するとSQL例外が発生する

### DIFF
--- a/iplass-core/src/main/java/org/iplass/mtp/impl/datastore/DataStore.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/datastore/DataStore.java
@@ -36,4 +36,10 @@ public abstract class DataStore implements ServiceInitListener<StoreService> {
 	public abstract Class<? extends MetaEntityStore> getEntityStoreType();
 
 	public abstract int stringPropertyStoreMaxLength(MetaStoreMapping metaStoreMapping);
+
+	/**
+	 * SELECT DISTINCT時に、ORDER BYで指定した式（列そのものでなく式自体）がSELECT句に
+	 * 含まれていないとエラーとなるDataStoreを利用している場合に<code>true</code>を返却。
+	 */
+	public abstract boolean isRequireOrderByExpressionInSelectForDistinct();
 }

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/datastore/grdb/GRdbDataStore.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/datastore/grdb/GRdbDataStore.java
@@ -56,6 +56,7 @@ public class GRdbDataStore extends RdbDataStore {
 	private Map<String, String> overwriteTableNamePostfixMap;
 
 	private Integer stringTypeLengthOnQuery;
+	private boolean requireOrderByExpressionInSelectForDistinct;
 
 	/** 強制的なテーブル名接尾辞の再生成（true の場合に再生成する） */
 	private boolean forceRegenerateTableNamePostfix;
@@ -172,6 +173,9 @@ public class GRdbDataStore extends RdbDataStore {
 
 		entityStore = new GRdbEntityStoreStrategy(this, rdb, cs);
 		applyMeta = new GRdbApplyMetaDataStrategy(this, rdb);
+
+		//RDB毎で判断するものとする
+		requireOrderByExpressionInSelectForDistinct = rdb.isRequireOrderByExpressionInSelectForDistinct();
 	}
 
 	@Override
@@ -221,4 +225,10 @@ public class GRdbDataStore extends RdbDataStore {
 		StorageSpaceMap ssm = getStorageSpaceMapOrDefault((MetaSchemalessRdbStoreMapping) metaStoreMapping);
 		return ssm.getVarcharColumnLength();
 	}
+
+	@Override
+	public boolean isRequireOrderByExpressionInSelectForDistinct() {
+		return requireOrderByExpressionInSelectForDistinct;
+	}
+
 }

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/entity/VirtualPropertyAdapter.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/entity/VirtualPropertyAdapter.java
@@ -217,6 +217,13 @@ public class VirtualPropertyAdapter extends ASTTransformerSupport implements Sea
 
 	private SearchResultIterator iterator;
 
+	//SELECT DISTINCT時に、ORDER BYで指定したSELECT型項目のソート用CASE式を、
+	//SELECT句にも追加するか否か（PostgreSQLやSQL Serverなど、ORDER BYの式自体がSELECT句に
+	//含まれていないとエラーとなるRDB向けの対応）
+	private boolean addOrderByCaseToSelectOnDistinct;
+	//上記の追加対象となったCASE式（transformedQueryのSelect句へ追加する為に退避しておく）
+	private List<Case> additionalSelectCasesForDistinctOrderBy;
+
 	public VirtualPropertyAdapter(Query query, EntityContext ec, EntityHandler eh) {
 		selectFieldMap = new HashMap<ValueExpression, FieldMapping>();
 		selectFieldList = new ArrayList<>(query.getSelect()
@@ -225,6 +232,8 @@ public class VirtualPropertyAdapter extends ASTTransformerSupport implements Sea
 		this.query = query;
 		this.ec = ec;
 		this.eh = eh;
+		this.addOrderByCaseToSelectOnDistinct = eh.getDataStore()
+				.isRequireOrderByExpressionInSelectForDistinct();
 		loadAdaptorMap = new HashMap<>();
 	}
 
@@ -292,6 +301,14 @@ public class VirtualPropertyAdapter extends ASTTransformerSupport implements Sea
 	public Query getTransformedQuery() {
 		if (transformedQuery == null) {
 			transformedQuery = (Query) query.accept(this);
+
+			//DISTINCT時にORDER BYの式をSELECT句に要求するRDB向けに退避しておいたCASE式を追加
+			if (additionalSelectCasesForDistinctOrderBy != null) {
+				for (Case cs : additionalSelectCasesForDistinctOrderBy) {
+					transformedQuery.getSelect()
+							.add(cs);
+				}
+			}
 
 			//subqueryのon内のReference名指定（もしくはTHIS指定）をoidでの結合に変換する。
 			transformedQuery.accept(new ThisRefNormalizer(ec, eh, null));
@@ -624,11 +641,48 @@ public class VirtualPropertyAdapter extends ASTTransformerSupport implements Sea
 								.getValue(), false)), new Literal(Long.valueOf(i), false));
 					}
 					cs.elseClause(new Literal(null, false));
+
+					//PostgreSQLやSQL Serverなど、SELECT DISTINCT時にORDER BYで指定した式自体が
+					//SELECT句に含まれていないとエラーとなるRDBの為、対象プロパティが既にSELECT句に
+					//含まれている場合（＝CASE式を追加してもDISTINCTの結果件数が変わらない場合）に限り、
+					//ソート用のCASE式をSELECT句にも追加する。
+					//（top-levelのクエリのみ対象。サブクエリは非対応。）
+					if (!isSubQuery && addOrderByCaseToSelectOnDistinct
+							&& query.getSelect().isDistinct()
+							&& isSelectedField((EntityField) order.getSortKey())) {
+						if (additionalSelectCasesForDistinctOrderBy == null) {
+							additionalSelectCasesForDistinctOrderBy = new ArrayList<>();
+						}
+						//ORDER BY側とは別インスタンスとする為copyする
+						additionalSelectCasesForDistinctOrderBy.add((Case) cs.copy());
+					}
+
 					return new SortSpec(cs, order.getType(), order.getNullOrderingSpec());
 				}
 			}
 		}
 		return super.visit(order);
+	}
+
+	/**
+	 * SELECT句に、指定のEntityField（プロパティ名・配列添字が一致するもの）が
+	 * 含まれているかを判定する。
+	 *
+	 * @param sortKey 判定対象のEntityField
+	 * @return 含まれている場合<code>true</code>
+	 */
+	private boolean isSelectedField(EntityField sortKey) {
+		List<ValueExpression> selectValues = query.getSelect()
+				.getSelectValues();
+		if (selectValues == null) {
+			return false;
+		}
+		for (ValueExpression v : selectValues) {
+			if (v instanceof EntityField && v.equals(sortKey)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 }

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/entity/VirtualPropertyAdapter.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/entity/VirtualPropertyAdapter.java
@@ -648,7 +648,8 @@ public class VirtualPropertyAdapter extends ASTTransformerSupport implements Sea
 					//ソート用のCASE式をSELECT句にも追加する。
 					//（top-levelのクエリのみ対象。サブクエリは非対応。）
 					if (!isSubQuery && addOrderByCaseToSelectOnDistinct
-							&& query.getSelect().isDistinct()
+							&& query.getSelect()
+									.isDistinct()
 							&& isSelectedField((EntityField) order.getSortKey())) {
 						if (additionalSelectCasesForDistinctOrderBy == null) {
 							additionalSelectCasesForDistinctOrderBy = new ArrayList<>();

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/rdb/adapter/RdbAdapter.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/rdb/adapter/RdbAdapter.java
@@ -689,4 +689,18 @@ public abstract class RdbAdapter {
 	public String getMultiTableTrickClauseForUpdate() {
 		return null;
 	}
+
+	/**
+	 * SELECT DISTINCT時に、ORDER BYで指定した式（列そのものでなく式自体）がSELECT句に
+	 * 含まれていないとエラーとなるRDBの場合に<code>true</code>を返します。
+	 * <p>
+	 * PostgreSQLやSQL Serverが該当します（Oracleは、ORDER BYの式内で参照している列がSELECT句に
+	 * 含まれていれば、式自体が含まれていなくてもエラーとならない為、対象外です）。
+	 * </p>
+	 *
+	 * @return 該当する場合は<code>true</code>を返します。
+	 */
+	public boolean isRequireOrderByExpressionInSelectForDistinct() {
+		return false;
+	}
 }

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/rdb/postgresql/PostgreSQLRdbAdapter.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/rdb/postgresql/PostgreSQLRdbAdapter.java
@@ -844,4 +844,9 @@ public class PostgreSQLRdbAdapter extends RdbAdapter {
 		}
 	}
 
+	@Override
+	public boolean isRequireOrderByExpressionInSelectForDistinct() {
+		return true;
+	}
+
 }

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/rdb/sqlserver/SqlServerRdbAdapter.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/rdb/sqlserver/SqlServerRdbAdapter.java
@@ -866,4 +866,9 @@ public class SqlServerRdbAdapter extends RdbAdapter {
 
 		return sb.toString();
 	}
+
+	@Override
+	public boolean isRequireOrderByExpressionInSelectForDistinct() {
+		return true;
+	}
 }


### PR DESCRIPTION
closes #2160

<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
PostgreSQL/SQL Server利用時、
SelectValueプロパティをソート条件にdistinctして検索する場合に、
当該SelectValueのorder by に指定したCASE文をselect項目に追加する。

