### PR TITLE
GEM: 多重度複数のReferencePropertyに対して参照セクション設定したときのバリデーション制御の修正対応

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/DetailCommandContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/DetailCommandContext.java
@@ -973,7 +973,7 @@ public class DetailCommandContext extends RegistrationCommandContext
 			//エラーがなくて、何もデータが入ってないものは破棄する
 			if (hasError || !isEmpty(entity)) {
 				entity.setDefinitionName(defName);
-				entity.setValue(Constants.REF_INDEX, list.size());
+				entity.setValue(Constants.REF_INDEX, i);
 
 				if (rsProperty != null) {
 					// entity,sectionでまとめる

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/DetailCommandContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/detail/DetailCommandContext.java
@@ -950,7 +950,7 @@ public class DetailCommandContext extends RegistrationCommandContext
 		for (int i = 0; i < count; i++) {
 			//データあり
 			String paramPrefix = prefix + p.getName() + "[" + Integer.toString(i) + "].";
-			String errorPrefix = (i != list.size() ? prefix + p.getName() + "[" + Integer.toString(list.size()) + "]." : null);
+			String errorPrefix = (i != list.size() ? prefix + p.getName() + "[" + Integer.toString(i) + "]." : null);
 			Entity entity = createEntity(paramPrefix, errorPrefix);
 
 			//入力エラー時に再Loadされないようにフラグ設定

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/element/section/ReferenceSection.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/element/section/ReferenceSection.jsp
@@ -78,6 +78,11 @@
 		return new LoadOption(propList);
 	}
 	int getOrderPropertValue(ReferenceSection section, Entity entity, EntityManager em) {
+		int order = toInteger(entity.getValue(section.getOrderPropName()));
+		if (order != -1 || entity.getOid() == null) {
+			return order;
+		}
+
 		Query query = new Query().select(section.getOrderPropName())
 				.from(entity.getDefinitionName())
 				.where(new And(


### PR DESCRIPTION
## 対応内容
#2197 の以下の事象について対応
### 多重度複数のReferencePropertyに対して参照セクション設定したとき、入力エラー画面で対象セクションが見えなくなる場合がある
入力エラー時に、DBからEntityを取得しなおそうとして失敗した結果、セクションが表示されなくなっていた
メモリ上の入力データがある場合は優先的に使用するように変更

### 多重度複数のReferencePropertyに対して参照セクション設定したとき、セクション内のバリデーションエラーの表示位置のずれ
エラーメッセージ生成時に、多重度複数プロパティで空の場合除外する処理の結果、内部Indexと表示Indexがずれていた。
そのため表示Index側を使用するように修正

## 動作確認・スクリーンショット（任意）
多重度複数のReferencePropertyを設定した参照セクションを複数設置し、一部のみデータを入力してエラー起こしたときに以下のケースが正常であることを確認
* エラーが起きても参照セクションが見えなくならないこと
* 1番目を空にして、2番目にデータを入力してセクション内エラーが起きるときに、エラーメッセージの位置がずれないこと

## レビュー観点・補足情報（任意）
