### PR TITLE
GEM: 日付や数値、真偽値型のPropertyをOIDとして指定しファイルアップロード画面でサンプルデータをダウンロードすると、空ファイ…

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/upload/EntityFileSampleDownloadCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/upload/EntityFileSampleDownloadCommand.java
@@ -577,7 +577,7 @@ public final class EntityFileSampleDownloadCommand implements Command {
 			}
 
 			if (value instanceof Boolean) {
-				value = (boolean) value ? "1" : "0";
+				return (boolean) value ? "1" : "0";
 			}
 			if (value instanceof Timestamp) {
 				SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/upload/EntityFileSampleDownloadCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/upload/EntityFileSampleDownloadCommand.java
@@ -26,6 +26,8 @@ import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -71,6 +73,7 @@ import org.iplass.mtp.impl.entity.fileport.EntityCsvWriteOption;
 import org.iplass.mtp.impl.entity.fileport.EntityCsvWriter;
 import org.iplass.mtp.impl.entity.fileport.EntityExcelWriteOption;
 import org.iplass.mtp.impl.entity.fileport.EntityExcelWriter;
+import org.iplass.mtp.impl.util.ConvertUtil;
 import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.util.DateUtil;
 import org.iplass.mtp.util.StringUtil;
@@ -416,11 +419,15 @@ public final class EntityFileSampleDownloadCommand implements Command {
 					}
 					continue;
 				} else if (pd instanceof DateTimeProperty) {
+					Timestamp currentDatetime = Timestamp.valueOf(
+							DateUtil.getCurrentTimestamp()
+									.toLocalDateTime()
+									.truncatedTo(ChronoUnit.SECONDS));
 					if (pd.getMultiplicity() == 1) {
-						entity.setValue(propName, DateUtil.getCurrentTimestamp());
+						entity.setValue(propName, currentDatetime);
 					} else {
 						entity.setValue(propName,
-								new Timestamp[] { DateUtil.getCurrentTimestamp(), DateUtil.getCurrentTimestamp() });
+								new Timestamp[] { currentDatetime, currentDatetime });
 					}
 					continue;
 				} else if (pd instanceof DecimalProperty) {
@@ -549,10 +556,11 @@ public final class EntityFileSampleDownloadCommand implements Command {
 				String oidValue = "";
 				int cnt = 0;
 				for (String propName : ed.getOidPropertyName()) {
+					Object value = entity.getValue(propName);
 					if (cnt == 0) {
-						oidValue = entity.getValue(propName);
+						oidValue = convertToOid(value);
 					} else {
-						oidValue = oidValue + "-" + entity.getValue(propName);
+						oidValue = oidValue + "-" + convertToOid(value);
 					}
 					cnt++;
 				}
@@ -560,6 +568,23 @@ public final class EntityFileSampleDownloadCommand implements Command {
 					entity.setOid(oidValue);
 				}
 			}
+		}
+
+		private String convertToOid(Object value) {
+
+			if (value == null) {
+				return null;
+			}
+
+			if (value instanceof Boolean) {
+				value = (boolean) value ? "1" : "0";
+			}
+			if (value instanceof Timestamp) {
+				SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+				return format.format(value);
+			}
+
+			return ConvertUtil.convertToString(value);
 		}
 
 	}

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/upload/EntityFileSampleDownloadCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/upload/EntityFileSampleDownloadCommand.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.iplass.gem.GemConfigService;
@@ -551,42 +552,29 @@ public final class EntityFileSampleDownloadCommand implements Command {
 		}
 
 		private void setOidValue(Entity entity) {
-
 			if (ed.getOidPropertyName() != null) {
-				String oidValue = "";
-				int cnt = 0;
-				for (String propName : ed.getOidPropertyName()) {
-					Object value = entity.getValue(propName);
-					if (cnt == 0) {
-						oidValue = convertToOid(value);
-					} else {
-						oidValue = oidValue + "-" + convertToOid(value);
-					}
-					cnt++;
-				}
+				String oidValue = ed.getOidPropertyName()
+						.stream()
+						.map(propName -> convertToOid(entity.getValue(propName)))
+						.collect(Collectors.joining("-"));
 				if (StringUtil.isNotEmpty(oidValue)) {
 					entity.setOid(oidValue);
 				}
 			}
 		}
 
-		private String convertToOid(Object value) {
-
+		private static String convertToOid(Object value) {
 			if (value == null) {
 				return null;
 			}
-
-			if (value instanceof Boolean) {
-				return (boolean) value ? "1" : "0";
+			if (value instanceof Boolean oidValue) {
+				return oidValue ? "1" : "0";
 			}
-			if (value instanceof Timestamp) {
-				SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-				return format.format(value);
+			if (value instanceof Timestamp oidValue) {
+				return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").format(oidValue);
 			}
-
 			return ConvertUtil.convertToString(value);
 		}
-
 	}
 
 	private class CsvDownloadSampleWriter extends FileDownloadSampleWriter {

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/upload/EntityFileSampleDownloadCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/upload/EntityFileSampleDownloadCommand.java
@@ -26,6 +26,7 @@ import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -552,28 +553,27 @@ public final class EntityFileSampleDownloadCommand implements Command {
 
 		private void setOidValue(Entity entity) {
 			if (ed.getOidPropertyName() != null) {
+				SimpleDateFormat timestampFormat = DateUtil.getSimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", true);
 				String oidValue = ed.getOidPropertyName()
 						.stream()
-						.map(propName -> convertToOid(entity.getValue(propName)))
+						.map(propName -> {
+							Object object = entity.getValue(propName);
+							if (object == null) {
+								return "";
+							}
+							if (object instanceof Boolean value) {
+								return value ? "1" : "0";
+							}
+							if (object instanceof Timestamp value) {
+								return timestampFormat.format(value);
+							}
+							return ConvertUtil.convertToString(object);
+						})
 						.collect(Collectors.joining("-"));
 				if (StringUtil.isNotEmpty(oidValue)) {
 					entity.setOid(oidValue);
 				}
 			}
-		}
-
-		private static String convertToOid(Object value) {
-			if (value == null) {
-				return null;
-			}
-			if (value instanceof Boolean oidValue) {
-				return oidValue ? "1" : "0";
-			}
-			if (value instanceof Timestamp oidValue) {
-				return DateUtil.getSimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", true)
-						.format(oidValue);
-			}
-			return ConvertUtil.convertToString(value);
 		}
 	}
 

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/upload/EntityFileSampleDownloadCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/upload/EntityFileSampleDownloadCommand.java
@@ -26,7 +26,6 @@ import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.text.SimpleDateFormat;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -571,7 +570,8 @@ public final class EntityFileSampleDownloadCommand implements Command {
 				return oidValue ? "1" : "0";
 			}
 			if (value instanceof Timestamp oidValue) {
-				return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").format(oidValue);
+				return DateUtil.getSimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", true)
+						.format(oidValue);
 			}
 			return ConvertUtil.convertToString(value);
 		}


### PR DESCRIPTION
## 対応内容
- 日付系（Date、Time、DateTime）や数値、真偽値型のPropertyがOIDの場合でもキャストエラーが発生しないように
OIDを設定するときにStringにキャストする処理を追加。 
- DateTime型、Boolean型の場合はOIDの表示形式が想定と異なるため、
「アップロード後にEntityデータのOIDに登録される値」と同等になるように修正。
　・ `convertToOid()` で上記2つの場合のフォーマットを追加。
　・ DateTime型のサンプルデータのカンマ以降は切り捨てに修正。
closes #2166 

## 動作確認・スクリーンショット（任意）
- OIDが上記のプロパティの時に空ファイルにならないことを確認
- 生成したサンプルファイルで正常にインポートができることを確認

## レビュー観点・補足情報（任意）
