### PR TITLE
WEB: 暖気処理のステータスが処理中から変化しないことがある

### DIFF
--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/WarmupStatusServlet.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/WarmupStatusServlet.java
@@ -184,15 +184,11 @@ public class WarmupStatusServlet extends HttpServlet {
 					logger.error("Failed to change warmup status to FAILED.", e);
 				}
 
-				if (t instanceof Exception e) {
-					throw e;
+				switch (t) {
+				case Exception e -> throw e;
+				case Error e -> throw e;
+				default -> throw new RuntimeException(t);
 				}
-
-				if (t instanceof Error e) {
-					throw e;
-				}
-
-				throw new RuntimeException(t);
 			}
 		}
 

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/WarmupStatusServlet.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/WarmupStatusServlet.java
@@ -172,21 +172,27 @@ public class WarmupStatusServlet extends HttpServlet {
 
 				return null;
 
-			} catch (Throwable e) {
-				logger.error("Warmup failed.", e);
-				ServiceRegistry.getRegistry()
-						.getService(WarmupService.class)
-						.changeStatus(WarmupStatus.FAILED);
+			} catch (Throwable t) {
+				logger.error("Warmup failed.", t);
 
-				if (e instanceof Exception) {
-					throw (Exception) e;
+				try {
+					ServiceRegistry.getRegistry()
+							.getService(WarmupService.class)
+							.changeStatus(WarmupStatus.FAILED);
+
+				} catch (Exception e) {
+					logger.error("Failed to change warmup status to FAILED.", e);
 				}
 
-				if (e instanceof Error) {
-					throw (Error) e;
+				if (t instanceof Exception e) {
+					throw e;
 				}
 
-				throw new RuntimeException(e);
+				if (t instanceof Error e) {
+					throw e;
+				}
+
+				throw new RuntimeException(t);
 			}
 		}
 

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/WarmupStatusServlet.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/WarmupStatusServlet.java
@@ -136,6 +136,7 @@ public class WarmupStatusServlet extends HttpServlet {
 	 * ウォームアップタスク実行
 	 * <p>
 	 * サーブレットの初期化処理で非同期実行されるウォームアップ処理のエントリポイントです。
+	 * エントリポイントでは Throwable で例外をキャッチし、例外をキャッチした場合はステータスを失敗に変更します。
 	 * </p>
 	 */
 	protected static class WarmupTaskExecutor implements Callable<Void> {
@@ -171,8 +172,11 @@ public class WarmupStatusServlet extends HttpServlet {
 
 				return null;
 
-			} catch (Exception e) {
+			} catch (Throwable e) {
 				logger.error("Warmup failed.", e);
+				ServiceRegistry.getRegistry()
+						.getService(WarmupService.class)
+						.changeStatus(WarmupStatus.FAILED);;
 				throw e;
 			}
 		}

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/WarmupStatusServlet.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/WarmupStatusServlet.java
@@ -176,8 +176,17 @@ public class WarmupStatusServlet extends HttpServlet {
 				logger.error("Warmup failed.", e);
 				ServiceRegistry.getRegistry()
 						.getService(WarmupService.class)
-						.changeStatus(WarmupStatus.FAILED);;
-				throw e;
+						.changeStatus(WarmupStatus.FAILED);
+
+				if (e instanceof Exception) {
+					throw (Exception) e;
+				}
+
+				if (e instanceof Error) {
+					throw (Error) e;
+				}
+
+				throw new RuntimeException(e);
 			}
 		}
 


### PR DESCRIPTION
closes #2198 .

<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->
- 暖気処理で発生した例外は Throwable でキャッチする
- 例外をキャッチした場合、ステータスを FAILED に変更する

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->
- 暖気処理が終了し、 `/warmupStatus` を確認
    - すべて正常終了した場合は、 `complete (200)` になることを確認（status: COMPLETE）
    - Exception がスローされた場合は、 `failed (500)` になることを確認（status: FAILED）
    - Error がスローされた場合は、 `failed (500)` になることを確認（status: FAILED）

## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->
- Error がスローされた場合に想定通りの動作となるように修正しています。
- それ以外は、現状と変わらない動作を行います。