### PR TITLE
gwt compile を JavaExec で実現する

### DIFF
--- a/iplass-admin/build.gradle
+++ b/iplass-admin/build.gradle
@@ -50,13 +50,13 @@ def buildGwtDir = layout.buildDirectory.dir('gwt').get()
 def gwtCompileTask = tasks.register('gwtCompile', JavaExec) {
 	group = 'build'
 	description = 'Compile GWT modules'
-	dependsOn processGwtResources
+	dependsOn tasks.named('processGwtResources')
 
 	// jvm arguments
 	minHeapSize = "512m"
 	maxHeapSize = "2g"
 	jvmArgs = [
-		"-Dgwt.persistentunitcachedir=${buildGwtDir.dir('cache')}"
+		"-Dgwt.persistentunitcachedir=${buildGwtDir.dir('cache').asFile}"
 	]
 	mainClass.set('com.google.gwt.dev.Compiler')
 	classpath += files(buildSrcGwt)
@@ -65,8 +65,8 @@ def gwtCompileTask = tasks.register('gwtCompile', JavaExec) {
 	args = [
 		'-sourceLevel', 'auto',
 		'-logLevel', 'INFO',
-		'-war', buildGwtDir.dir('out'),
-		'-workDir', buildGwtDir.dir('work'),
+		'-war', buildGwtDir.dir('out').asFile,
+		'-workDir', buildGwtDir.dir('work').asFile,
 		'-localWorkers', '6',
 		'-strict',
 		'org.iplass.adminconsole.AdminConsole',

--- a/iplass-admin/build.gradle
+++ b/iplass-admin/build.gradle
@@ -57,6 +57,9 @@ def gwtCompileTask = tasks.register('gwtCompile', JavaExec) {
 	description = 'Compile GWT modules'
 	dependsOn tasks.named('processGwtResources')
 
+	inputs.files(files(buildSrcGwt))
+	outputs.dir(buildGwtDir.dir('out'))
+
 	// jvm arguments
 	minHeapSize = "512m"
 	maxHeapSize = "2g"

--- a/iplass-admin/build.gradle
+++ b/iplass-admin/build.gradle
@@ -47,9 +47,10 @@ def buildSrcGwt = layout.buildDirectory.dir('src/gwt')
 def buildSrcGwtTrans = layout.buildDirectory.dir('src/gwt-trans')
 def buildGwtDir = layout.buildDirectory.dir('gwt').get()
 
-final def MIN_PROCESSORS = 6
+// 最小のGWTコンパイルワーカー数の指定の下限。この値以下のワーカー数を設定するとエラーが発生することがある。
+final def MIN_GWT_WORKERS = 6
 def availableProcessors = Runtime.runtime.availableProcessors()
-def gwtCompileWorkers = availableProcessors > MIN_PROCESSORS ? availableProcessors - 1 : 1
+def gwtCompileWorkers = availableProcessors > MIN_GWT_WORKERS ? availableProcessors - 1 : 1
 
 def gwtCompileTask = tasks.register('gwtCompile', JavaExec) {
 	group = 'build'
@@ -73,8 +74,8 @@ def gwtCompileTask = tasks.register('gwtCompile', JavaExec) {
 		'-workDir', buildGwtDir.dir('work').asFile,
 	]
 
-	// processor 数が1より大きければローカルワーカーを設定する
-	if (gwtCompileWorkers > MIN_PROCESSORS) {
+	if (gwtCompileWorkers >= MIN_GWT_WORKERS) {
+		// worker 設定可能数が MIN_GWT_WORKERS 以上の場合は、-localWorkers オプションを追加する
 		args += ['-localWorkers', gwtCompileWorkers]
 	}
 
@@ -85,7 +86,7 @@ def gwtCompileTask = tasks.register('gwtCompile', JavaExec) {
 
 	doFirst {
 		// gwt args を出力する
-		println "GWT Compile Args: ${args.join(' ')}"
+		logger.lifecycle("GWT Compile Args: ${args.join(' ')}")
 	}
 }
 

--- a/iplass-admin/build.gradle
+++ b/iplass-admin/build.gradle
@@ -1,24 +1,15 @@
-// https://github.com/jiakuan/gwt-gradle-plugin/issues/75
-plugins {
-  id "org.docstr.gwt" version "1.1.30"
-}
-
 apply from: 'libs.gradle'
 dependencies {
 	implementation project(':iplass-core')
 	implementation project(':iplass-web')
 	implementation project(':iplass-gem')
 	implementation project(':iplass-tools')
-}
 
-apply plugin: 'gwt-compiler'
-apply plugin: 'eclipse'
-
-eclipse {
-
-	//gwtSdkをClassPathに追加
-	classpath {
-		plusConfigurations += [ configurations.gwtSdk ]
+	// 'iplass-' から始まる依存関係はプロジェクト参照。プロジェクト参照の sourceSets.main.output を gwtCompileOnly に追加する
+	configurations.implementation.dependencies.each {
+		if (it.name.startsWith('iplass-')) {
+			add('gwtCompileOnly', project(":${it.name}").sourceSets.main.output)
+		}
 	}
 }
 
@@ -35,7 +26,7 @@ compileJava {
 	source = fileTree('src/main/java') {
 		exclude 'org/iplass/adminconsole/client/**'
 		exclude 'org/iplass/adminconsole/trans/**'
-		exclude 'edu/ycp/cs/dh/acegwt/client/**'
+		exclude 'org/iplass/gwt/ace/client/**'
 //		exclude 'com/google/gwt/user/client/**'  //これはサーバでも必要
 	}
 }
@@ -45,8 +36,8 @@ processResources {
 	from 'src/main/resources'
 	exclude 'org/iplass/adminconsole/**/*.gwt.xml'
 	exclude 'org/iplass/adminconsole/public/**'
-	exclude 'edu/ycp/cs/dh/acegwt/**/*.gwt.xml'
-	exclude 'edu/ycp/cs/dh/acegwt/public/**'
+	exclude 'org/iplass/gwt/ace/**/*.gwt.xml'
+	exclude 'org/iplass/gwt/ace/public/**'
 
 	// 重複ファイル設定（コピーされたファイルを正とする）
 	duplicatesStrategy = DuplicatesStrategy.INCLUDE
@@ -54,27 +45,43 @@ processResources {
 
 def buildSrcGwt = layout.buildDirectory.dir('src/gwt')
 def buildSrcGwtTrans = layout.buildDirectory.dir('src/gwt-trans')
+def buildGwtDir = layout.buildDirectory.dir('gwt').get()
 
-gwt {
-	src = files(buildSrcGwt)
-	// TODO gwt plugin jakarta-servlet 版に対応していないので、バージョンを指定し依存関係を設定しない
-	//gwtVersion = this.gwtVersion
-	modules 'org.iplass.adminconsole.AdminConsole'
-	minHeapSize = '512M'
-	maxHeapSize = '2048M'
-	logLevel = 'INFO'
-	sourceLevel = 'auto'
-	compiler.strict = true
+def gwtCompileTask = tasks.register('gwtCompile', JavaExec) {
+	group = 'build'
+	description = 'Compile GWT modules'
+	dependsOn processGwtResources
+
+	// jvm arguments
+	minHeapSize = "512m"
+	maxHeapSize = "2g"
+	jvmArgs = [
+		"-Dgwt.persistentunitcachedir=${buildGwtDir.dir('cache')}"
+	]
+	mainClass.set('com.google.gwt.dev.Compiler')
+	classpath += files(buildSrcGwt)
+	classpath += configurations.gwtCompileOnly
+
+	args = [
+		'-sourceLevel', 'auto',
+		'-logLevel', 'INFO',
+		'-war', buildGwtDir.dir('out'),
+		'-workDir', buildGwtDir.dir('work'),
+		'-localWorkers', '6',
+		'-strict',
+		'org.iplass.adminconsole.AdminConsole',
+	]
 }
 
 jar {
-	dependsOn('compileGwt')
+	dependsOn gwtCompileTask
 
 	includeEmptyDirs = false;
 
 	// META-INF配下にgwtコンパイル結果をコピー
-	into('META-INF/resources/admin/mtpadmin') { from(layout.buildDirectory.dir('gwt/out/mtpadmin')) }
-
+	into('META-INF/resources/admin/mtpadmin') { 
+		from buildGwtDir.dir('out/mtpadmin')
+	}
 }
 
 task processGwtResources(type: Sync) {
@@ -91,7 +98,6 @@ task processGwtResources(type: Sync) {
 	from buildSrcGwtTrans
 	into buildSrcGwt
 }
-tasks.compileGwt.dependsOn processGwtResources
 
 task copyGwtTransSrc(type: Sync) {
 

--- a/iplass-admin/build.gradle
+++ b/iplass-admin/build.gradle
@@ -47,6 +47,9 @@ def buildSrcGwt = layout.buildDirectory.dir('src/gwt')
 def buildSrcGwtTrans = layout.buildDirectory.dir('src/gwt-trans')
 def buildGwtDir = layout.buildDirectory.dir('gwt').get()
 
+def availableProcessors = Runtime.runtime.availableProcessors()
+def gwtCompileWorkers = availableProcessors > 1 ? availableProcessors - 1 : 1
+
 def gwtCompileTask = tasks.register('gwtCompile', JavaExec) {
 	group = 'build'
 	description = 'Compile GWT modules'
@@ -67,10 +70,22 @@ def gwtCompileTask = tasks.register('gwtCompile', JavaExec) {
 		'-logLevel', 'INFO',
 		'-war', buildGwtDir.dir('out').asFile,
 		'-workDir', buildGwtDir.dir('work').asFile,
-		'-localWorkers', '6',
+	]
+
+	// processor 数が1より大きければローカルワーカーを設定する
+	if (gwtCompileWorkers > 1) {
+		args += ['-localWorkers', gwtCompileWorkers]
+	}
+
+	args += [
 		'-strict',
 		'org.iplass.adminconsole.AdminConsole',
 	]
+
+	doFirst {
+		// gwt args を出力する
+		println "GWT Compile Args: ${args.join(' ')}"
+	}
 }
 
 jar {

--- a/iplass-admin/build.gradle
+++ b/iplass-admin/build.gradle
@@ -47,8 +47,9 @@ def buildSrcGwt = layout.buildDirectory.dir('src/gwt')
 def buildSrcGwtTrans = layout.buildDirectory.dir('src/gwt-trans')
 def buildGwtDir = layout.buildDirectory.dir('gwt').get()
 
+final def MIN_PROCESSORS = 6
 def availableProcessors = Runtime.runtime.availableProcessors()
-def gwtCompileWorkers = availableProcessors > 1 ? availableProcessors - 1 : 1
+def gwtCompileWorkers = availableProcessors > MIN_PROCESSORS ? availableProcessors - 1 : 1
 
 def gwtCompileTask = tasks.register('gwtCompile', JavaExec) {
 	group = 'build'
@@ -73,7 +74,7 @@ def gwtCompileTask = tasks.register('gwtCompile', JavaExec) {
 	]
 
 	// processor 数が1より大きければローカルワーカーを設定する
-	if (gwtCompileWorkers > 1) {
+	if (gwtCompileWorkers > MIN_PROCESSORS) {
 		args += ['-localWorkers', gwtCompileWorkers]
 	}
 

--- a/iplass-admin/libs.gradle
+++ b/iplass-admin/libs.gradle
@@ -1,14 +1,14 @@
-ext {
-	// TODO gwt plugin jakarta-servlet 版に対応していないので、バージョンを指定し依存関係を設定しない
-	//gwtVersion = "2.10.0"
-}
-
 configurations {
 	wjRuntime
 
 	compileOnly.extendsFrom(jeecoreapis)
 	compileOnly.extendsFrom(jeewebapis)
 	runtimeOnly.extendsFrom(wjRuntime)
+
+	gwtCompileOnly {
+		extendsFrom(jeecoreapis)
+		extendsFrom(jeewebapis)
+	}
 }
 
 dependencies {
@@ -27,36 +27,38 @@ dependencies {
 	//jackson
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 
+	// gwt-servlet-jakarta
+	implementation sharedLib('org.gwtproject:gwt-servlet-jakarta')
+
 	wjRuntime sharedLib('org.webjars.npm:ace-builds')
 
 	//smart gwt has no public maven repository
 	compileOnly fileTree(rootProject.ext.localLibDir) {
 		include 'smartgwt/**/*.jar'
 	}
+	compileOnly sharedLib('org.gwtproject:gwt-user')
 
-}
-
-// FIXME gwt plugin が gwt-servlet-jakarta に対応するまで以下のような設定を実施する
-afterEvaluate {
-	configurations {
-		gwt
-		gwtSdk
+ 	// GWTコンパイル用依存関係
+	// gwt
+	gwtCompileOnly(sharedLib('org.gwtproject:gwt-dev')) {
+		// java.xml パッケージを含む xml-apis ライブラリを推移依存するため除外
+		exclude group: 'net.sourceforge.htmlunit', module: 'htmlunit'
+		// NOTE: apache-jsp 関連のライブラリを推移依存する。害が無いので除外しないが不要ではある。
+		//exclude group: 'org.eclipse.jetty'
 	}
-	dependencies {
-		// gwt.gwtVersion を指定すれば設定される依存関係を個別設定
-		gwtSdk(sharedLib('org.gwtproject:gwt-dev')) {
-		  // java.xml パッケージを含む xml-apis ライブラリを推移依存するため除外
-		  exclude group: 'net.sourceforge.htmlunit', module: 'htmlunit'
-		  // NOTE: apache-jsp 関連のライブラリを推移依存する。害が無いので除外しないが不要ではある。
-		  //exclude group: 'org.eclipse.jetty'
-		}
-		gwtSdk sharedLib('org.gwtproject:gwt-user')
-		implementation sharedLib('org.gwtproject:gwt-servlet-jakarta')
-		gwt(sharedLib('org.gwtproject:gwt-codeserver')) {
-		  // java.xml パッケージを含む xml-apis ライブラリを推移依存するため除外
-		  exclude group: 'net.sourceforge.htmlunit', module: 'htmlunit'
-		  // NOTE: apache-jsp 関連のライブラリを推移依存する。害が無いので除外しないが不要ではある。
-		  //exclude group: 'org.eclipse.jetty'
-		}
+	gwtCompileOnly(sharedLib('org.gwtproject:gwt-codeserver')) {
+		// java.xml パッケージを含む xml-apis ライブラリを推移依存するため除外
+		exclude group: 'net.sourceforge.htmlunit', module: 'htmlunit'
+		// NOTE: apache-jsp 関連のライブラリを推移依存する。害が無いので除外しないが不要ではある。
+		//exclude group: 'org.eclipse.jetty'
+	}
+	gwtCompileOnly sharedLib('org.gwtproject:gwt-user')
+	gwtCompileOnly sharedLib('org.gwtproject:gwt-servlet-jakarta')
+	// jackson
+	gwtCompileOnly platform(sharedLib('com.fasterxml.jackson:jackson-bom'))
+	gwtCompileOnly 'com.fasterxml.jackson.core:jackson-databind'
+	//smart gwt has no public maven repository
+	gwtCompileOnly fileTree(rootProject.ext.localLibDir) {
+		include 'smartgwt/**/*.jar'
 	}
 }


### PR DESCRIPTION
closes #2218 .

<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->
- gwt プラグインを削除
- gwt プラグインに関連する設定を削除
- gwt compile を行う JavaExec を追加
- java, resources クライアントファイルの除外設定を見直し

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->
- コンパイル確認
    - プラグインによるコンパイル時と同等のファイルが作成されることの確認
    - リリース時に実行するビルドコマンド `gradlew build jar` が正常終了することの確認
- 動作確認
    - Admin Console のメタデータ全画面オープン、メタデータ作成／保存／削除
    - Admin Console のツール全画面オープン、操作実施
    - コード編集画面を開き、編集・保存ができること

## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->
- iplass-admin プロジェクトの gwt コンパイル実行方法の変更の対応です
- コード編集画面を操作できることから、除外リソースの影響はありません
