### PR TITLE
GEM: textareaのリサイズ時に画面レイアウト（フッター位置）が追従しない

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/plugin/fixHeight.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/plugin/fixHeight.js
@@ -53,7 +53,7 @@
 
 	$.fn.sameHeight = function() {
 		var maxHeight = 0;
-		this.css("height","auto");
+		this.css("height","auto").css("min-height","");
 		this.each(function(){
 			if ( $(this).height() > maxHeight ) maxHeight = $(this).height();
 		});

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/plugin/fixHeight.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/plugin/fixHeight.js
@@ -57,7 +57,7 @@
 		this.each(function(){
 			if ( $(this).height() > maxHeight ) maxHeight = $(this).height();
 		});
-		return this.height(maxHeight);
+		return this.css("min-height", maxHeight);
 	}
 
 	function getChildren( i_parent ) {


### PR DESCRIPTION
<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->
GEMの詳細編集画面などで、textarea（複数行テキスト）をブラウザ標準のリサイズ操作で高さを変更すると、
画面レイアウトが再計算され、内容がフッター領域に重なって表示される不具合を修正。

-  原因：`fixHeight.js の sameHeight() は、行内要素の高さを初期表示時に height()（固定値）で揃える実装となっていた。
textarea をブラウザ標準機能でリサイズした場合でも、checkFixHeight は再計算されないため、行の高さが更新されず、拡大後の textarea がフッター領域と重なって表示される場合があった。
- 対応：sameHeight() による高さ設定を height から min-height に変更した。
これにより、初期表示時の高さ揃えを維持しつつ、textarea リサイズ後も要素の高さに応じてレイアウトが自然に追従するよう改善した。

closes #2225 
## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->
1. GEMの詳細編集画面（entityが複数列を持つレイアウト）を開き、textareaのリサイズハンドルをドラッグして高さを増やす、レイアウトが追従し、フッターとの重なりが発生しないことを確認
1. 通常時（リサイズしない場合）の行内要素の高さ揃えが崩れていないことを確認
## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->
