### PR TITLE
GEM: Reference型Propertyを表示タイプ：UNIQUEで編集する際のエラーメッセージ改善 対応

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/common.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/common.js
@@ -2885,6 +2885,11 @@ function searchUniqueReference(id, selectAction, viewAction, defName, propName, 
 		});
 
 		var key = selectArray[0];
+		if (typeof key === "undefined" || key == null || key === "") {
+			alert(scriptContext.gem.locale.reference.notSelectedData);
+			return;
+		}
+
 		// 重複チェック （自分を除く）
 		if (key in refs && !$(refs[key]).is("#" + _id)) {
 			alert(scriptContext.gem.locale.reference.duplicateData);

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/common.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/common.js
@@ -2885,7 +2885,9 @@ function searchUniqueReference(id, selectAction, viewAction, defName, propName, 
 		});
 
 		var key = selectArray[0];
-		if (typeof key === "undefined" || key == null || key === "") {
+		
+		// 未選択の場合は処理を中断する
+		if (key == null || key === "") {
 			alert(scriptContext.gem.locale.reference.notSelectedData);
 			return;
 		}

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/i18n/gem-locale-en.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/i18n/gem-locale-en.js
@@ -50,6 +50,7 @@ scriptContext.gem.locale.reference.deleteBtn = "Delete";
 scriptContext.gem.locale.reference.deleteLabel = "Delete";
 scriptContext.gem.locale.reference.detail = "Detail";
 scriptContext.gem.locale.reference.duplicateData = "Duplicate data.";
+scriptContext.gem.locale.reference.notSelectedData = "Target data has not been selected.";
 scriptContext.gem.locale.reference.edit = "Edit";
 scriptContext.gem.locale.reference.noResult = "Data not found.";
 scriptContext.gem.locale.reference.pleaseSelectAny = "Please Select {0}";

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/i18n/gem-locale-ja.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/i18n/gem-locale-ja.js
@@ -50,6 +50,7 @@ scriptContext.gem.locale.reference.deleteBtn = "削除";
 scriptContext.gem.locale.reference.deleteLabel = "削除";
 scriptContext.gem.locale.reference.detail = "詳細";
 scriptContext.gem.locale.reference.duplicateData = "重複のデータ。";
+scriptContext.gem.locale.reference.notSelectedData = "対象データが未選択です。";
 scriptContext.gem.locale.reference.edit = "編集";
 scriptContext.gem.locale.reference.noResult = "データが見つかりません。";
 scriptContext.gem.locale.reference.pleaseSelectAny = "{0} を選択してください";

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/i18n/gem-locale-th.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/i18n/gem-locale-th.js
@@ -50,6 +50,7 @@ scriptContext.gem.locale.reference.deleteBtn = "ลบ";
 scriptContext.gem.locale.reference.deleteLabel = "ลบ";
 scriptContext.gem.locale.reference.detail = "รายละเอียด";
 scriptContext.gem.locale.reference.duplicateData = "ข้อมูลที่ซ้ำกัน";
+scriptContext.gem.locale.reference.notSelectedData = "ยังไม่ได้เลือกข้อมูลเป้าหมาย";
 scriptContext.gem.locale.reference.edit = "แก้ไข";
 scriptContext.gem.locale.reference.noResult = "ไม่พบข้อมูล";
 scriptContext.gem.locale.reference.pleaseSelectAny = "กรุณาเลือก {0}";

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/i18n/gem-locale-zh-CN.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/i18n/gem-locale-zh-CN.js
@@ -49,6 +49,7 @@ scriptContext.gem.locale.reference.deleteBtn = "删除";
 scriptContext.gem.locale.reference.deleteLabel = "删除";
 scriptContext.gem.locale.reference.detail = "详细";
 scriptContext.gem.locale.reference.duplicateData = "重复的数据。";
+scriptContext.gem.locale.reference.notSelectedData = "未选择目标数据。";
 scriptContext.gem.locale.reference.edit = "编辑";
 scriptContext.gem.locale.reference.noResult = "没找到数据。";
 scriptContext.gem.locale.reference.pleaseSelectAny = "请选择 {0}";

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/i18n/gem-locale-zh-TW.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/i18n/gem-locale-zh-TW.js
@@ -50,6 +50,7 @@ scriptContext.gem.locale.reference.deleteBtn = "刪除";
 scriptContext.gem.locale.reference.deleteLabel = "刪除";
 scriptContext.gem.locale.reference.detail = "詳細";
 scriptContext.gem.locale.reference.duplicateData = "重複的數據。";
+scriptContext.gem.locale.reference.notSelectedData = "未選擇目標數據。";
 scriptContext.gem.locale.reference.edit = "編輯";
 scriptContext.gem.locale.reference.noResult = "沒找到數據。";
 scriptContext.gem.locale.reference.pleaseSelectAny = "請選擇 {0}";


### PR DESCRIPTION
<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->
closes #2181 
## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->

- 編集画面でEditorの「選択」ボタンを開き、候補を何も選択せずに「確定」ボタンを押した際に表示されるエラーメッセージは　`対象データが未選択です。`　と表示されるようになりました。あわせて、多言語対応テストも実施しました。

## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->
